### PR TITLE
Add generic feupdate measure output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ macros.
   initial particles. (#113)
 - `CPDI` on `SpGrid` is now rejected explicitly; use a dense grid for CPDI.
   (#130)
+- `feupdate!` now uses a single `measure` output keyword for domain and boundary
+  integration. The old `volume` and `area` output keywords were removed.
 
 ### Deprecations and Migration
 

--- a/docs/literate/tutorials/heat.jl
+++ b/docs/literate/tutorials/heat.jl
@@ -32,7 +32,7 @@ function main()
 
     ## Basis weights
     weights = generate_basis_weights(mesh, size(points); name=Val(:N))
-    feupdate!(weights, mesh; volume=points.V) # Use `feupdate!` instead of `update!`
+    feupdate!(weights, mesh; measure=points.V) # Use `feupdate!` instead of `update!`
 
     ## Global matrix
     ndofs = 1 # Degrees of freedom per node

--- a/src/fem.jl
+++ b/src/fem.jl
@@ -9,12 +9,12 @@ end
 function feupdate!(
         weights::AbstractArray{<: BasisWeight{S}}, mesh::UnstructuredMesh{S, dim},
         nodes::AbstractArray{<: Vec{dim}} = mesh;
-        volume::Union{Nothing, AbstractArray} = nothing,
+        measure::Union{Nothing, AbstractArray} = nothing,
         quadrature_rule::QuadratureRule = quadrature_rule(cellshape(mesh)),
     ) where {dim, S <: Shape{dim}}
     qpts, qwts = quadrature_rule.points, quadrature_rule.weights
     qdata = jet.(Ref(Order(1)), Ref(cellshape(mesh)), qpts)
-    _feupdate!(Val(:volume), weights, mesh, nodes, volume, nothing, qdata, qwts)
+    _feupdate!(Val(:domain), weights, mesh, nodes, measure, nothing, qdata, qwts)
 end
 
 @inline _basis_values_and_gradients(mesh::UnstructuredMesh, qdata, cell, p) = qdata[p]
@@ -40,45 +40,50 @@ function _feupdate!(mode, weights, mesh::AbstractMesh, nodes, measure, normal, q
     end
 end
 
-function _check_feupdate_outputs(::Val{:volume}, weights, volume, normal)
-    @assert isnothing(volume) || size(weights) == size(volume)
+function _check_feupdate_outputs(::Val{:domain}, weights, measure, normal)
+    @assert isnothing(measure) || size(weights) == size(measure)
+    @assert isnothing(normal)
 end
-function _check_feupdate_outputs(::Val{:area}, weights, area, normal)
-    @assert isnothing(area) || size(weights) == size(area)
+function _check_feupdate_outputs(::Val{:boundary}, weights, measure, normal)
+    @assert isnothing(measure) || size(weights) == size(measure)
     @assert isnothing(normal) || size(weights) == size(normal)
 end
 
-@inline _set_feupdate_values!(::Val{:volume}, bw, N, dNdξ, J) = set_values!(bw, (N, dNdξ .⊡ Ref(inv(J))))
-@inline _set_feupdate_values!(::Val{:area}, bw, N, dNdξ, J) = set_values!(bw, (N,))
+# This is dL, dA, or dV depending on the parametric dimension of the element.
+@inline _jacobian_measure(qwt, J) = qwt * sqrt(det(J'J))
+
+# Domain cells have a square Jacobian, so gradients can be mapped to physical coordinates.
+@inline _set_feupdate_values!(::Val{:domain}, bw, N, dNdξ, J) = set_values!(bw, (N, dNdξ .⊡ Ref(inv(J))))
+# Boundary cells only need basis values for line/surface integration.
+@inline _set_feupdate_values!(::Val{:boundary}, bw, N, dNdξ, J) = set_values!(bw, (N,))
 
 _get_normal(J::Mat{3,2}) = J[:,1] × J[:,2]
 _get_normal(J::Mat{2,1}) = Vec(J[2,1], -J[1,1])
+_get_normal(J::Mat{3,1}) = throw(ArgumentError("normal is not defined for a 3D line element"))
 
-@inline function _set_feupdate_outputs!(::Val{:volume}, volume, normal, p, cell, qwt, J)
-    if volume !== nothing
-        volume[p,cell] = qwt * det(J)
+@inline function _set_feupdate_outputs!(::Val{:domain}, measure, normal, p, cell, qwt, J)
+    if measure !== nothing
+        measure[p,cell] = _jacobian_measure(qwt, J)
     end
 end
-@inline function _set_feupdate_outputs!(::Val{:area}, area, normal, p, cell, qwt, J)
-    if area !== nothing || normal !== nothing
+@inline function _set_feupdate_outputs!(::Val{:boundary}, measure, normal, p, cell, qwt, J)
+    if measure !== nothing
+        measure[p,cell] = _jacobian_measure(qwt, J)
+    end
+    if normal !== nothing
         n = _get_normal(J)
         n_norm = norm(n)
-        if area !== nothing
-            area[p,cell] = qwt * n_norm
-        end
-        if normal !== nothing
-            normal[p,cell] = n / n_norm
-        end
+        normal[p,cell] = n / n_norm
     end
 end
 
 function feupdate!(
         weights::AbstractArray{<: BasisWeight{S}}, mesh::UnstructuredMesh{S, dim},
         nodes::AbstractArray{<: Vec{dim}} = mesh;
-        area::Union{Nothing, AbstractArray} = nothing, normal::Union{Nothing, AbstractArray} = nothing,
+        measure::Union{Nothing, AbstractArray} = nothing, normal::Union{Nothing, AbstractArray} = nothing,
         quadrature_rule::QuadratureRule = quadrature_rule(cellshape(mesh)),
     ) where {S <: Shape, dim}
     qpts, qwts = quadrature_rule.points, quadrature_rule.weights
     qdata = jet.(Ref(Order(1)), Ref(cellshape(mesh)), qpts)
-    _feupdate!(Val(:area), weights, mesh, nodes, area, normal, qdata, qwts)
+    _feupdate!(Val(:boundary), weights, mesh, nodes, measure, normal, qdata, qwts)
 end

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -93,12 +93,13 @@ end
         end
         particles = generate_particles(ParticleProp, mesh)
         weights = generate_basis_weights(mesh, size(particles))
-        feupdate!(weights, mesh; volume = particles.detJdV)
+        feupdate!(weights, mesh; measure = particles.detJdV)
         sum(particles.detJdV)
     end
     cmesh = CartesianMesh(1, (0,2))
     @test compute_volume(UnstructuredMesh(Tesserae.Line2(), cmesh)) ≈
           compute_volume(UnstructuredMesh(Tesserae.Line3(), cmesh)) ≈ 2
+
     cmesh = CartesianMesh(1, (0,2), (-1,3))
     @test compute_volume(UnstructuredMesh(Tesserae.Quad4(), cmesh)) ≈
           compute_volume(UnstructuredMesh(Tesserae.Quad8(), cmesh)) ≈
@@ -122,7 +123,7 @@ end
         mesh_face = Tesserae.extract_face(mesh_body, 1:length(mesh_body))
         particles = generate_particles(ParticleProp, mesh_face)
         weights = generate_basis_weights(mesh_face, size(particles))
-        feupdate!(weights, mesh_face; normal = particles.n, area = particles.detJdA)
+        feupdate!(weights, mesh_face; normal = particles.n, measure = particles.detJdA)
         sum(particles.detJdA)
     end
     cmesh = CartesianMesh(1, (0,1), (0,1))
@@ -137,6 +138,22 @@ end
           compute_area(UnstructuredMesh(Tesserae.Hex27(), cmesh)) ≈ 6
     @test compute_area(UnstructuredMesh(Tesserae.Tet4(), cmesh))  ≈
           compute_area(UnstructuredMesh(Tesserae.Tet10(), cmesh)) ≈ 6 * (1+√2)
+
+    line_mesh = UnstructuredMesh(
+        Tesserae.Line2(),
+        [Vec(0.0,0.0,0.0), Vec(1.0,2.0,2.0)],
+        [Tesserae.SVector(1, 2)],
+    )
+    LinePointProp = @NamedTuple begin
+        x      :: Vec{3, Float64}
+        n      :: Vec{3, Float64}
+        detJdL :: Float64
+    end
+    line_points = generate_particles(LinePointProp, line_mesh)
+    line_weights = generate_basis_weights(line_mesh, size(line_points))
+    feupdate!(line_weights, line_mesh; measure=line_points.detJdL)
+    @test sum(line_points.detJdL) ≈ 3
+    @test_throws ArgumentError feupdate!(line_weights, line_mesh; normal=line_points.n)
 
     cmesh1 = CartesianMesh(1, (0,2), (0,2))
     cmesh2 = CartesianMesh(1, (1,3), (1,3))


### PR DESCRIPTION
## Summary
- replace `feupdate!` volume/area outputs with a single `measure` output
- update the FEM heat tutorial to use `measure`
- add mesh coverage for domain, boundary, and 3D line measures
