### PR TITLE
Use free for active DOF maps in tutorials

### DIFF
--- a/docs/literate/tutorials/dam_break.jl
+++ b/docs/literate/tutorials/dam_break.jl
@@ -159,7 +159,7 @@ function main(transfer = FLIP(1.0))
         @. grid.vⁿ = grid.mv / grid.m * m_mask
         @. grid.aⁿ = grid.ma / grid.m * m_mask
 
-        ## Update a dof map
+        ## Update free DOF maps
         dofmask_u = falses(3, size(grid)...)
         dofmask_p = falses(3, size(grid)...)
         for i in 1:2
@@ -176,12 +176,12 @@ function main(transfer = FLIP(1.0))
             grid.aⁿ[i] = grid.aⁿ[i] .* (true,false)
             dofmask_u[2,i] = false
         end
-        dofmap_u = DofMap(dofmask_u)
-        dofmap_p = DofMap(dofmask_p)
-        dofmap = DofMap(dofmask_u .| dofmask_p)
+        free_u = DofMap(dofmask_u)
+        free_p = DofMap(dofmask_p)
+        free = DofMap(dofmask_u .| dofmask_p)
 
         ## Solve grid position, dispacement, velocity, acceleration and pressure by VMS method
-        state = (; grid, particles, weights, weights_cell, ρ, μ, β, γ, A, dofmap, dofmap_u, dofmap_p, Δt)
+        state = (; grid, particles, weights, weights_cell, ρ, μ, β, γ, A, free, free_u, free_p, Δt)
         variational_multiscale_method(state)
 
         if transfer isa FLIP
@@ -237,7 +237,7 @@ end
 
 function variational_multiscale_method(state)
 
-    (; grid, dofmap, dofmap_u, dofmap_p, β, γ, Δt) = state
+    (; grid, free, free_u, free_p, β, γ, Δt) = state
     @. grid.u_p = zero(grid.u_p)
 
     ## Compute VMS stabilization coefficients using current grid velocity,
@@ -247,15 +247,15 @@ function variational_multiscale_method(state)
     K = jacobian(state)
 
     ## Extract the activated degrees of freedom
-    A = extract(K, dofmap, dofmap)
-    Aᵤᵤ = extract(K, dofmap_u, dofmap_u) # dispacement-dispacement
-    Aᵤₚ = extract(K, dofmap_u, dofmap_p) # dispacement-pressure
-    Aₚᵤ = extract(K, dofmap_p, dofmap_u) # pressure-dispacement
-    Aₚₚ = extract(K, dofmap_p, dofmap_p) # pressure-pressure
+    A = extract(K, free, free)
+    Aᵤᵤ = extract(K, free_u, free_u) # dispacement-dispacement
+    Aᵤₚ = extract(K, free_u, free_p) # dispacement-pressure
+    Aₚᵤ = extract(K, free_p, free_u) # pressure-dispacement
+    Aₚₚ = extract(K, free_p, free_p) # pressure-pressure
 
     ## Reindex DOFs relative to the extracted `A` (not the full `K`).
-    dofs_u = indexin(dofs(dofmap_u), dofs(dofmap))
-    dofs_p = indexin(dofs(dofmap_p), dofs(dofmap))
+    dofs_u = indexin(dofs(free_u), dofs(free))
+    dofs_p = indexin(dofs(free_p), dofs(free))
 
     ## Build block preconditioner (approximate Schur complement form)
     ## - Pᵤ: dispacement block preconditioner from Aᵤᵤ
@@ -274,7 +274,7 @@ function variational_multiscale_method(state)
     end)
 
     ## Solve nonlinear system using GMRES
-    U = zeros(ndofs(dofmap)) # Initialize nodal dispacement and pressure with zero
+    U = zeros(ndofs(free)) # Initialize nodal dispacement and pressure with zero
     linsolve(x, A, b) = copy!(x, gmres(A, b; N=P⁻¹)[1])
     Tesserae.newton!(U, U->residual(U,state), U->A; linsolve, backtracking=true)
 
@@ -337,10 +337,10 @@ end
 # ## Residual vector
 
 function residual(U, state)
-    (; grid, particles, weights, μ, β, γ, dofmap, Δt) = state
+    (; grid, particles, weights, μ, β, γ, free, Δt) = state
 
     ## Map `U` to grid dispacement and pressure
