### PR TITLE
Support transfer interpolation

### DIFF
--- a/docs/literate/tutorials/taylor_impact.jl
+++ b/docs/literate/tutorials/taylor_impact.jl
@@ -147,6 +147,7 @@ function main()
             @threaded for p in eachindex(particles)
                 particles.c[p] = sqrt((λ+2μ) / (particles.m[p]/particles.V[p])) + norm(particles.v[p])
             end
+            ## `@timeit` can box variables assigned inside it; `::Float64` keeps `Δt` concrete below.
             Δt::Float64 = CFL * spacing(grid.x) / maximum(particles.c)
         end
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -413,7 +413,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         end
     end
 
-    esc(body)
+    esc(interpolate_transfer_values(body, program))
 end
 
 @inline _get_supportnodes(bw_i, grid_i, bw_j, grid_j, ::Val{true}) = (@_propagate_inbounds_meta; (supportnodes(bw_i, grid_i), supportnodes(bw_j, grid_j)))

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -11,6 +11,7 @@ is_sum(eq::TransferEquation) = eq.kind === :sum
 
 struct TransferProgram
     equations::Vector{TransferEquation}
+    interpolations::Vector{Pair{Symbol, Any}}
 end
 
 function split_sum_equations(program::TransferProgram, macroname::String)
@@ -140,6 +141,10 @@ for i in eachindex(grid)
 end
 ```
 
+Use `\$(expr)` inside transfer equations to evaluate an outer expression once
+before the generated transfer loops and use the captured value in the loop body.
+For example, `\$Δt` captures the current value of `Δt`.
+
 !!! warning
     In `@P2G`, `Calculation on grid` part must be placed after
     `Particle-to-grid transfer` part.
@@ -191,6 +196,7 @@ function P2G_expr(schedule::QuoteNode, (grid,i), (particles,p), (weights,ip), pa
         end
     end
 
+    code = interpolate_transfer_values(code, program)
     esc(prettify(code; lines=true, alias=false))
 end
 
@@ -415,6 +421,10 @@ for p in eachindex(particles)
 end
 ```
 
+Use `\$(expr)` inside transfer equations to evaluate an outer expression once
+before the generated transfer loops and use the captured value in the loop body.
+For example, `\$Δt` captures the current value of `Δt`.
+
 !!! warning
     In `@G2P`, `Calculation on particles` part must be placed after
     `Grid-to-particle transfer` part.
