### PR TITLE
Allow suppressing CartesianMesh cover warnings

### DIFF
--- a/docs/literate/tutorials/collapse.jl
+++ b/docs/literate/tutorials/collapse.jl
@@ -23,7 +23,7 @@ function main()
     g   = 9.81 # Gravity acceleration
     CFL = 1.0  # Courant number
     if @isdefined(RUN_TESTS) && RUN_TESTS #src
-        h = 0.015                         #src
+        h = 0.02                          #src
         t_stop = 0.75                     #src
     end                                   #src
 

--- a/docs/literate/tutorials/collapse.jl
+++ b/docs/literate/tutorials/collapse.jl
@@ -60,7 +60,7 @@ function main()
     end
 
     ## Background grid
-    grid = generate_grid(GridProp, CartesianMesh(h, (-3,3), (0,1)))
+    grid = generate_grid(GridProp, CartesianMesh(h, (-3,3), (0,1); warn=false))
 
     ## Particles
     particles = generate_particles(ParticleProp, grid.x)

--- a/docs/literate/tutorials/collapse.jl
+++ b/docs/literate/tutorials/collapse.jl
@@ -60,7 +60,7 @@ function main()
     end
 
     ## Background grid
-    grid = generate_grid(GridProp, CartesianMesh(h, (-3,3), (0,1); warn=false))
+    grid = generate_grid(GridProp, CartesianMesh(h, (-3,3), (0,1)))
 
     ## Particles
     particles = generate_particles(ParticleProp, grid.x)

--- a/docs/literate/tutorials/dam_break.jl
+++ b/docs/literate/tutorials/dam_break.jl
@@ -90,7 +90,7 @@ function main(transfer = FLIP(1.0))
     end
 
     ## Background grid
-    grid = generate_grid(GridProp, CartesianMesh(h, (0,3.22), (0,2.5)))
+    grid = generate_grid(GridProp, CartesianMesh(h, (0,3.22), (0,2.5); warn=false))
     for cell in CartesianIndices(size(grid).-1)
         for i in cellnodes(cell)
             grid.V[i] += (h/2)^2

--- a/docs/literate/tutorials/dam_break.jl
+++ b/docs/literate/tutorials/dam_break.jl
@@ -90,7 +90,7 @@ function main(transfer = FLIP(1.0))
     end
 
     ## Background grid
-    grid = generate_grid(GridProp, CartesianMesh(h, (0,3.22), (0,2.5); warn=false))
+    grid = generate_grid(GridProp, CartesianMesh(h, (0,3.22), (0,2.5)))
     for cell in CartesianIndices(size(grid).-1)
         for i in cellnodes(cell)
             grid.V[i] += (h/2)^2

--- a/docs/literate/tutorials/taylor_impact.jl
+++ b/docs/literate/tutorials/taylor_impact.jl
@@ -62,9 +62,9 @@ function main()
     end
 
     ## Background grid
-    grid = generate_grid(GridProp, CartesianMesh(R/12, (-3R,3R), (-3R,3R), (0,L+0.1L)))
+    grid = generate_grid(GridProp, CartesianMesh(R/12, (-3R,3R), (-3R,3R), (0,L+0.1L); warn=false))
     if @isdefined(RUN_TESTS) && RUN_TESTS                                                  #src
-        grid = generate_grid(GridProp, CartesianMesh(R/6, (-3R,3R), (-3R,3R), (0,L+0.1L))) #src
+        grid = generate_grid(GridProp, CartesianMesh(R/6, (-3R,3R), (-3R,3R), (0,L+0.1L); warn=false)) #src
     end                                                                                    #src
 
     ## Particles

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -11,11 +11,11 @@ function _check_block_size_log2(::Val{L}) where {L}
 end
 
 """
-    CartesianMesh([T,] h, (xmin, xmax), (ymin, ymax)...; block_size_log2=Val(2))
+    CartesianMesh([T,] h, (xmin, xmax), (ymin, ymax)...; warn=true, block_size_log2=Val(2))
 
 Construct a uniform Cartesian mesh with scalar spacing `h` (same in all directions).
 If an axis length is not divisible by `h`, the upper bound is expanded to cover the
-requested domain, and a warning is emitted.
+requested domain. Set `warn=false` to suppress the expansion warning.
 `block_size_log2` sets the block decomposition used by [`ThreadPartition`](@ref) and [`SpArray`](@ref)
 grids generated from this mesh.
 
@@ -68,23 +68,23 @@ function CartesianMesh(axes::Vararg{AbstractRange{<: AbstractFloat}, dim}; block
     CartesianMesh(axes, h, inv(h); block_size_log2)
 end
 
-function _covered_axis(h::Real, lims::Tuple{Real, Real})
+function _covered_axis(h::Real, lims::Tuple{Real, Real}; warn::Bool)
     xmin, xmax = lims
     ax = range(xmin, xmax; step=h)
     n = length(ax)
     if !isapprox(last(ax), xmax)
         actual_xmax = xmin + n*h
         n += 1
-        @warn "CartesianMesh axis length is not divisible by spacing; expanding the upper bound to cover the requested domain" requested=lims actual=(xmin, actual_xmax) spacing=h
+        warn && @warn "CartesianMesh axis length is not divisible by spacing; expanding the upper bound to cover the requested domain" requested=lims actual=(xmin, actual_xmax) spacing=h
     end
     range(xmin; step=h, length=n)
 end
 
-function CartesianMesh(::Type{T}, h::Real, minmax::Vararg{Tuple{Real, Real}, dim}; pad::Int = 0, block_size_log2::Val{L}=Val(BLOCK_SIZE_LOG2)) where {T, dim, L}
+function CartesianMesh(::Type{T}, h::Real, minmax::Vararg{Tuple{Real, Real}, dim}; pad::Int = 0, warn::Bool = true, block_size_log2::Val{L}=Val(BLOCK_SIZE_LOG2)) where {T, dim, L}
     @assert all(x->x[1]<x[2], minmax)
 
     axes = map(minmax) do lims
-        ax = _covered_axis(h, lims)
+        ax = _covered_axis(h, lims; warn)
         pad == 0 && return Vector{T}(ax)
 
         start = first(ax) - pad*h

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -11,6 +11,8 @@
     @test size(covered_mesh) === (5,)
     @test covered_mesh[1] === Vec(0.0)
     @test covered_mesh[end] === Vec(1.2)
+    quiet_covered_mesh = @test_nowarn CartesianMesh(0.3, (0,1); warn=false)
+    @test quiet_covered_mesh == covered_mesh
     for n in (2, 3, 7, 10)
         L = 1.0
         exact_cover_mesh = @test_nowarn CartesianMesh(L/n, (0, L))


### PR DESCRIPTION
- Add `warn=false` for intentional CartesianMesh cover expansion.
- Use it in the Taylor impact tutorial.
- Use divisible spacing in the collapse tutorial test.