### PR TITLE
Hoist particle-only P2G RHS products

### DIFF
--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -314,10 +314,12 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         TransferEquation(eq.kind, eq.lhs, resolve_refs(eq.rhs, scope), eq.op)
     end
     replaced = scope.replacements
+    inner_symbols = p2g_cached_symbols(replaced, 1, 2, 4, 5)
 
     fillzeros = Any[]
     gmats = Any[]
     gdofs_init = Any[]
+    hoist_exprs = Any[]
     lmat_init = Any[]
     local_jdofs = Any[]
     local_idofs = Any[]
@@ -342,6 +344,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
 
         op == :(=)  && push!(fillzeros, :(Tesserae.fillzero!($gmat)))
         op == :(-=) && (rhs = :(-$rhs))
+        rhs = hoist_p2g_rhs!(hoist_exprs, inner_symbols, rhs)
         lmat_dims = Symbol(lmat, :dims)
         push!(gmats, gmat)
         if gi == i && gj == j
@@ -374,6 +377,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
 
     body = quote
         $(replaced[3]...)
+        $(hoist_exprs...)
         $bw_i, $bw_j = $weights_i′[$p], $weights_j′[$p]
         $supportnodes_expr
         $(lmat_init...)

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -269,25 +269,29 @@ end
 function hoist_p2g_rhs!(hoist_exprs::Vector, inner_symbols::Set{Symbol}, expr)
     MacroTools.postwalk(expr) do ex
         if Meta.isexpr(ex, :call) && first(ex.args) === :*
-            return hoist_p2g_product_edges!(hoist_exprs, inner_symbols, Any[ex.args[2:end]...])
+            return hoist_p2g_product_runs!(hoist_exprs, inner_symbols, Any[ex.args[2:end]...])
         end
         ex
     end
 end
 
-function hoist_p2g_product_edges!(hoist_exprs::Vector, inner_symbols::Set{Symbol}, args::Vector)
-    first_inner = findfirst(arg -> p2g_has_symbol(arg, inner_symbols), args)
-    first_inner === nothing && return p2g_product_expr(args)
-    last_inner = findlast(arg -> p2g_has_symbol(arg, inner_symbols), args)
-
+function hoist_p2g_product_runs!(hoist_exprs::Vector, inner_symbols::Set{Symbol}, args::Vector)
     newargs = Any[]
-    append_p2g_hoisted_edge!(newargs, hoist_exprs, args[1:first_inner-1])
-    append!(newargs, args[first_inner:last_inner])
-    append_p2g_hoisted_edge!(newargs, hoist_exprs, args[last_inner+1:end])
+    run = Any[]
+    for arg in args
+        if p2g_simple_factor(arg) && !p2g_has_symbol(arg, inner_symbols)
+            push!(run, arg)
+        else
+            append_p2g_hoisted_run!(newargs, hoist_exprs, run)
+            empty!(run)
+            push!(newargs, arg)
+        end
+    end
+    append_p2g_hoisted_run!(newargs, hoist_exprs, run)
     p2g_product_expr(newargs)
 end
 