@@ -448,6 +458,7 @@ function G2P_expr(schedule::QuoteNode, (grid,i), (particles,p), (weights,ip), pr
         end
     end
 
+    code = interpolate_transfer_values(code, program)
     esc(prettify(code; lines=true, alias=false))
 end
 
@@ -649,6 +660,7 @@ function G2P2G_expr(schedule::QuoteNode, (grid,i), (particles,p), (weights,ip), 
         end
     end
 
+    code = interpolate_transfer_values(code, program)
     esc(prettify(code; lines=true, alias=false))
 end
 
@@ -682,10 +694,13 @@ end
 function parse_transfer_program(expr::Expr)
     expr = MacroTools.prewalk(MacroTools.rmlines, expr)
     @capture(expr, begin exprs__ end) || error("expected a `begin ... end` block, got $expr")
+    interpolations = Pair{Symbol, Any}[]
     equations = map(exprs) do ex
         dict = MacroTools.trymatch(Expr(:op_, :lhs_, :rhs_), ex)
         dict === nothing && error("wrong expression: $ex")
         lhs, rhs, op = dict[:lhs], dict[:rhs], dict[:op]
+        has_transfer_interpolation(lhs) && error("transfer interpolation with `\$` is only allowed on the RHS, got LHS `$lhs`")
+        rhs = extract_transfer_interpolations(rhs, interpolations)
         if @capture(rhs, @∑ eq_)
             (op == :(=) || op == :(+=) || op == :(-=)) || error("@∑ is only allowed on the RHS of assignments with `=`, `+=`, or `-=`, got $ex")
             return TransferEquation(:sum, lhs, eq, op)
@@ -693,7 +708,34 @@ function parse_transfer_program(expr::Expr)
         has_sum_macro(rhs) && error("@∑ must appear alone as the entire RHS expression, got $ex")
         TransferEquation(:assign, lhs, rhs, op)
     end
-    TransferProgram(equations)
+    TransferProgram(equations, interpolations)
+end
+
+function has_transfer_interpolation(expr)
+    Meta.isexpr(expr, :$, 1) && return true
+    expr isa Expr || return false
+    any(has_transfer_interpolation, expr.args)
+end
+
+function extract_transfer_interpolations(expr, interpolations)
+    if Meta.isexpr(expr, :$, 1)
+        captured = gensym(:transfer_interp)
+        push!(interpolations, captured => only(expr.args))
+        return captured
+    elseif expr isa Expr
+        return Expr(expr.head, map(arg -> extract_transfer_interpolations(arg, interpolations), expr.args)...)
+    else
+        return expr
+    end
+end
+
+function interpolate_transfer_values(code, program::TransferProgram)
+    isempty(program.interpolations) && return code
+    bindings = map(program.interpolations) do captured_rhs
+        captured, rhs = captured_rhs
+        Expr(:(=), captured, rhs)
+    end
+    Expr(:let, Expr(:block, bindings...), code)
 end
 
 function resolve_refs(expr, scope::TransferScope)

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -213,6 +213,88 @@
         @test actual_grid.v ≈ expected_grid.v
     end
 
+    @testset "interpolation" begin
+        grid, particles, weights = transfer_fixture()
+
+        p2g_scale = 2.0
+        p2g_captures = Ref(0)
+        expected_grid = deepcopy(grid)
+        actual_grid = deepcopy(grid)
+
+        @P2G expected_grid=>i particles=>p weights=>ip begin
+            m[i] = @∑ w[ip] * m[p] * p2g_scale
+            v[i] = x[i] * (p2g_scale + 1)
+        end
+
+        @P2G actual_grid=>i particles=>p weights=>ip begin
+            m[i] = @∑ w[ip] * m[p] * $(begin
+                p2g_captures[] += 1
+                p2g_scale
+            end)
+            v[i] = x[i] * $(begin
+                p2g_captures[] += 1
+                p2g_scale + 1
+            end)
+        end
+
+        @test p2g_captures[] == 2
+        @test actual_grid.m ≈ expected_grid.m
+        @test actual_grid.v ≈ expected_grid.v
+
+        g2p_scale = 3.0
+        g2p_captures = Ref(0)
+        expected_particles = deepcopy(particles)
+        actual_particles = deepcopy(particles)
+
+        @G2P grid=>i expected_particles=>p weights=>ip begin
+            v[p] = @∑ w[ip] * v[i] * g2p_scale
+        end
+
+        @G2P grid=>i actual_particles=>p weights=>ip begin
+            v[p] = @∑ w[ip] * v[i] * $(begin
+                g2p_captures[] += 1
+                g2p_scale
+            end)
+        end
+
+        @test g2p_captures[] == 1
+        @test actual_particles.v ≈ expected_particles.v
+
+        g2p2g_scale = 4.0
+        g2p2g_captures = Ref(0)
+        expected_grid = deepcopy(grid)
+        expected_particles = deepcopy(particles)
+        actual_grid = deepcopy(grid)
+        actual_particles = deepcopy(particles)
+
+        @G2P2G expected_grid=>i expected_particles=>p weights=>ip begin
+            v[p] = @∑ w[ip] * v[i] * g2p2g_scale
+            m[i] = @∑ w[ip] * m[p] * g2p2g_scale
+        end
+
+        @G2P2G actual_grid=>i actual_particles=>p weights=>ip begin
+            v[p] = @∑ w[ip] * v[i] * $(begin
+                g2p2g_captures[] += 1
+                g2p2g_scale
+            end)
+            m[i] = @∑ w[ip] * m[p] * $(begin
+                g2p2g_captures[] += 1
+                g2p2g_scale
+            end)
+        end
+
+        @test g2p2g_captures[] == 2
+        @test actual_particles.v ≈ expected_particles.v
+        @test actual_grid.m ≈ expected_grid.m
+
+        ex = Meta.parse(raw"""
+            @P2G grid=>i particles=>p weights=>ip begin
+                $m[i] = @∑ w[ip] * m[p]
+            end
+        """)
+        @test_throws ErrorException macroexpand(@__MODULE__, ex)
+    end
+
     @testset "threaded matches sequential" begin
         Δt = 0.01
         gravity = Vec(0.0, -9.81)


### PR DESCRIPTION
Adds transfer interpolation with `$` so outer expressions can be evaluated once before generated transfer loops and reused inside `@P2G`, `@G2P`, `@G2P2G`, and `@P2G_Matrix` bodies.