### PR TITLE
Remove unnecessary GPU synchronizations

### DIFF
--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -423,7 +423,6 @@ function update!(weights::AbstractArray{<: BasisWeight}, particles::StructArray,
     else
         kernel = gpukernel_update_weight(backend)
         kernel(weights, particles, mesh, filter; ndrange=length(particles))
-        synchronize(backend)
     end
     weights
 end

--- a/src/Stencil/core.jl
+++ b/src/Stencil/core.jl
@@ -39,7 +39,6 @@ function _stencil!(::GPUDevice, combine, dest, src, offsets, weights, baseshift,
     backend = get_backend(dest)
     kernel = kernel_stencil(backend)
     kernel(combine, dest, src, offsets, weights, baseshift, first(indices); ndrange=size(indices))
-    synchronize(backend)
 end
 
 function stencil!(combine, dest::StencilArray, src::StencilArray, offsets::AbstractArray{CartesianIndex{dim}}, weights::AbstractArray{<: Number}; pad::Int) where {dim}

--- a/src/foreach.jl
+++ b/src/foreach.jl
@@ -90,5 +90,4 @@ function foreach_loop(f, device::GPUDevice, ::Val{scheduler}, collection) where 
         kernel = gpukernel_foreach(backend)
         kernel(f, collection; ndrange=size(collection))
     end
-    synchronize(backend)
 end

--- a/src/sparray.jl
+++ b/src/sparray.jl
@@ -270,13 +270,12 @@ function _number_blocks!(sp::SpIndices, activity, backend::GPU)
     # activity -> 0/1 markers -> prefix sum -> inactive blocks reset to 0.
     init_kernel = gpukernel_init_block_numbering!(backend)
     init_kernel(block_numbers, activity; ndrange=length(block_numbers))
-    synchronize(backend)
 
     cumsum!(vec(block_numbers), vec(block_numbers))
-    synchronize(backend)
 
     finalize_kernel = gpukernel_finalize_block_numbering!(backend)
     finalize_kernel(block_numbers, activity, active_count_buffer; ndrange=length(block_numbers))
+    # Only sync before the CPU reads `active_count_buffer`.
     synchronize(backend)
     only(Array(active_count_buffer)) * blocklength(sp)
 end
@@ -426,7 +425,6 @@ function _activate_neighbor_blocks!(active, occupied, backend::GPU)
     fillzero!(active)
     expand_kernel = gpukernel_expand_occupied_blocks!(backend)
     expand_kernel(active, occupied; ndrange=length(occupied))
-    synchronize(backend)
     active
 end
 
@@ -655,7 +653,6 @@ function _copyto_sp_broadcast!(device::GPUDevice, dest::SpArray, bc::Broadcasted
     spinds = get_spinds(dest)
     kernel = gpukernel_copyto_sp_broadcast!(backend)
     kernel(dest, bc, spinds; ndrange=_spindex_ndrange(spinds))
-    synchronize(backend)
     dest
 end
 

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -361,7 +361,6 @@ function P2G(f, device::GPUDevice, ::Val{scheduler}, grid, particles, weights, :
     backend = get_backend(device)
     kernel = gpukernel_P2G(backend)
     kernel(f, hybrid(grid), particles, weights; ndrange=length(particles))
-    synchronize(backend)
 end
 
 function P2G_nosum_expr((grid,i), nosum_equations::Vector)
@@ -413,7 +412,6 @@ function P2G_nosum(f, device::GPUDevice, grid)
         kernel = gpukernel_P2G_nosum(backend)
         kernel(f, grid; ndrange=size(grid))
     end
-    synchronize(backend)
 end
 
 function check_arguments_for_P2G(grid, particles, weights, partition)
@@ -570,7 +568,6 @@ function G2P(f, device::GPUDevice, ::Val{scheduler}, grid, particles, weights) w
     backend = get_backend(device)
     kernel = gpukernel_G2P(backend)
     kernel(f, grid, particles, weights; ndrange=length(particles))
-    synchronize(backend)
 end
 
 function G2P_sum_expr((grid,i), (particles,p), (weights,ip), sum_equations::Vector, nosum_equations::Vector)


### PR DESCRIPTION
Remove host-side synchronization after GPU kernel launches that continue on the GPU. Keep synchronization only where SpArray code immediately reads GPU-produced values on the CPU.