### PR TITLE
Direct B-spline updates

### DIFF
--- a/src/Basis/bspline.jl
+++ b/src/Basis/bspline.jl
@@ -91,18 +91,6 @@ end
     end
 end
 
-@generated function Base.values(order::Order{k}, spline::AbstractBSpline, x::Vec, mesh::CartesianMesh{dim}) where {k, dim}
-    quote
-        @_inline_meta
-        xmin = get_xmin(mesh)
-        h⁻¹ = spacing_inv(mesh)
-        ξ = (x - xmin) * h⁻¹
-        vals1d = @ntuple $dim d -> values1d(order, spline, ξ[d])
-        vals = @ntuple $(k+1) a -> prod_each_dimension(Order(a-1), vals1d...)
-        @ntuple $(k+1) i -> vals[i]*h⁻¹^(i-1)
-    end
-end
-
 @inline function update_property!(bw::BasisWeight, spline::AbstractBSpline, pt, mesh::CartesianMesh)
     indices = supportnodes(bw)
     if has_full_support(bw, indices)

--- a/src/Basis/bspline.jl
+++ b/src/Basis/bspline.jl
@@ -119,8 +119,73 @@ function update_property_truncated!(bw::BasisWeight, spline::AbstractBSpline, pt
         set_values!(bw, ip, values(derivative_order(bw), spline, getx(pt), mesh, i))
     end
 end
-@inline function update_property_full!(bw::BasisWeight, spline::AbstractBSpline, pt, mesh)
-    set_values!(bw, values(derivative_order(bw), spline, getx(pt), mesh))
+@inline function update_property_full!(bw::BasisWeight, spline::AbstractBSpline, pt, mesh::CartesianMesh)
+    direct_set_values!(bw, derivative_order(bw), spline, getx(pt), mesh)
+end
+
+_bspline_var(r, d) = Symbol(:v, r, :_, d)
+
+_bspline_value_type(::Val{1}, dim) = Vec{dim}
+_bspline_value_type(::Val{k}, dim) where {k} = Tensor{Tuple{@Symmetry{fill(dim, k)...}}}
+
+function _bspline_product_expr(terms)
+    @assert !isempty(terms)
+    length(terms) == 1 && return only(terms)
+    Expr(:call, :*, terms...)
+end
+
+function _bspline_derivative_expr(component::CartesianIndex, dim)
+    counts = map(d -> count(==(d), Tuple(component)), 1:dim)
+    terms = map(d -> _bspline_var(counts[d], d), 1:dim)
+    _bspline_product_expr(terms)
+end
+
+_bspline_component_indices(::Val{1}, dim) = map(CartesianIndex, 1:dim)
+function _bspline_component_indices(::Val{k}, dim) where {k}
+    TT = _bspline_value_type(Val(k), dim)
+    Array(CartesianIndices(size(TT))[Tensorial.independent_to_component_map(TT)])
+end
+
+function _bspline_value_expr(::Val{0}, dim)
+    _bspline_product_expr(map(d -> _bspline_var(0, d), 1:dim))
+end
+function _bspline_value_expr(::Val{k}, dim) where {k}
+    TT = _bspline_value_type(Val(k), dim)
+    hpow = Symbol(:hpow_, k)
+    entries = map(J -> :($(_bspline_derivative_expr(J, dim)) * $hpow),
+                  _bspline_component_indices(Val(k), dim))
+    :($TT(($(entries...),)))
+end
+
+@generated function direct_set_values!(bw::BasisWeight, order::Order{k}, spline::AbstractBSpline{Degree{n}}, x, mesh::CartesianMesh{dim}) where {k, n, dim}
+    dims = ntuple(_ -> n + 1, dim)
+    node_assignments = map(enumerate(CartesianIndices(dims))) do (i, I)
+        loads = [
+            :($(_bspline_var(r, d)) = vals1d[$d][$(r + 1)][$(I[d])])
+            for d in 1:dim for r in 0:k
+        ]
+        assignments = map(0:k) do r
+            :($(Symbol(:vals_, r))[$i] = $(_bspline_value_expr(Val(r), dim)))
+        end
+        quote
+            $(loads...)
+            $(assignments...)
+        end
+    end
+
+    quote
+        @_inline_meta
+        xmin = get_xmin(mesh)
+        h⁻¹ = spacing_inv(mesh)
+        ξ = (x - xmin) * h⁻¹
+        vals1d = @ntuple $dim d -> values1d(order, spline, ξ[d])
+        @nexprs $(k + 1) r -> vals_{r - 1} = values(bw, r)
+        @nexprs $k r -> hpow_r = h⁻¹^r
+        @inbounds begin
+            $(node_assignments...)
+        end
+        bw
+    end
 end
 
 """

--- a/src/Basis/bspline.jl
+++ b/src/Basis/bspline.jl
@@ -128,24 +128,28 @@ _bspline_var(r, d) = Symbol(:v, r, :_, d)
 _bspline_value_type(::Val{1}, dim) = Vec{dim}
 _bspline_value_type(::Val{k}, dim) where {k} = Tensor{Tuple{@Symmetry{fill(dim, k)...}}}
 
+# Build the scalar product for one tensor-product component.
 function _bspline_product_expr(terms)
     @assert !isempty(terms)
     length(terms) == 1 && return only(terms)
     Expr(:call, :*, terms...)
 end
 
+# A component index such as CartesianIndex(2, 1, 1) means ∂/∂x₁ for dim == 3.
 function _bspline_derivative_expr(component::CartesianIndex, dim)
     counts = map(d -> count(==(d), Tuple(component)), 1:dim)
     terms = map(d -> _bspline_var(counts[d], d), 1:dim)
     _bspline_product_expr(terms)
 end
 
+# Store only independent components for symmetric derivative tensors.
 _bspline_component_indices(::Val{1}, dim) = map(CartesianIndex, 1:dim)
 function _bspline_component_indices(::Val{k}, dim) where {k}
     TT = _bspline_value_type(Val(k), dim)
     Array(CartesianIndices(size(TT))[Tensorial.independent_to_component_map(TT)])
 end
 
+# Generate one value to write into the BasisWeight property arrays.
 function _bspline_value_expr(::Val{0}, dim)
     _bspline_product_expr(map(d -> _bspline_var(0, d), 1:dim))
 end
@@ -157,16 +161,15 @@ function _bspline_value_expr(::Val{k}, dim) where {k}
     :($TT(($(entries...),)))
 end
 
+# Fill the full-support BasisWeight arrays directly, avoiding prod_each_dimension
+# and the following copyto! into BasisWeight storage.
 @generated function direct_set_values!(bw::BasisWeight, order::Order{k}, spline::AbstractBSpline{Degree{n}}, x, mesh::CartesianMesh{dim}) where {k, n, dim}
     dims = ntuple(_ -> n + 1, dim)
     node_assignments = map(enumerate(CartesianIndices(dims))) do (i, I)
-        loads = [
-            :($(_bspline_var(r, d)) = vals1d[$d][$(r + 1)][$(I[d])])
-            for d in 1:dim for r in 0:k
-        ]
-        assignments = map(0:k) do r
-            :($(Symbol(:vals_, r))[$i] = $(_bspline_value_expr(Val(r), dim)))
-        end
+        # Load all 1D basis values needed at this support node.
+        loads = [:($(_bspline_var(r, d)) = vals1d[$d][$(r + 1)][$(I[d])]) for d in 1:dim for r in 0:k]
+        # Write value, gradient, Hessian, ... directly into each stored array.
+        assignments = [:($(Symbol(:vals_, r))[$i] = $(_bspline_value_expr(Val(r), dim))) for r in 0:k]
         quote
             $(loads...)
             $(assignments...)
@@ -179,7 +182,7 @@ end
         h⁻¹ = spacing_inv(mesh)
         ξ = (x - xmin) * h⁻¹
         vals1d = @ntuple $dim d -> values1d(order, spline, ξ[d])
-        @nexprs $(k + 1) r -> vals_{r - 1} = values(bw, r)
+        @nexprs $(k + 1) r -> vals_{r-1} = values(bw, r)
         @nexprs $k r -> hpow_r = h⁻¹^r
         @inbounds begin
             $(node_assignments...)


### PR DESCRIPTION
## Summary

- Fill full-support B-spline `BasisWeight` arrays directly.
- Avoid the intermediate `prod_each_dimension` tuple path for full-support updates.
- Remove the now-unused full-support B-spline `values` method.

## Benchmark

BenchmarkTools `@benchmark update!($bw, $x, $mesh)` vs `main`:

```text
dim  kernel     order  min speedup  median speedup
2D   quadratic  1      1.073        1.082
2D   quadratic  2      1.402        1.423
2D   quadratic  3      0.946        0.961
2D   cubic      1      1.051        1.092
2D   cubic      2      0.994        1.012
2D   cubic      3      1.010        1.030
3D   quadratic  1      1.207        1.213
3D   quadratic  2      1.436        1.421
3D   quadratic  3      1.464        1.475
3D   cubic      1      1.280        1.330
3D   cubic      2      1.638        1.613
3D   cubic      3      1.806        1.882
```
