### PR TITLE
Cache UnstructuredMesh support nodes

### DIFF
--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -69,6 +69,7 @@ end
 function KernelAbstractions.get_backend(mesh::UnstructuredMesh)
     backend = get_backend(mesh.nodes)
     @assert get_backend(mesh.cellsupports) == backend
+    @assert get_backend(mesh.usednodes) == backend
     backend
 end
 

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -228,10 +228,37 @@ end
     end
 end
 
+"""
+    UnstructuredMesh(shape, nodes, cellsupports)
+
+Create an unstructured finite-element mesh.
+"""
 struct UnstructuredMesh{S <: Shape, dim, T, L} <: AbstractMesh{dim, T, 1}
     shape::S
     nodes::Vector{Vec{dim, T}}
     cellsupports::Vector{SVector{L, Int}}
+    usednodes::Vector{Int}
+end
+
+function UnstructuredMesh(shape::S, nodes::Vector{Vec{dim, T}}, cellsupports::Vector{SVector{L, Int}}) where {S <: Shape, dim, T, L}
+    UnstructuredMesh{S, dim, T, L}(shape, nodes, cellsupports, _collect_supportnodes(cellsupports))
+end
+
+function _collect_supportnodes(cellsupports)
+    nodes = Int[]
+    if !isempty(cellsupports)
+        sizehint!(nodes, length(cellsupports) * length(first(cellsupports)))
+    end
+    for indices in cellsupports
+        append!(nodes, indices)
+    end
+    unique!(sort!(nodes))
+end
+
+function _refresh_supportnodes!(mesh::UnstructuredMesh)
+    empty!(mesh.usednodes)
+    append!(mesh.usednodes, _collect_supportnodes(mesh.cellsupports))
+    mesh
 end
 
 Base.size(mesh::UnstructuredMesh) = size(mesh.nodes)
@@ -250,6 +277,14 @@ cellshape(mesh::UnstructuredMesh) = mesh.shape
 ncells(mesh::UnstructuredMesh) = length(mesh.cellsupports)
 cells(mesh::UnstructuredMesh) = eachindex(mesh.cellsupports)
 
+"""
+    supportnodes(mesh::UnstructuredMesh)
+    supportnodes(mesh::UnstructuredMesh, cell::Int)
+
+Return the sorted node indices used by `mesh`, or the local support node
+indices of `cell`.
+"""
+@inline supportnodes(mesh::UnstructuredMesh) = mesh.usednodes
 @inline supportnodes(mesh::UnstructuredMesh, cell::Int) = (@_propagate_inbounds_meta; mesh.cellsupports[cell])
 
 UnstructuredMesh(mesh::CartesianMesh) = UnstructuredMesh(default_cellshape(mesh), mesh)
@@ -364,7 +399,7 @@ function Base.merge!(dest::UnstructuredMesh{S}, src::UnstructuredMesh{S}) where 
             push!(dest.cellsupports, nodemap[supportnodes(src, cell)])
         end
     end
-    dest
+    _refresh_supportnodes!(dest)
 end
 function Base.merge!(dest::UnstructuredMesh{S}, src1::UnstructuredMesh{S}, src2::UnstructuredMesh{S}, others::UnstructuredMesh{S}...) where {S}
     merge!(merge!(dest, src1), src2, others...)

--- a/test/gmsh.jl
+++ b/test/gmsh.jl
@@ -15,6 +15,7 @@ nodecoordinates(mesh) = sort([Tuple(mesh[i]) for i in eachindex(mesh)])
     domain = meshes["domain"]
     @test Tesserae.cellshape(domain) == Tesserae.Tri3()
     @test Tesserae.ncells(domain) == 2
+    @test supportnodes(domain) == [1, 2, 3, 4]
     @test sort([cellcoordinates(domain, cell) for cell in cells(domain)]) == [
         ((0.0, 0.0), (1.0, 0.0), (1.0, 1.0)),
         ((0.0, 0.0), (1.0, 1.0), (0.0, 1.0)),
@@ -23,6 +24,7 @@ nodecoordinates(mesh) = sort([Tuple(mesh[i]) for i in eachindex(mesh)])
     boundary = meshes["boundary"]
     @test Tesserae.cellshape(boundary) == Tesserae.Line2()
     @test Tesserae.ncells(boundary) == 2
+    @test supportnodes(boundary) == [1, 2, 3, 4]
     @test sort([cellcoordinates(boundary, cell) for cell in cells(boundary)]) == [
         ((0.0, 0.0), (0.0, 1.0)),
         ((1.0, 0.0), (1.0, 1.0)),

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -77,6 +77,8 @@ end
     @test Tesserae.ncells(mesh) == 24
     @test collect(cells(mesh)) == collect(1:Tesserae.ncells(mesh))
     @test supportnodes(mesh, 1) === mesh.cellsupports[1]
+    @test supportnodes(mesh) === mesh.usednodes
+    @test supportnodes(mesh) == collect(eachindex(mesh))
     @test mesh == vec(cmesh)
     cmesh′ = CartesianMesh(0.5, (1,3), (1,4))
     mesh .= vec(cmesh′) # test setindex!
@@ -84,6 +86,14 @@ end
     @test Tesserae.cellshape(UnstructuredMesh(CartesianMesh(1, (0,2)))) == Tesserae.Line2()
     @test Tesserae.cellshape(UnstructuredMesh(CartesianMesh(1, (0,2), (0,3)))) == Tesserae.Quad4()
     @test Tesserae.cellshape(UnstructuredMesh(CartesianMesh(1, (0,2), (0,3), (0,4)))) == Tesserae.Hex8()
+
+    mesh_with_unused_node = Tesserae.UnstructuredMesh(
+        Tesserae.Line2(),
+        [Vec(0.0), Vec(1.0), Vec(2.0)],
+        [Tesserae.SVector(1, 3)],
+    )
+    @test length(mesh_with_unused_node) == 3
+    @test supportnodes(mesh_with_unused_node) == [1, 3]
 
     function compute_volume(mesh)
         dim = Tesserae.get_dimension(Tesserae.cellshape(mesh))

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -276,7 +276,7 @@
                 m[i] = @∑ w[ip] * m[p]
             end
         end))
-        @test count(_ -> true, eachmatch(r"supportnodes", expanded)) == 1
+        @test count(_ -> true, eachmatch(r"\bsupportnodes\(", expanded)) == 1
         @test count(_ -> true, eachmatch(r"weights\[p\]", expanded)) == 1
     end
 


### PR DESCRIPTION
Adds cached support-node indices to `UnstructuredMesh` and exposes them through `supportnodes(mesh)`. The existing `supportnodes(mesh, cell)` behavior is unchanged, and the cache is refreshed when meshes are merged.