### PR TITLE
Optimize StructVector particle reorder

### DIFF
--- a/src/thread_partition.jl
+++ b/src/thread_partition.jl
@@ -298,9 +298,7 @@ threadsafe_groups(bs::BlockStrategy) = bs.activegroups
 function reorder_particles!(particles::AbstractVector, bs::BlockStrategy)
     n_assigned = nassigned(bs)
     _reorder_particles!(particles, bs.particleindices, n_assigned)
-    @inbounds for k in 1:n_assigned
-        bs.particleindices[k] = k
-    end
+    copyto!(bs.particleindices, 1:n_assigned)
     particles
 end
 
@@ -315,30 +313,41 @@ function _reorder_particles!(particles::AbstractVector, particleindices::Abstrac
     (firstindex(particles) == 1 && lastindex(particles) == nₚ) || throw(ArgumentError("reorder_particles!: particles must be 1-based indexed (`Vector`-like)."))
     nₚ_assigned > nₚ && error("reorder_particles!: The block assignment contains more particle IDs than exist (assigned=$nₚ_assigned, total=$nₚ).")
 
-    perm = Vector{Int}(undef, nₚ)
-    !iszero(nₚ_assigned) && copyto!(perm, 1, particleindices, 1, nₚ_assigned)
-
-    if nₚ_assigned != nₚ
-        seen = falses(nₚ)
-        for i in 1:nₚ_assigned
-            p = perm[i]
-            1 ≤ p ≤ nₚ || error("reorder_particles!: particle ID $p is out of range (valid: 1:$nₚ).")
-            @inbounds begin
-                seen[p] && error("reorder_particles!: particle $p is duplicated in the block assignment.")
-                seen[p] = true
-            end
-        end
-
-        @warn "reorder_particles!: Some particles are outside of the grid and were not assigned to any block. They will be kept at the end of the array." maxlog=1
-        k = nₚ_assigned
-        @inbounds for p in 1:nₚ
-            if !seen[p]
-                k += 1
-                perm[k] = p
-            end
-        end
-        @assert k == nₚ
+    # Common case: every particle is inside the mesh, so the flat block-ordered
+    # particleindices array is already the complete reorder permutation.
+    if nₚ_assigned == nₚ
+        particle_order = view(particleindices, 1:nₚ)
+        particles_copied = @inbounds particles[particle_order]
+        particles .= particles_copied
+        return particle_order
     end
+
+    perm = Vector{Int}(undef, nₚ)
+    # Only the first nₚ_assigned entries are valid; the rest may contain stale
+    # ids from a previous partition update.
+    copyto!(perm, 1, particleindices, 1, nₚ_assigned)
+
+    # Fallback: keep particles outside the mesh after the assigned particles,
+    # preserving their original relative order.
+    seen = falses(nₚ)
+    for i in 1:nₚ_assigned
+        p = perm[i]
+        1 ≤ p ≤ nₚ || error("reorder_particles!: particle ID $p is out of range (valid: 1:$nₚ).")
+        @inbounds begin
+            seen[p] && error("reorder_particles!: particle $p is duplicated in the block assignment.")
+            seen[p] = true
+        end
+    end
+
+    @warn "reorder_particles!: Some particles are outside of the grid and were not assigned to any block. They will be kept at the end of the array." maxlog=1
+    k = nₚ_assigned
+    @inbounds for p in 1:nₚ
+        if !seen[p]
+            k += 1
+            perm[k] = p
+        end
+    end
+    @assert k == nₚ
 
     particles_copied = @inbounds particles[perm]
     copyto!(particles, 1, particles_copied, 1, nₚ)

--- a/src/thread_partition.jl
+++ b/src/thread_partition.jl
@@ -1,9 +1,26 @@
 abstract type PartitionStrategy end
 
-# Scratch buffers reused by BlockStrategy.update!:
+struct ParticleReorderBuffers
+    by_component_type::Dict{DataType, Any}
+end
+ParticleReorderBuffers() = ParticleReorderBuffers(Dict{DataType, Any}())
+
+const THREADED_COMPONENT_REORDER_MIN_LENGTH = 2^16
+
+function buffer_for_component!(buffers::ParticleReorderBuffers, component::T) where {T}
+    buffer = get(buffers.by_component_type, T, nothing)
+    if !(buffer isa T) || length(buffer) != length(component)
+        buffer = similar(component, length(component))
+        buffers.by_component_type[T] = buffer
+    end
+    buffer::T
+end
+
+# Reusable buffers owned by BlockStrategy:
 #   * per-chunk block histograms
 #   * per-particle packed block ids and 1-based numbers within each chunk/block
 #   * touched/active block lists used to avoid full block-array clears/scans
+#   * particle reorder buffers for StructVector component arrays
 struct BlockUpdateWorkspace{dim}
     chunk_counts::Vector{Array{Int, dim}}
     packed_particle_blocks::Vector{UInt64}
@@ -11,6 +28,7 @@ struct BlockUpdateWorkspace{dim}
     touchedblocks::Vector{Vector{Int}}
     active_epoch_marks::Vector{Int}
     active_epoch::Base.RefValue{Int}
+    particle_reorder_buffers::ParticleReorderBuffers
 end
 
 function BlockUpdateWorkspace(blkdims::Dims{dim}) where {dim}
@@ -21,6 +39,7 @@ function BlockUpdateWorkspace(blkdims::Dims{dim}) where {dim}
         [Int[] for _ in 1:Threads.nthreads()],
         zeros(Int, prod(blkdims)),
         Ref(0),
+        ParticleReorderBuffers(),
     )
 end
 
