### PR TITLE
Fix Jaumann stress rate sign

### DIFF
--- a/docs/literate/tutorials/collapse.jl
+++ b/docs/literate/tutorials/collapse.jl
@@ -189,7 +189,7 @@ function cauchy_stress(model::DruckerPrager, σⁿ::SymmetricSecondOrderTensor{3
 
     ## Elastic predictor
     cᵉ = λ*δ⊗δ + 2G*I
-    σᵗʳ = σⁿ + cᵉ ⊡₂ symmetric(∇u) + 2*symmetric(σⁿ * skew(∇u)) # Consider Jaumann stress-rate
+    σᵗʳ = σⁿ + cᵉ ⊡₂ symmetric(∇u) + 2*symmetric(skew(∇u) * σⁿ) # Consider Jaumann stress-rate
     dfdσ, fᵗʳ = gradient(f, σᵗʳ, :all)
     fᵗʳ ≤ 0 && tr(σᵗʳ)/3 ≤ pₜ && return σᵗʳ
 

--- a/docs/literate/tutorials/rigid_body_contact.jl
+++ b/docs/literate/tutorials/rigid_body_contact.jl
@@ -195,7 +195,7 @@ function vonmises_model(σⁿ, ∇u; λ, G, σy)
     δ = one(SymmetricSecondOrderTensor{3})
     I = one(SymmetricFourthOrderTensor{3})
     cᵉ = λ*δ⊗δ + 2G*I
-    σᵗʳ = σⁿ + cᵉ ⊡₂ symmetric(∇u) + 2*symmetric(σⁿ * skew(∇u)) # Consider Jaumann stress-rate
+    σᵗʳ = σⁿ + cᵉ ⊡₂ symmetric(∇u) + 2*symmetric(skew(∇u) * σⁿ) # Consider Jaumann stress-rate
     dfdσ, fᵗʳ = gradient(σ -> vonmises(σ) - σy, σᵗʳ, :all)
     if fᵗʳ > 0
         dλ = fᵗʳ / (dfdσ ⊡₂ cᵉ ⊡₂ dfdσ)


### PR DESCRIPTION
Fixes the Jaumann stress-rate rotation term in the collapse and rigid-body contact tutorials so the Cauchy stress rotates consistently with the current velocity-gradient convention.