### PR TITLE
Support P2G_Matrix with SpGrid

### DIFF
--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -425,13 +425,24 @@ end
 
 @inline function matrix_supportnodes(bw, grid)
     @_propagate_inbounds_meta
-    nodes = supportnodes(bw, grid)
+    # Matrix assembly indexes global DOF tables, which are built on logical
+    # grid indices. For an SpGrid, supportnodes(bw, grid) returns SpIndex
+    # storage tokens instead. Using those here would require SpIndex to fully
+    # support AbstractArray indexing.
+    nodes = supportnodes(bw)
+    @boundscheck checkbounds(get_mesh(grid), nodes)
     nodes, nodes
 end
 
 @inline function matrix_supportnodes(bw_i, grid_i, bw_j, grid_j)
     @_propagate_inbounds_meta
-    supportnodes(bw_i, grid_i), supportnodes(bw_j, grid_j)
+    # See the single-grid method: matrix DOF tables need logical grid indices,
+    # not SpGrid storage tokens.
+    nodes_i = supportnodes(bw_i)
+    nodes_j = supportnodes(bw_j)
+    @boundscheck checkbounds(get_mesh(grid_i), nodes_i)
+    @boundscheck checkbounds(get_mesh(grid_j), nodes_j)
+    nodes_i, nodes_j
 end
 
 function matrix_dof_tables(gmat, row_grid, col_grid)

--- a/test/sparray.jl
+++ b/test/sparray.jl
@@ -385,4 +385,49 @@ end
     @test Tesserae.nblocks(Tesserae.get_spinds(grid_block3)) === Tesserae.nblocks(Tesserae.strategy(partition_block3))
 end
 
+@testset "@P2G_Matrix" begin
+    basis = BSpline(Linear())
+    mesh = CartesianMesh(1.0, (0,31), (0,31); block_size_log2=Val(2))
+    GridProp = @NamedTuple{x::Vec{2, Float64}, m::Float64}
+    ParticleProp = @NamedTuple{x::Vec{2, Float64}}
+
+    dense_grid = generate_grid(GridProp, mesh)
+    sp_grid = generate_grid(SpArray, GridProp, mesh)
+    particles = generate_particles(ParticleProp, mesh; alg=GridSampling())
+    filter!(particles) do p
+        x = p.x
+        (x[1] - 2)^2 + (x[2] - 2)^2 < 2
+    end
+    weights = generate_basis_weights(basis, mesh, length(particles))
+    update!(weights, particles, mesh)
+    update_sparsity!(sp_grid, particles.x)
+
+    @test length(collect(Tesserae.activeindices(Tesserae.get_spinds(sp_grid)))) < length(dense_grid)
+    @test eltype(supportnodes(weights[1], sp_grid)) <: Tesserae.SpIndex
+
+    A_dense = create_sparse_matrix(basis, mesh; ndofs=(2, 2))
+    A_sp = create_sparse_matrix(basis, mesh; ndofs=(2, 2))
+    A = A_dense
+    @P2G_Matrix dense_grid=>(i,j) particles=>p weights=>(ip,jp) begin
+        A[i,j] = @∑ ∇w[ip] ⊗ ∇w[jp]
+    end
+    A = A_sp
+    @P2G_Matrix sp_grid=>(i,j) particles=>p weights=>(ip,jp) begin
+        A[i,j] = @∑ ∇w[ip] ⊗ ∇w[jp]
+    end
+    @test A_sp ≈ A_dense
+
+    B_dense = create_sparse_matrix(basis, mesh; ndofs=(2, 2))
+    B_sp = create_sparse_matrix(basis, mesh; ndofs=(2, 2))
+    B = B_dense
+    @P2G_Matrix (dense_grid,dense_grid)=>(i,j) particles=>p (weights,weights)=>(ip,jp) begin
+        B[i,j] = @∑ ∇w[ip] ⊗ ∇w[jp]
+    end
+    B = B_sp
+    @P2G_Matrix (sp_grid,dense_grid)=>(i,j) particles=>p (weights,weights)=>(ip,jp) begin
+        B[i,j] = @∑ ∇w[ip] ⊗ ∇w[jp]
+    end
+    @test B_sp ≈ B_dense
+end
+
 end


### PR DESCRIPTION
Updates matrix support-node lookup to use the logical nodes stored in `BasisWeight` when indexing global DOF tables. This avoids passing SpGrid storage indices into matrix assembly.

Adds SpGrid coverage for `@P2G_Matrix`, including same-grid and mixed-grid assembly compared against dense-grid results.