-    dofmap(grid.u_p) .= U
+    free(grid.u_p) .= U
     grid.u .= map(x->@Tensor(x[1:2]), grid.u_p)
     grid.p .= map(x->x[3], grid.u_p)
 
@@ -364,13 +364,13 @@ function residual(U, state)
     end
 
     ## Map grid values to vector `R`
-    Array(dofmap(map(vcat, grid.R_mom, grid.R_mas)))
+    Array(free(map(vcat, grid.R_mom, grid.R_mas)))
 end
 
 # ## Jacobian matrix
 
 function jacobian(state)
-    (; grid, particles, weights, ρ, μ, β, γ, A, dofmap, Δt) = state
+    (; grid, particles, weights, ρ, μ, β, γ, A, free, Δt) = state
 
     ## Construct the Jacobian matrix
     cₚ = 2μ * one(SymmetricFourthOrderTensor{2})

--- a/docs/literate/tutorials/heat.jl
+++ b/docs/literate/tutorials/heat.jl
@@ -42,7 +42,7 @@ function main()
     dofmask = trues(ndofs, size(grid)...)
     dofmask[1, findall(x -> x[1]==-1 || x[1]==1, mesh)] .= false
     dofmask[1, findall(x -> x[2]==-1 || x[2]==1, mesh)] .= false
-    dofmap = DofMap(dofmask)
+    free = DofMap(dofmask)
 
     ## Construct global vector (on grid) and matrix
     @P2G grid=>i points=>p weights=>ip begin
@@ -53,7 +53,7 @@ function main()
     end
 
     ## Solve the equation
-    dofmap(grid.u) .= Symmetric(extract(K, dofmap)) \ Array(dofmap(grid.f))
+    free(grid.u) .= Symmetric(extract(K, free)) \ Array(free(grid.f))
 
     ## Output the results
     openvtk("heat", mesh) do vtk

--- a/docs/literate/tutorials/implicit_jacobian_based.jl
+++ b/docs/literate/tutorials/implicit_jacobian_based.jl
@@ -127,18 +127,18 @@ function main()
             iszero(grid.m[i]) && (dofmask[:,i] .= false)
         end
 
-        ## Update boundary conditions and dofmap
+        ## Update boundary conditions and free DOF map
         @. grid.u = zero(grid.u)
         for i in eachindex(grid)
             if grid.X[i][1] ≤ 0 && grid.X[i][2] > -(1+2h)
                 dofmask[:,i] .= false
             end
         end
-        dofmap = DofMap(dofmask)
+        free = DofMap(dofmask)
 
         ## Solve the nonlinear equation
-        state = (; grid, particles, weights, kirchhoff_stress, β, γ, A, dofmap, Δt)
-        U = copy(dofmap(grid.u)) # Convert grid data to plain vector data
+        state = (; grid, particles, weights, kirchhoff_stress, β, γ, A, free, Δt)
+        U = copy(free(grid.u)) # Convert grid data to plain vector data
         compute_residual(U) = residual(U, state)
         compute_jacobian(U) = jacobian(U, state)
         Tesserae.newton!(U, compute_residual, compute_jacobian)
@@ -179,9 +179,9 @@ function main()
 end
 
 function residual(U::AbstractVector, state)
-    (; grid, particles, weights, kirchhoff_stress, β, γ, dofmap, Δt) = state
+    (; grid, particles, weights, kirchhoff_stress, β, γ, free, Δt) = state
 
-    dofmap(grid.u) .= U
+    free(grid.u) .= U
     @. grid.a = (1/(β*Δt^2))*grid.u - (1/(β*Δt))*grid.vⁿ - (1/2β-1)*grid.aⁿ
     @. grid.v = grid.vⁿ + ((1-γ)*grid.aⁿ + γ*grid.a) * Δt
 
@@ -198,18 +198,18 @@ function residual(U::AbstractVector, state)
         f[i] = @∑ V⁰[p] * τ[p] * (∇w[ip] ⊡ ΔF⁻¹[p]) - w[ip] * m[p] * b[p]
     end
 
-    @. $dofmap(grid.m) * $dofmap(grid.a) + $dofmap(grid.f)
+    @. $free(grid.m) * $free(grid.a) + $free(grid.f)
 end
 
 function jacobian(U::AbstractVector, state)
