### PR TITLE
Add foreach macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to Tesserae.jl will be documented in this file.
 ## v0.7.0 - Unreleased
 
 v0.7.0 focuses on larger and more inspectable MPM workflows: sparse-grid GPU
-execution, clearer threaded CPU scattering, more predictable particle
-generation, and better tools for understanding transfer macros.
+execution, backend-aware local loops, clearer threaded CPU scattering, more
+predictable particle generation, and better tools for understanding transfer
+macros.
 
 ### Highlights
 
@@ -20,6 +21,8 @@ generation, and better tools for understanding transfer macros.
   spacing. (#113)
 - `@explain` now prints readable CPU reference code for transfer macros,
   including threaded transfers and matrix assembly. (#126)
+- `@foreach` provides backend-aware loops over grids, particles, and active
+  sparse grid nodes without abusing transfer macros as generic loop kernels.
 - P2G and basis-weight updates are faster across dense and sparse grid paths.
   (#124, #129, #131, #132, #133)
 
@@ -54,6 +57,8 @@ generation, and better tools for understanding transfer macros.
 - Added `@showprogress` for Tesserae's progress display. (#139)
 - Added `@explain` and `ExplainedCode` for inspecting transfer macro structure.
   (#126)
+- Added `@foreach` for CPU/GPU loops over grids, particles, and active `SpGrid`
+  nodes.
 - Added transfer interpolation with `$(expr)` inside transfer macro right-hand
   sides, allowing an outer expression to be evaluated once before generated
   transfer loops. (#118)

--- a/docs/src/transfer.md
+++ b/docs/src/transfer.md
@@ -9,7 +9,29 @@ The same macro body can include the transfer itself and the local grid or partic
 @P2G
 @G2P
 @G2P2G
+@foreach
 ```
+
+## Backend-aware local loops
+
+Use [`@foreach`](@ref) for local grid or particle updates that are not transfers.
+It follows the same `collection=>i` field-access convention as transfer macros:
+
+```julia
+@foreach grid=>i begin
+    m⁻¹[i] = ifelse(iszero(m[i]), zero(m[i]), inv(m[i]))
+    v[i] = mv[i] * m⁻¹[i]
+end
+
+@foreach particles=>p begin
+    x[p] += v[p] * Δt
+end
+```
+
+On dense grids, [`@foreach`](@ref) visits all grid nodes.
+On `SpGrid`, it visits only active sparse nodes.
+When the collection is on GPU, the loop is dispatched as a GPU kernel.
+Prefix it with [`@threaded`](@ref) to parallelize CPU loops.
 
 ## Inspecting transfer code
 

--- a/src/Tesserae.jl
+++ b/src/Tesserae.jl
@@ -34,6 +34,7 @@ export
 # utils
     fillzero!,
     @threaded,
+    @foreach,
     @showprogress,
 # ThreadPartition
     ThreadPartition,
@@ -137,6 +138,7 @@ include("Basis/kernelcorrection.jl")
 include("fem.jl")
 
 include("transfer.jl")
+include("foreach.jl")
 include("implicit.jl")
 include("explain.jl")
 

--- a/src/foreach.jl
+++ b/src/foreach.jl
@@ -1,0 +1,94 @@
+"""
+    @foreach collection=>i begin
+        statements...
+    end
+
+Run `statements` for each index of `collection`.
+Inside the block, `field[i]` is resolved to `collection.field[i]`, matching the
+field-access convention used by transfer macros.
+Use `\$(expr)` to evaluate an outer expression once before the generated loop.
+
+For `SpGrid`, only active sparse indices are visited. On GPU, the loop is
+dispatched as a backend kernel.
+"""
+macro foreach(collection_i, body)
+    foreach_expr(QuoteNode(:nothing), collection_i, body)
+end
+
+macro foreach(schedule::QuoteNode, collection_i, body)
+    foreach_expr(schedule, collection_i, body)
+end
+
+function foreach_expr(schedule::QuoteNode, collection_i, body)
+    collection, i = unpair(collection_i)
+    interpolations = Pair{Symbol, Any}[]
+    body = extract_transfer_interpolations(body, interpolations)
+    scope = TransferScope([collection=>i])
+    body = resolve_refs(body, scope)
+    if !DEBUG
+        body = :(@inbounds $body)
+    end
+    code = quote
+        Tesserae.foreach_loop(($collection, $i) -> $body,
+                              Tesserae.get_device($collection),
+                              Val($schedule), $collection)
+    end
+    code = interpolate_transfer_values(code, TransferProgram(TransferEquation[], interpolations))
+    esc(prettify(code; lines=true, alias=false))
+end
+
+foreach_indices(collection) = eachindex(collection)
+foreach_indices(collection::SpGrid) = activeindices(get_spinds(collection))
+
+function foreach_loop(f, ::CPUDevice, ::Val{scheduler}, collection) where {scheduler}
+    tforeach(foreach_indices(collection), scheduler) do i
+        @inline f(collection, i)
+    end
+end
+
+function foreach_loop(f, ::CPUDevice, ::Val{:nothing}, collection::SpGrid)
+    for i in foreach_indices(collection)
+        @inline f(collection, i)
+    end
+end
+
+function foreach_loop(f, ::CPUDevice, ::Val{scheduler}, collection::SpGrid) where {scheduler}
+    tforeach(collect(foreach_indices(collection)), scheduler) do i
+        @inline f(collection, i)
+    end
+end
+
+@kernel function gpukernel_foreach(f, collection)
+    i = @index(Global, Cartesian)
+    f(collection, i)
+end
+
+@kernel function gpukernel_foreach_linear(f, collection)
+    i = @index(Global)
+    f(collection, i)
+end
+
+@kernel function gpukernel_foreach_spgrid(f, collection, @Const(spinds))
+    k = @index(Global)
+    active, i = _active_spindex(spinds, k)
+    if active
+        @inbounds f(collection, i)
+    end
+end
+
+function foreach_loop(f, device::GPUDevice, ::Val{scheduler}, collection) where {scheduler}
+    scheduler == :nothing || @warn "Multi-threading is disabled for GPU" maxlog=1
+    backend = get_backend(device)
+    if collection isa SpGrid
+        spinds = get_spinds(collection)
+        kernel = gpukernel_foreach_spgrid(backend)
+        kernel(f, collection, spinds; ndrange=_spindex_ndrange(spinds))
+    elseif ndims(collection) == 1
+        kernel = gpukernel_foreach_linear(backend)
+        kernel(f, collection; ndrange=length(collection))
+    else
+        kernel = gpukernel_foreach(backend)
+        kernel(f, collection; ndrange=size(collection))
+    end
+    synchronize(backend)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -219,7 +219,7 @@ function threaded_expr(schedule::QuoteNode, expr::Expr)
             end
         end
     elseif Meta.isexpr(expr, :macrocall) &&
-           (expr.args[1] in (Symbol("@P2G"), Symbol("@G2P"), Symbol("@G2P2G"), Symbol("@P2G_Matrix")))
+           (expr.args[1] in (Symbol("@P2G"), Symbol("@G2P"), Symbol("@G2P2G"), Symbol("@P2G_Matrix"), Symbol("@foreach")))
         insert!(expr.args, 3, schedule)
         esc(expr)
     else

--- a/test/explain.jl
+++ b/test/explain.jl
@@ -1,4 +1,4 @@
-@testset "explain" begin
+@testset "Explain macro" begin
     function explain_setup()
         T = Float64
         GridProp = @NamedTuple begin

--- a/test/foreach.jl
+++ b/test/foreach.jl
@@ -1,0 +1,71 @@
+@testset "Foreach macro" begin
+    @testset "Grid" begin
+        mesh = CartesianMesh(1.0, (0,2), (0,2))
+        GridProp = @NamedTuple{x::Vec{2,Float64}, m::Float64, mv::Vec{2,Float64}, v::Vec{2,Float64}}
+        grid = generate_grid(GridProp, mesh)
+        @. grid.m = 2
+        @. grid.mv = Vec(1, -1)
+
+        @foreach grid=>i begin
+            v[i] = x[i] + mv[i] / m[i]
+        end
+
+        @test all(i -> grid.v[i] == grid.x[i] + grid.mv[i] / grid.m[i], eachindex(grid))
+
+        @. grid.v = zero(grid.v)
+        @threaded @foreach grid=>i begin
+            v[i] = x[i] - mv[i] / m[i]
+        end
+
+        @test all(i -> grid.v[i] == grid.x[i] - grid.mv[i] / grid.m[i], eachindex(grid))
+    end
+
+    @testset "Particles" begin
+        mesh = CartesianMesh(1.0, (0,2), (0,2))
+        ParticleProp = @NamedTuple{x::Vec{2,Float64}, v::Vec{2,Float64}}
+        particles = generate_particles(ParticleProp, mesh; alg=GridSampling())
+        @. particles.v = Vec(0.25, -0.5)
+        x0 = copy(particles.x)
+        Δt = 0.2
+
+        @foreach particles=>p begin
+            x[p] += v[p] * Δt
+        end
+
+        @test particles.x == x0 .+ particles.v .* Δt
+    end
+
+    @testset "Interpolation" begin
+        mesh = CartesianMesh(1.0, (0,2), (0,2))
+        grid = generate_grid(@NamedTuple{x::Vec{2,Float64}, m::Float64}, mesh)
+        calls = Ref(0)
+        scale() = (calls[] += 1; 3.0)
+
+        @foreach grid=>i begin
+            m[i] = $(scale()) * (x[i][1] + 1)
+        end
+
+        @test calls[] == 1
+        @test all(i -> grid.m[i] == 3 * (grid.x[i][1] + 1), eachindex(grid))
+    end
+
+    @testset "SpGrid" begin
+        mesh = CartesianMesh(1.0, (0,8), (0,8))
+        GridProp = @NamedTuple{x::Vec{2,Float64}, m::Float64, v::Vec{2,Float64}}
+        grid = generate_grid(SpArray, GridProp, mesh)
+        particles = [Vec(1.0, 1.0), Vec(7.0, 7.0)]
+        update_sparsity!(grid, particles)
+
+        @foreach grid=>i begin
+            m[i] = 1
+            v[i] = x[i]
+        end
+
+        active = collect(Tesserae.activeindices(grid.m))
+        @test !isempty(active)
+        @test all(i -> grid.m[i] == 1, active)
+        @test all(i -> grid.v[i] == grid.x[i], active)
+        @test all(i -> iszero(grid.m[i]), filter(i -> !Tesserae.isactive(grid.m, i), eachindex(grid.m)))
+        @test all(i -> iszero(grid.v[i]), filter(i -> !Tesserae.isactive(grid.v, i), eachindex(grid.v)))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ include("basis.jl")
 include("shapes.jl")
 
 include("transfer.jl")
+include("foreach.jl")
 include("implicit.jl")
 include("explain.jl")
 


### PR DESCRIPTION
Adds a backend-aware @foreach macro for local loops over grids, particles, and active sparse grid nodes.

Updates transfer docs, v0.7 changelog notes, and focused coverage for dense grids, particles, interpolation, threaded loops, and SpGrid traversal.