### PR TITLE
Disallow CPDI on SpGrid

### DIFF
--- a/docs/src/sparray.md
+++ b/docs/src/sparray.md
@@ -26,6 +26,9 @@ grid = generate_grid(SpArray, GridProp, mesh)
 The first field, usually `x`, remains the mesh.
 The other grid fields are stored as `SpArray`s and share the same sparsity pattern.
 
+!!! warning
+    [`CPDI`](@ref) is currently supported only with dense grids, because its support follows the deformed particle domain.
+
 ## Updating sparsity
 
 Inactive entries are treated as structural zeros: they read as zero, and writes to inactive entries are ignored.

--- a/src/Basis/cpdi.jl
+++ b/src/Basis/cpdi.jl
@@ -18,6 +18,11 @@ end
 """
 struct CPDI <: Kernel end
 
+_cpdi_spgrid_error(context) =
+    error("$context: CPDI is currently supported only on dense Grid, not SpGrid")
+
+@inline supportnodes(::BasisWeight{CPDI}, ::SpGrid) = _cpdi_spgrid_error("supportnodes")
+
 struct CPDISupportNodes{T, V <: AbstractVector{T}} <: AbstractVector{T}
     indices::V
     len::Int

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -319,6 +319,7 @@ function check_arguments_for_P2G(grid, particles, weights, partition)
     get_mesh(grid) isa AbstractMesh || error("@P2G: grid must have a mesh")
     eltype(weights) <: BasisWeight || error("@P2G: invalid `BasisWeight`s, got type $(typeof(weights))")
     if grid isa SpGrid
+        eltype(weights) <: BasisWeight{CPDI} && _cpdi_spgrid_error("@P2G")
         if length(propertynames(grid)) > 1
             isempty(get_data(getproperty(grid, 2))) && error("@P2G: SpGrid indices not activated")
         end
@@ -787,6 +788,7 @@ function check_arguments_for_G2P(grid, particles, weights)
     get_mesh(grid) isa AbstractMesh || error("@G2P: grid must have a mesh")
     eltype(weights) <: BasisWeight || error("@G2P: invalid `BasisWeight`s, got type $(typeof(weights))")
     if grid isa SpGrid
+        eltype(weights) <: BasisWeight{CPDI} && _cpdi_spgrid_error("@G2P")
         if length(propertynames(grid)) > 1
             isempty(get_data(getproperty(grid, 2))) && error("@G2P: SpGrid indices not activated")
         end

--- a/test/basis.jl
+++ b/test/basis.jl
@@ -178,6 +178,16 @@ end # BasisWeight
             F = one(Mat{dim,dim})
             x = interior_point(Val(dim))
             check_update!(bw, (;x,l,F), x, mesh; partition=true, reproduces_linear=true)
+
+            GridProp = NamedTuple{(:x, :m), Tuple{Vec{dim, Float64}, Float64}}
+            spgrid = generate_grid(SpArray, GridProp, mesh)
+            err = try
+                supportnodes(bw, spgrid)
+                nothing
+            catch err
+                sprint(showerror, err)
+            end
+            @test err isa String && occursin("CPDI is currently supported only on dense Grid, not SpGrid", err)
         end
     end
 

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -28,6 +28,36 @@
         grid, particles, weights
     end
 
+    function cpdi_spgrid_fixture()
+        mesh = CartesianMesh(1.0, (0,2), (0,2))
+        GridProp = @NamedTuple begin
+            x :: Vec{2, Float64}
+            m :: Float64
+            v :: Vec{2, Float64}
+        end
+        ParticleProp = @NamedTuple begin
+            x :: Vec{2, Float64}
+            m :: Float64
+            v :: Vec{2, Float64}
+            F :: SecondOrderTensor{2, Float64, 4}
+            l :: Float64
+        end
+
+        grid = generate_grid(SpArray, GridProp, mesh)
+        particles = generate_particles(ParticleProp, mesh; alg=GridSampling())
+        weights = generate_basis_weights(CPDI(), mesh, length(particles))
+        grid, particles, weights
+    end
+
+    function error_message(f)
+        try
+            f()
+            nothing
+        catch err
+            sprint(showerror, err)
+        end
+    end
+
     function initialize_mpm_state!(grid, particles)
         for p in eachindex(particles)
             particles.m[p] = 1.0 + 0.05p
@@ -158,6 +188,24 @@
         @test actual.f ≈ expected.f
         @test actual.vⁿ ≈ expected.vⁿ
         @test actual.v ≈ expected.v
+    end
+
+    @testset "CPDI rejects SpGrid" begin
+        grid, particles, weights = cpdi_spgrid_fixture()
+
+        p2g_err = error_message() do
+            @P2G grid=>i particles=>p weights=>ip begin
+                m[i] = @∑ w[ip] * m[p]
+            end
+        end
+        @test p2g_err isa String && occursin("@P2G: CPDI is currently supported only on dense Grid, not SpGrid", p2g_err)
+
+        g2p_err = error_message() do
+            @G2P grid=>i particles=>p weights=>ip begin
+                v[p] = @∑ w[ip] * v[i]
+            end
+        end
+        @test g2p_err isa String && occursin("@G2P: CPDI is currently supported only on dense Grid, not SpGrid", g2p_err)
     end
 
     @testset "@G2P" begin


### PR DESCRIPTION
Summary:
- Reject CPDI weights with SpGrid in P2G/G2P checks.
- Add a supportnodes guard and sparse-grid warning.