### PR TITLE
Speed up SpGrid P2G scatter writes

### DIFF
--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -237,10 +237,28 @@ function p2g_sum_add_expr(lhs, index, rhs)
     :(Tesserae.add!($array, $index, $rhs))
 end
 
-Base.@propagate_inbounds p2g_write_index(grid::SpGrid, i::CartesianIndex) = get_spinds(grid)[Tuple(i)...]
-Base.@propagate_inbounds p2g_write_index(grid::SpGrid, i) = i
-Base.@propagate_inbounds p2g_write_index(grid::Grid, i::CartesianIndex) = LinearIndices(grid)[i]
+struct P2GSpGridStorageIndex
+    i::Int
+end
+
 Base.@propagate_inbounds p2g_write_index(grid, i) = i
+Base.@propagate_inbounds p2g_write_index(grid::Grid, i::CartesianIndex) = LinearIndices(grid)[i]
+Base.@propagate_inbounds p2g_write_index(grid::SpGrid, i::CartesianIndex) =
+    p2g_write_index(grid, get_spinds(grid)[Tuple(i)...])
+@inline function p2g_write_index(::SpGrid, i::SpIndex)
+    si = storageindex(i)
+    @boundscheck iszero(si) && error("@P2G: inactive SpGrid support node. Call update_sparsity! before @P2G.")
+    P2GSpGridStorageIndex(si)
+end
+
+@inline function add!(A::SpArray{T}, i::P2GSpGridStorageIndex, v::T) where {T}
+    @_propagate_inbounds_meta
+    @debug checkbounds(get_data(A), i.i)
+    @inbounds get_data(A)[i.i] += v
+    A
+end
+
+@inline _atomic_index(A::HybridArray{<:Any, <:Any, <:SpArray}, i::P2GSpGridStorageIndex) = i.i
 
 # CPU: sequential
 function P2G(f, ::CPUDevice, ::Val{scheduler}, grid, particles, weights, ::Nothing) where {scheduler}

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -243,8 +243,7 @@ end
 
 Base.@propagate_inbounds p2g_write_index(grid, i) = i
 Base.@propagate_inbounds p2g_write_index(grid::Grid, i::CartesianIndex) = LinearIndices(grid)[i]
-Base.@propagate_inbounds p2g_write_index(grid::SpGrid, i::CartesianIndex) =
-    p2g_write_index(grid, get_spinds(grid)[Tuple(i)...])
+Base.@propagate_inbounds p2g_write_index(grid::SpGrid, i::CartesianIndex) = p2g_write_index(grid, get_spinds(grid)[Tuple(i)...])
 @inline function p2g_write_index(::SpGrid, i::SpIndex)
     si = storageindex(i)
     @boundscheck iszero(si) && error("@P2G: inactive SpGrid support node. Call update_sparsity! before @P2G.")

--- a/test/sparray.jl
+++ b/test/sparray.jl
@@ -389,8 +389,10 @@ end
     bad_activity = falses(Tesserae.nblocks(Tesserae.get_spinds(bad_grid)))
     bad_activity[1,1] = true
     update_sparsity!(bad_grid, bad_activity)
-    bad_nodes = supportnodes(bad_weights[1], bad_grid)
-    bad_node = bad_nodes[findfirst(i -> !Tesserae.isactive(i), bad_nodes)]
+    @inbounds bad_nodes = view(Tesserae.get_spinds(bad_grid), supportnodes(bad_weights[1]))
+    bad_node_index = findfirst(i -> !Tesserae.isactive(i), bad_nodes)
+    @test !isnothing(bad_node_index)
+    bad_node = bad_nodes[bad_node_index]
     @test_throws ErrorException Tesserae.p2g_write_index(bad_grid, bad_node)
 
     mesh_block3 = CartesianMesh(1.0, (0, 8), (0, 16); block_size_log2=Val(3))

--- a/test/sparray.jl
+++ b/test/sparray.jl
@@ -378,6 +378,21 @@ end
     @test sp_grid.v ≈ dense_grid.v
     @test all(!iszero, map(Tesserae.storageindex, Tesserae.activeindices(sp_grid.m)))
 
+    bad_mesh = CartesianMesh(1.0, (0,31), (0,31); block_size_log2=Val(2))
+    bad_grid = generate_grid(SpArray, GridProp, bad_mesh)
+    bad_particles = generate_particles(ParticleProp, bad_mesh; alg=GridSampling())
+    filter!(bad_particles) do p
+        p.x[1] > 28 && p.x[2] > 28
+    end
+    bad_weights = generate_basis_weights(BSpline(Linear()), bad_mesh, length(bad_particles))
+    update!(bad_weights, bad_particles, bad_mesh)
+    bad_activity = falses(Tesserae.nblocks(Tesserae.get_spinds(bad_grid)))
+    bad_activity[1,1] = true
+    update_sparsity!(bad_grid, bad_activity)
+    bad_nodes = supportnodes(bad_weights[1], bad_grid)
+    bad_node = bad_nodes[findfirst(i -> !Tesserae.isactive(i), bad_nodes)]
+    @test_throws ErrorException Tesserae.p2g_write_index(bad_grid, bad_node)
+
     mesh_block3 = CartesianMesh(1.0, (0, 8), (0, 16); block_size_log2=Val(3))
     grid_block3 = generate_grid(SpArray, GridProp, mesh_block3)
     partition_block3 = ThreadPartition(mesh_block3)


### PR DESCRIPTION
- Converts SpGrid `@P2G` write indices to compact SpArray storage indices and writes through that storage path.
- Keeps inactive SpGrid support-node validation under bounds checking while preserving the inbounds fast path for `@P2G`.