### PR TITLE
Add common cell support API

### DIFF
--- a/src/Tesserae.jl
+++ b/src/Tesserae.jl
@@ -51,6 +51,7 @@ export
     findcell,
     extract,
     UnstructuredMesh,
+    cells,
 # Grid
     Grid,
     SpGrid,

--- a/src/export.jl
+++ b/src/export.jl
@@ -51,13 +51,13 @@ end
 
 function _vtk_grid(vtk, mesh::UnstructuredMesh; kwargs...)
     shape = cellshape(mesh)
-    cells = WriteVTK.MeshCell[]
+    vtk_cells = WriteVTK.MeshCell[]
     celltype = to_vtk_celltype(shape)
-    for c in 1:ncells(mesh)
-        indices = cellnodeindices(mesh, c)
-        push!(cells, WriteVTK.MeshCell(celltype, indices[to_vtk_connectivity(shape)]))
+    for cell in cells(mesh)
+        indices = supportnodes(mesh, cell)
+        push!(vtk_cells, WriteVTK.MeshCell(celltype, indices[to_vtk_connectivity(shape)]))
     end
-    WriteVTK.vtk_grid(vtk, maparray(x->Vec{3,Float32}(resize(x,3)), mesh), cells; kwargs...)
+    WriteVTK.vtk_grid(vtk, maparray(x->Vec{3,Float32}(resize(x,3)), mesh), vtk_cells; kwargs...)
 end
 
 # add_field_data