@@ -295,9 +314,9 @@ function update_threadsafe_groups!(bs::BlockStrategy)
 end
 threadsafe_groups(bs::BlockStrategy) = bs.activegroups
 
-function reorder_particles!(particles::AbstractVector, bs::BlockStrategy)
+function reorder_particles!(particles::StructVector, bs::BlockStrategy)
     n_assigned = nassigned(bs)
-    _reorder_particles!(particles, bs.particleindices, n_assigned)
+    _reorder_particles!(particles, bs.particleindices, n_assigned, bs.update_workspace.particle_reorder_buffers)
     copyto!(bs.particleindices, 1:n_assigned)
     particles
 end
@@ -307,7 +326,39 @@ function reorder_particles!(particles::AbstractVector, ptsinblks::AbstractArray{
     particles
 end
 
-function _reorder_particles!(particles::AbstractVector, particleindices::AbstractVector{Int}, nₚ_assigned::Integer)
+function _permute_particles!(particles::StructVector, perm, buffers::ParticleReorderBuffers)
+    for component in StructArrays.components(particles)
+        buffer = buffer_for_component!(buffers, component)
+        _permute_component!(component, perm, buffer)
+    end
+    particles
+end
+
+function _permute_component!(component, perm, buffer)
+    n = length(component)
+    # _reorder_particles! passes a full-length valid permutation; the buffer has
+    # the same length as the component, so the gather loop can skip bounds checks.
+    if Threads.nthreads() == 1 || n < THREADED_COMPONENT_REORDER_MIN_LENGTH
+        @inbounds for k in 1:n
+            buffer[k] = component[perm[k]]
+        end
+    else
+        nchunks = Threads.nthreads()
+        chunksize = cld(n, nchunks)
+        tforeach(1:nchunks) do chunk_id
+            firstp = (chunk_id - 1) * chunksize + 1
+            lastp = min(chunk_id * chunksize, n)
+            @inbounds for k in firstp:lastp
+                buffer[k] = component[perm[k]]
+            end
+        end
+    end
+
+    copyto!(component, buffer)
+    component
+end
+
+function _reorder_particles!(particles::StructVector, particleindices::AbstractVector{Int}, nₚ_assigned::Integer, buffers::ParticleReorderBuffers=ParticleReorderBuffers())
     nₚ = length(particles)
 
     (firstindex(particles) == 1 && lastindex(particles) == nₚ) || throw(ArgumentError("reorder_particles!: particles must be 1-based indexed (`Vector`-like)."))
@@ -317,8 +368,7 @@ function _reorder_particles!(particles::AbstractVector, particleindices::Abstrac
     # particleindices array is already the complete reorder permutation.
     if nₚ_assigned == nₚ
         particle_order = view(particleindices, 1:nₚ)
-        particles_copied = @inbounds particles[particle_order]
-        particles .= particles_copied
+        _permute_particles!(particles, particle_order, buffers)
         return particle_order
     end
 
@@ -349,8 +399,7 @@ function _reorder_particles!(particles::AbstractVector, particleindices::Abstrac
     end
     @assert k == nₚ
 
-    particles_copied = @inbounds particles[perm]
-    copyto!(particles, 1, particles_copied, 1, nₚ)
+    _permute_particles!(particles, perm, buffers)
 
     perm
 end

--- a/test/partitioning.jl
+++ b/test/partitioning.jl
@@ -1,13 +1,15 @@
 @testset "ThreadPartition" begin
     @testset "BlockStrategy" begin
         mesh = CartesianMesh(0.25, (0,4), (0,4))
-        xₚ = generate_particles(mesh)
-        filter!(xₚ) do (x,y)
+        particles = generate_particles(@NamedTuple{x::Vec{2, Float64}}, mesh)
+        filter!(particles) do particle
+            x, y = particle.x
             (x-2)^2 + (y-2)^2 < 1
         end
 
         Random.seed!(1234)
-        shuffle!(xₚ)
+        shuffle!(particles)
+        xₚ = particles.x
 
         bs = (@inferred Tesserae.BlockStrategy(mesh))
         @test Tesserae.nblocks(bs) === Tesserae.nblocks(mesh)
@@ -52,7 +54,7 @@
         end
 
         # Reordering should keep block ranges and P2G color-group order valid.
-        reorder_particles!(xₚ, bs)
+        reorder_particles!(particles, bs)
 
         n_assigned = Tesserae.nassigned(bs)
         @test bs.particleindices[1:n_assigned] == collect(1:n_assigned)
@@ -60,7 +62,7 @@
 
         update!(bs, xₚ)
         check_group_order(bs)
-        reorder_particles!(xₚ, bs)
+        reorder_particles!(particles, bs)
         n_assigned = Tesserae.nassigned(bs)
         @test bs.particleindices[1:n_assigned] == collect(1:n_assigned)
         check_group_order(bs)
@@ -78,11 +80,14 @@
         check_group_order(moving_bs)
         check_particle_blocks(moving_bs, mesh, moving_xₚ)
 
-        moving_xₚ = [Vec(0.125, 0.125), Vec(10.0, 10.0), Vec(3.875, 0.125)]
+        moving_particles = generate_particles(@NamedTuple{x::Vec{2, Float64}}, mesh)
+        resize!(moving_particles, 3)
+        moving_particles.x .= [Vec(0.125, 0.125), Vec(10.0, 10.0), Vec(3.875, 0.125)]
+        moving_xₚ = moving_particles.x
         update!(moving_bs, moving_xₚ)
         check_group_order(moving_bs)
         check_particle_blocks(moving_bs, mesh, moving_xₚ)
-        @test_logs (:warn, r"Some particles are outside of the grid") reorder_particles!(moving_xₚ, moving_bs)
+        @test_logs (:warn, r"Some particles are outside of the grid") reorder_particles!(moving_particles, moving_bs)
         n_assigned = Tesserae.nassigned(moving_bs)
         @test moving_bs.particleindices[1:n_assigned] == collect(1:n_assigned)
         @test Tesserae.findblock(moving_xₚ[end], mesh) === nothing


### PR DESCRIPTION
* Reuse per-component buffers for StructVector particle reorder in BlockStrategy.
* Keep BlockStrategy reorder on the StructVector path and update the partitioning test to exercise it.