-function append_p2g_hoisted_edge!(newargs::Vector, hoist_exprs::Vector, args)
+function append_p2g_hoisted_run!(newargs::Vector, hoist_exprs::Vector, args)
     if length(args) > 1 && all(p2g_simple_factor, args) && any(p2g_has_symbol, args)
         sym = gensym(:p2g_rhs)
         rhs = p2g_product_expr(Any[args...])

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -206,18 +206,22 @@ function P2G_sum_expr((grid,i), (particles,p), (weights,ip), sum_equations::Vect
     scope = TransferScope([grid=>i, particles=>p, bw=>ip]; cache=true)
     sum_equations = resolve_sum_equations(sum_equations, scope, "@P2G", i)
     replaced = scope.replacements
+    inner_symbols = p2g_cached_symbols(replaced, 1, 3)
 
     fillzeros = Any[]
+    hoist_exprs = Any[]
     sum_exprs = Any[]
     for eq in sum_equations
         (; lhs, rhs, op) = eq
         op == :(=)  && push_unique!(fillzeros, :(Tesserae.fillzero!($(remove_indexing(lhs)))))
         op == :(-=) && (rhs = :(-$rhs))
+        rhs = hoist_p2g_rhs!(hoist_exprs, inner_symbols, rhs)
         push!(sum_exprs, p2g_sum_add_expr(lhs, gridwriteindex, rhs))
     end
 
     body = quote
         $(replaced[2]...)
+        $(hoist_exprs...)
         $bw = $weights[$p]
         $gridindices = supportnodes($bw, $grid)
         for $ip in eachindex($gridindices)
@@ -229,6 +233,70 @@ function P2G_sum_expr((grid,i), (particles,p), (weights,ip), sum_equations::Vect
     end
 
     Expr(:block, fillzeros...), body
+end
+
+function p2g_cached_symbols(replaced::Vector{Vector{Expr}}, groups::Integer...)
+    symbols = Set{Symbol}()
+    for ex in Iterators.flatten(replaced[group] for group in groups)
+        Meta.isexpr(ex, :(=), 2) && ex.args[1] isa Symbol && push!(symbols, ex.args[1])
+    end
+    symbols
+end
+
+function p2g_has_symbol(expr, symbols=nothing)
+    if expr isa Symbol
+        return symbols === nothing || expr in symbols
+    elseif expr isa Expr
+        return any(arg -> p2g_has_symbol(arg, symbols), expr.args)
+    else
+        return false
+    end
+end
+
+function p2g_simple_factor(expr)
+    expr isa Union{Symbol, Number, QuoteNode} && return true
+    if Meta.isexpr(expr, :call, 2) && expr.args[1] in (:-, :+)
+        return p2g_simple_factor(expr.args[2])
+    end
+    false
+end
+
+function p2g_product_expr(args::Vector)
+    length(args) == 1 && return only(args)
+    Expr(:call, :*, args...)
+end
+
+function hoist_p2g_rhs!(hoist_exprs::Vector, inner_symbols::Set{Symbol}, expr)
+    MacroTools.postwalk(expr) do ex
+        if Meta.isexpr(ex, :call) && first(ex.args) === :*
+            return hoist_p2g_product_edges!(hoist_exprs, inner_symbols, Any[ex.args[2:end]...])
+        end
+        ex
+    end
+end
+
+function hoist_p2g_product_edges!(hoist_exprs::Vector, inner_symbols::Set{Symbol}, args::Vector)
+    first_inner = findfirst(arg -> p2g_has_symbol(arg, inner_symbols), args)
+    first_inner === nothing && return p2g_product_expr(args)
+    last_inner = findlast(arg -> p2g_has_symbol(arg, inner_symbols), args)
+
+    newargs = Any[]
+    append_p2g_hoisted_edge!(newargs, hoist_exprs, args[1:first_inner-1])
+    append!(newargs, args[first_inner:last_inner])
+    append_p2g_hoisted_edge!(newargs, hoist_exprs, args[last_inner+1:end])
+    p2g_product_expr(newargs)
+end
+
+function append_p2g_hoisted_edge!(newargs::Vector, hoist_exprs::Vector, args)
+    if length(args) > 1 && all(p2g_simple_factor, args) && any(p2g_has_symbol, args)
+        sym = gensym(:p2g_rhs)
+        rhs = p2g_product_expr(Any[args...])
+        push!(hoist_exprs, :($sym = $rhs))
+        push!(newargs, sym)
+    else
+        append!(newargs, args)
+    end
+    newargs
 end
 
 function p2g_sum_add_expr(lhs, index, rhs)

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -192,10 +192,10 @@
 
     @testset "P2G RHS product hoisting" begin
         hoist_exprs = Any[]
-        rhs = Tesserae.hoist_p2g_rhs!(hoist_exprs, Set([:wi, :∇wi]), :(a * b * wi * c * d * ∇wi * e * f))
+        rhs = Tesserae.hoist_p2g_rhs!(hoist_exprs, Set([:wi, :∇wi]), :(2 * a * b * wi * c * d * ∇wi * e * f))
         hoisted_symbols = map(ex -> ex.args[1], hoist_exprs)
 
-        @test map(ex -> ex.args[2], hoist_exprs) == [:(a * b), :(c * d), :(e * f)]
+        @test map(ex -> ex.args[2], hoist_exprs) == [:(2 * a * b), :(c * d), :(e * f)]
         @test rhs == Expr(:call, :*, hoisted_symbols[1], :wi, hoisted_symbols[2], :∇wi, hoisted_symbols[3])
     end
 

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -190,6 +190,15 @@
         @test actual.v ≈ expected.v
     end
 
+    @testset "P2G RHS product hoisting" begin
+        hoist_exprs = Any[]
+        rhs = Tesserae.hoist_p2g_rhs!(hoist_exprs, Set([:wi, :∇wi]), :(a * b * wi * c * d * ∇wi * e * f))
+        hoisted_symbols = map(ex -> ex.args[1], hoist_exprs)
+
+        @test map(ex -> ex.args[2], hoist_exprs) == [:(a * b), :(c * d), :(e * f)]
+        @test rhs == Expr(:call, :*, hoisted_symbols[1], :wi, hoisted_symbols[2], :∇wi, hoisted_symbols[3])
+    end
+
     @testset "CPDI rejects SpGrid" begin
         grid, particles, weights = cpdi_spgrid_fixture()
 


### PR DESCRIPTION
Hoists particle-only product runs in P2G-family right-hand sides outside support-node loops. This preserves factor order while avoiding repeated particle-only multiplications in `@P2G`, `@G2P2G`, and `@P2G_Matrix` scatter paths.