--- a/src/fem.jl
+++ b/src/fem.jl
@@ -18,16 +18,16 @@ function feupdate!(
     @assert size(weights) == (length(qpts), ncells(mesh))
     @assert isnothing(volume) || size(weights) == size(volume)
     valgrads = jet.(Ref(Order(1)), Ref(cellshape(mesh)), qpts)
-    for c in 1:ncells(mesh)
-        indices = cellnodeindices(mesh, c)
+    for cell in cells(mesh)
+        indices = supportnodes(mesh, cell)
         x = nodes[indices]
         for p in eachindex(qpts, qwts)
             N, dNdξ = valgrads[p]
             J = sum(x .⊗ dNdξ)
-            set_values!(weights[p,c], (N, dNdξ .⊡ Ref(inv(J))))
-            supportnodes_storage(weights[p,c])[] = indices
+            set_values!(weights[p,cell], (N, dNdξ .⊡ Ref(inv(J))))
+            supportnodes_storage(weights[p,cell])[] = indices
             if volume !== nothing
-                volume[p,c] = qwts[p] * det(J)
+                volume[p,cell] = qwts[p] * det(J)
             end
         end
     end
@@ -48,21 +48,21 @@ function feupdate!(
     @assert isnothing(area) || size(weights) == size(area)
     @assert isnothing(normal) || size(weights) == size(normal)
     valgrads = jet.(Ref(Order(1)), Ref(cellshape(mesh)), qpts)
-    for c in 1:ncells(mesh)
-        indices = cellnodeindices(mesh, c)
+    for cell in cells(mesh)
+        indices = supportnodes(mesh, cell)
         x = nodes[indices]
         for p in eachindex(qpts, qwts)
             N, dNdξ = valgrads[p]
             J = sum(x .⊗ dNdξ)
             n = _get_normal(J)
             n_norm = norm(n)
-            set_values!(weights[p,c], (N,))
-            supportnodes_storage(weights[p,c])[] = indices
+            set_values!(weights[p,cell], (N,))
+            supportnodes_storage(weights[p,cell])[] = indices
             if area !== nothing
-                area[p,c] = qwts[p] * n_norm
+                area[p,cell] = qwts[p] * n_norm
             end
             if normal !== nothing
-                normal[p,c] = n / n_norm
+                normal[p,cell] = n / n_norm
             end
         end
     end

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -68,7 +68,7 @@ end
 # UnstructuredMesh
 function KernelAbstractions.get_backend(mesh::UnstructuredMesh)
     backend = get_backend(mesh.nodes)
-    @assert get_backend(mesh.cellnodeindices) == backend
+    @assert get_backend(mesh.cellsupports) == backend
     backend
 end
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -182,16 +182,16 @@ function create_sparse_matrix(::Type{T}, (mesh1,mesh2)::Tuple{UnstructuredMesh, 
     ncol = length(gdofs2)
 
     I, J = Int[], Int[]
-    for c1 in 1:ncells(mesh1)
-        cellnodes1 = cellnodeindices(mesh1, c1)
+    for cell1 in cells(mesh1)
+        cellnodes1 = supportnodes(mesh1, cell1)
         primary_cellnodes1 = cellnodes1[primarynodes_indices(cellshape(mesh1))]
         celldofs1 = gdofs1[:, cellnodes1]
 
         if mesh1 === mesh2
             append_dofs!(I, J, celldofs1, celldofs1)
         else
-            for c2 in 1:ncells(mesh2)
-                cellnodes2 = cellnodeindices(mesh2, c2)
+            for cell2 in cells(mesh2)
+                cellnodes2 = supportnodes(mesh2, cell2)
                 primary_cellnodes2 = cellnodes2[primarynodes_indices(cellshape(mesh2))]
                 if mesh1[primary_cellnodes1] ≈ mesh2[primary_cellnodes2]
                     celldofs2 = gdofs2[:, cellnodes2]

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -231,7 +231,7 @@ end
 struct UnstructuredMesh{S <: Shape, dim, T, L} <: AbstractMesh{dim, T, 1}
     shape::S
     nodes::Vector{Vec{dim, T}}
-    cellnodeindices::Vector{SVector{L, Int}}
+    cellsupports::Vector{SVector{L, Int}}
 end
 
 Base.size(mesh::UnstructuredMesh) = size(mesh.nodes)
@@ -247,9 +247,10 @@ end
 end
 
 cellshape(mesh::UnstructuredMesh) = mesh.shape
-ncells(mesh::UnstructuredMesh) = length(mesh.cellnodeindices)
+ncells(mesh::UnstructuredMesh) = length(mesh.cellsupports)
+cells(mesh::UnstructuredMesh) = eachindex(mesh.cellsupports)
 
-@inline cellnodeindices(mesh::UnstructuredMesh, c::Int) = (@_propagate_inbounds_meta; mesh.cellnodeindices[c])
+@inline supportnodes(mesh::UnstructuredMesh, cell::Int) = (@_propagate_inbounds_meta; mesh.cellsupports[cell])
 
 UnstructuredMesh(mesh::CartesianMesh) = UnstructuredMesh(default_cellshape(mesh), mesh)
 default_cellshape(::CartesianMesh{1}) = Line2()
@@ -314,29 +315,29 @@ end
 
 function extract(mesh::UnstructuredMesh, nodeindices::AbstractVector{Int})
     shape = cellshape(mesh)
-    cells = SVector{nlocalnodes(shape), Int}[]
-    for c in 1:ncells(mesh)
-        indices = cellnodeindices(mesh, c)
+    supports = SVector{nlocalnodes(shape), Int}[]
+    for cell in cells(mesh)
+        indices = supportnodes(mesh, cell)
         if all(in.(indices, Ref(nodeindices)))
-            push!(cells, indices)
+            push!(supports, indices)
         end
     end
-    UnstructuredMesh(shape, mesh.nodes, cells)
+    UnstructuredMesh(shape, mesh.nodes, supports)
 end
 
 function extract_face(mesh::UnstructuredMesh, nodeindices::AbstractVector{Int})
     shape = faceshape(cellshape(mesh))
-    cells = SVector{nlocalnodes(shape), Int}[]
-    for c in 1:ncells(mesh)
-        indices = cellnodeindices(mesh, c)
+    supports = SVector{nlocalnodes(shape), Int}[]
+    for cell in cells(mesh)
+        indices = supportnodes(mesh, cell)
         for conn in faces(cellshape(mesh))
             faceindices = indices[conn]
             if all(in.(faceindices, Ref(nodeindices)))
-                push!(cells, faceindices)
+                push!(supports, faceindices)
             end
         end
     end
-    UnstructuredMesh(shape, mesh.nodes, unique(cells))
+    UnstructuredMesh(shape, mesh.nodes, unique(supports))
 end
 
 function Base.merge!(dest::UnstructuredMesh{S}, src::UnstructuredMesh{S}) where {S}
@@ -355,12 +356,12 @@ function Base.merge!(dest::UnstructuredMesh{S}, src::UnstructuredMesh{S}) where 
         end
     end
 
-    sortedinds_src = map(inds -> sort(nodemap[inds]), src.cellnodeindices)
-    sortedinds_dst = map(sort, dest.cellnodeindices)
-    for c in 1:ncells(src)
-        inds_src = sortedinds_src[c]
+    sortedinds_src = map(inds -> sort(nodemap[inds]), src.cellsupports)
+    sortedinds_dst = map(sort, dest.cellsupports)
+    for cell in cells(src)
+        inds_src = sortedinds_src[cell]
         if all(inds_dest -> inds_src !== inds_dest, sortedinds_dst)
-            push!(dest.cellnodeindices, nodemap[cellnodeindices(src, c)])
+            push!(dest.cellsupports, nodemap[supportnodes(src, cell)])
         end
     end
     dest
@@ -369,6 +370,6 @@ function Base.merge!(dest::UnstructuredMesh{S}, src1::UnstructuredMesh{S}, src2:
     merge!(merge!(dest, src1), src2, others...)
 end
 function Base.merge(x::UnstructuredMesh{S}, y::UnstructuredMesh{S}, z::UnstructuredMesh{S}...) where {S}
-    dest = UnstructuredMesh(cellshape(x), copy(x.nodes), copy(x.cellnodeindices))
+    dest = UnstructuredMesh(cellshape(x), copy(x.nodes), copy(x.cellsupports))
     merge!(dest, y, z...)
 end

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -26,12 +26,12 @@ function generate_points(alg::CellSampling, mesh::UnstructuredMesh{<: Any, dim, 
     shape = cellshape(mesh)
 
     points = Matrix{Vec{dim, T}}(undef, length(qpts), ncells(mesh))
-    for c in 1:ncells(mesh)
-        indices = cellnodeindices(mesh, c)
+    for cell in cells(mesh)
+        indices = supportnodes(mesh, cell)
         x = mesh[indices]
         for (i, qpt) in enumerate(qpts)
             N = value(shape, qpt)
-            points[i,c] = sum(N .* x)
+            points[i,cell] = sum(N .* x)
         end
     end
     points

--- a/src/thread_partition.jl
+++ b/src/thread_partition.jl
@@ -480,7 +480,7 @@ function CellStrategy(mesh::UnstructuredMesh)
     coloring = Graphs.degree_greedy_color(g)
 
     groups = [Int[] for _ in 1:coloring.num_colors]
-    @inbounds for cell in 1:ncells(mesh)
+    @inbounds for cell in cells(mesh)
         push!(groups[coloring.colors[cell]], cell)
     end
 
@@ -493,8 +493,8 @@ function _cell_conflict_graph(mesh::UnstructuredMesh)
     graph = SimpleGraph(nc)
 
     node2cells = [Int[] for _ in 1:nn]
-    @inbounds for cell in 1:nc
-        for i in cellnodeindices(mesh, cell)
+    @inbounds for cell in cells(mesh)
+        for i in supportnodes(mesh, cell)
             push!(node2cells[i], cell)
         end
     end

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -75,6 +75,8 @@ end
     mesh = UnstructuredMesh(cmesh)
     @test length(mesh) == 35
     @test Tesserae.ncells(mesh) == 24
+    @test collect(cells(mesh)) == collect(1:Tesserae.ncells(mesh))
+    @test supportnodes(mesh, 1) === mesh.cellsupports[1]
     @test mesh == vec(cmesh)
     cmesh′ = CartesianMesh(0.5, (1,3), (1,4))
     mesh .= vec(cmesh′) # test setindex!

--- a/test/thread_partition.jl
+++ b/test/thread_partition.jl
@@ -113,8 +113,8 @@
         for group in groups
             for i in 1:length(group)-1, j in i+1:length(group)
                 cell1, cell2 = group[i], group[j]
-                nodes1 = Tesserae.cellnodeindices(mesh, cell1)
-                nodes2 = Tesserae.cellnodeindices(mesh, cell2)
+                nodes1 = supportnodes(mesh, cell1)
+                nodes2 = supportnodes(mesh, cell2)
                 @test isempty(intersect(Set(nodes1), Set(nodes2)))
             end
         end


### PR DESCRIPTION
Adds a shared cell iteration entry point for unstructured meshes and routes FEM assembly, sparsity, sampling, export, and cell partitioning through `cells(mesh)` and `supportnodes(mesh, cell)`. The old cellnodeindices API name is removed from tracked source and tests, with `UnstructuredMesh` storing per-cell supports as `cellsupports`.