-    (; grid, particles, weights, β, A, dofmap, Δt) = state
+    (; grid, particles, weights, β, A, free, Δt) = state
 
     dotdot(a,ℂ,b) = @einsum (i,j) -> a[k] * ℂ[i,k,j,l] * b[l]
     @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
         A[i,j] = @∑ dotdot(∇w[ip] ⊡ ΔF⁻¹[p], ℂ[p], ∇w[jp] ⊡ ΔF⁻¹[p]) * V⁰[p]
     end
 
-    extract(A, dofmap) + Diagonal(inv(β*Δt^2) * dofmap(grid.m))
+    extract(A, free) + Diagonal(inv(β*Δt^2) * free(grid.m))
 end
 
 using Test                            #src

--- a/docs/literate/tutorials/implicit_jacobian_free.jl
+++ b/docs/literate/tutorials/implicit_jacobian_free.jl
@@ -132,11 +132,11 @@ function main()
             dofmask[:,i] .= false
             grid.u[i] = (rotmat(2π*Δt, Vec(1,0,0)) - I) * grid.X[i]
         end
-        dofmap = DofMap(dofmask)
+        free = DofMap(dofmask)
 
         ## Solve the nonlinear equation
-        state = (; grid, particles, weights, kirchhoff_stress, β, γ, dofmap, Δt)
-        U = copy(dofmap(grid.u)) # Convert grid data to plain vector data
+        state = (; grid, particles, weights, kirchhoff_stress, β, γ, free, Δt)
+        U = copy(free(grid.u)) # Convert grid data to plain vector data
         compute_residual(U) = residual(U, state)
         compute_jacobian(U) = jacobian(U, state)
         Tesserae.newton!(U, compute_residual, compute_jacobian; linsolve = (x,A,b)->copy!(x,gmres(A,b)[1]))
@@ -168,9 +168,9 @@ function main()
 end
 
 function residual(U::AbstractVector, state)
-    (; grid, particles, weights, kirchhoff_stress, β, γ, dofmap, Δt) = state
+    (; grid, particles, weights, kirchhoff_stress, β, γ, free, Δt) = state
 
-    dofmap(grid.u) .= U
+    free(grid.u) .= U
     @. grid.a = (1/(β*Δt^2))*grid.u - (1/(β*Δt))*grid.vⁿ - (1/2β-1)*grid.aⁿ
     @. grid.v = grid.vⁿ + ((1-γ)*grid.aⁿ + γ*grid.a) * Δt
 
@@ -187,18 +187,18 @@ function residual(U::AbstractVector, state)
         f[i] = @∑ V⁰[p] * τ[p] * (∇w[ip] ⊡ ΔF⁻¹[p])
     end
 
-    @. β*Δt^2 * ($dofmap(grid.a) + $dofmap(grid.f) * $dofmap(grid.m⁻¹))
+    @. β*Δt^2 * ($free(grid.a) + $free(grid.f) * $free(grid.m⁻¹))
 end
 
 function jacobian(U::AbstractVector, state)
-    (; grid, particles, weights, β, dofmap, Δt) = state
+    (; grid, particles, weights, β, free, Δt) = state
 
     ## Create a linear map to represent Jacobian-vector product J*δU.
     ## `U` is acutally not used because the stiffness tensor is already calculated
     ## when computing the residual vector.
     fillzero!(grid.δu)
     function mul!(JδU, δU)
-        dofmap(grid.δu) .= δU
+        free(grid.δu) .= δU
 
         @G2P2G grid=>i particles=>p weights=>ip begin
             ∇u[p] = @∑ δu[i] ⊗ (∇w[ip] ⊡ ΔF⁻¹[p])
@@ -206,9 +206,9 @@ function jacobian(U::AbstractVector, state)
             f[i] = @∑ V⁰[p] * τ[p] * (∇w[ip] ⊡ ΔF⁻¹[p])
         end
 
-        @. JδU = δU + β*Δt^2 * $dofmap(grid.f) * $dofmap(grid.m⁻¹)
+        @. JδU = δU + β*Δt^2 * $free(grid.f) * $free(grid.m⁻¹)
     end
-    LinearOperator(Float64, ndofs(dofmap), ndofs(dofmap), false, false, mul!)
+    LinearOperator(Float64, ndofs(free), ndofs(free), false, false, mul!)
 end
 
 using Test                                #src


### PR DESCRIPTION
For readability, rename tutorial `DofMap` variables to `free`, `free_u`, and `free_p` where they represent active/free degrees of freedom. This only changes tutorial variable names and does not change behavior.