### PR TITLE
Rework manual documentation flow

### DIFF
--- a/docs/literate/tutorials/collapse.jl
+++ b/docs/literate/tutorials/collapse.jl
@@ -8,6 +8,8 @@
 # | ----------- | ------------ | ----------------------------|
 # | 19k         | 8k           | 20 sec                      |
 #
+# The VTK output is written to `output/collapse`.
+#
 # This tutorial simulates the collapse of a sand column using a Drucker--Prager material model.
 # The full simulation is shown first, followed by the material update used inside `main`.
 

--- a/docs/literate/tutorials/collision.jl
+++ b/docs/literate/tutorials/collision.jl
@@ -8,6 +8,8 @@
 # | ----------- | ------------ | --------------------------- |
 # | 17k         | 2.9k         | 5 sec                       |
 #
+# The VTK output is written to `output/collision`.
+#
 # This tutorial compares several velocity transfer schemes on the collision of two elastic rings:
 #
 # * PIC--FLIP mixed transfer[^1]

--- a/docs/literate/tutorials/cpdi.jl
+++ b/docs/literate/tutorials/cpdi.jl
@@ -8,6 +8,8 @@
 # | ----------- | ------------ | --------------------------- |
 # | 27k         | 500          | 15 sec                      |
 #
+# The VTK output is written to `output/cpdi`.
+#
 # This tutorial uses convected particle domain interpolation (CPDI) for a large-deformation 3D bar problem[^1].
 #
 # [^1]: [Sadeghirad, A., Brannon, R.M. and Burghardt, J., 2011. A convected particle domain interpolation technique to extend applicability of the material point method for problems involving massive deformations. International Journal for numerical methods in Engineering, 86(12), pp.1435-1456.](https://doi.org/10.1002/nme.3110)

--- a/docs/literate/tutorials/dam_break.jl
+++ b/docs/literate/tutorials/dam_break.jl
@@ -8,6 +8,8 @@
 # | ----------- | ------------ | --------------------------- |
 # | 28k         | 3.5k         | 10 min                      |
 #
+# The VTK output is written to `output/dam_break`.
+#
 # This tutorial uses stabilized mixed MPM with the variational multiscale method for incompressible fluid flow[^1].
 #
 # [^1]: [Chandra, B., Hashimoto, R., Matsumi, S., Kamrin, K. and Soga, K., 2024. Stabilized mixed material point method for incompressible fluid flow analysis. Computer Methods in Applied Mechanics and Engineering, 419, p.116644.](https://doi.org/10.1016/j.cma.2023.116644)

--- a/docs/literate/tutorials/implicit_jacobian_based.jl
+++ b/docs/literate/tutorials/implicit_jacobian_based.jl
@@ -8,6 +8,8 @@
 # | ----------- | ------------ | --------------------------- |
 # | 600         | 300          | 2 sec                       |
 #
+# The VTK output is written to `output/implicit_jacobian_based`.
+#
 # This tutorial assembles the Jacobian matrix explicitly for an implicit MPM problem.
 # It is useful when the sparse matrix structure and boundary-condition handling should be visible.
 

--- a/docs/literate/tutorials/implicit_jacobian_free.jl
+++ b/docs/literate/tutorials/implicit_jacobian_free.jl
@@ -8,6 +8,8 @@
 # | ----------- | ------------ | --------------------------- |
 # | 26k         | 300          | 1 min                       |
 #
+# The VTK output is written to `output/implicit_jacobian_free`.
+#
 # This tutorial solves an implicit MPM problem with a Jacobian-free Newton--Krylov method.
 # The linear solve is written as a matrix-free operator.
 

--- a/docs/literate/tutorials/rigid_body_contact.jl
+++ b/docs/literate/tutorials/rigid_body_contact.jl
@@ -8,6 +8,8 @@
 # | ----------- | ------------ | ----------------------------|
 # | 14k         | 220k         | 6 min                       |
 #
+# The VTK output is written to `output/rigid_body_contact`.
+#
 # This tutorial simulates a deformable ground layer interacting with a moving rigid disk.
 # The contact force is computed on particles and then coupled to the usual MPM update.
 

--- a/docs/literate/tutorials/taylor_impact.jl
+++ b/docs/literate/tutorials/taylor_impact.jl
@@ -8,6 +8,8 @@
 # | ----------- | ------------ | ----------------------------|
 # | 1.5M        | 1.8k         | 6 min (8 threads)           |
 #
+# The VTK output is written to `output/taylor_impact`.
+#
 # This tutorial uses a Taylor impact test to demonstrate multi-threaded MPM simulation.
 #
 

--- a/docs/literate/tutorials/tlmpm_vortex.jl
+++ b/docs/literate/tutorials/tlmpm_vortex.jl
@@ -8,6 +8,8 @@
 # | ----------- | ------------ | --------------------------- |
 # | 8k          | 27k          | 30 sec                      |
 #
+# The VTK output is written to `output/tlmpm_vortex`.
+#
 # This tutorial demonstrates the total Lagrangian material point method[^1].
 # It solves the generalized vortex problem[^1] using a linear kernel.
 #

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,15 +37,22 @@ makedocs(;
             ],
         ],
         "Manual" => [
-            "mesh.md"
-            "generation.md"
-            "basis.md"
-            "transfer.md"
-            "implicit_utils.md"
-            "multithreading.md"
-            "gpu.md"
-            "sparray.md"
-            "export.md"
+            "Overview" => "manual.md"
+            "Core workflow" => [
+                "mesh.md"
+                "generation.md"
+                "basis.md"
+                "transfer.md"
+                "export.md"
+            ]
+            "Scaling simulations" => [
+                "multithreading.md"
+                "gpu.md"
+                "sparray.md"
+            ]
+            "Advanced methods" => [
+                "implicit_utils.md"
+            ]
         ]
     ],
     doctest = true, # :fix

--- a/docs/src/basis.md
+++ b/docs/src/basis.md
@@ -4,8 +4,11 @@ CollapsedDocStrings = false
 
 # Basis Functions
 
-Basis weights store the values and gradients of a basis function between particles and nearby grid nodes.
-They are updated after particles move and then reused by transfer macros such as [`@P2G`](@ref) and [`@G2P`](@ref).
+Basis functions define the interpolation between particles and grid nodes.
+Tesserae stores this local particle-grid relation as basis weights, which contain the basis values and gradients used by transfer macros such as [`@P2G`](@ref) and [`@G2P`](@ref).
+
+Because particles move through the mesh, basis weights are updated before transfers that use the current particle positions.
+The basis type determines the support nodes of each particle, affecting both the transfer behavior and computational cost.
 
 ```@docs
 update!(::AbstractArray{<: BasisWeight}, ::Tesserae.StructArray, ::Tesserae.AbstractMesh, ::AbstractArray)

--- a/docs/src/export.md
+++ b/docs/src/export.md
@@ -1,7 +1,9 @@
 # Export
 
-Tesserae supports VTK output for visualization.
-The export functions are built on the [WriteVTK.jl](https://github.com/JuliaVTK/WriteVTK.jl) package.
+Tesserae uses VTK files to write simulation states that can be opened in [ParaView](https://www.paraview.org/).
+Grid fields and particle fields can be exported separately, combined into a multiblock dataset, or collected as a time series.
+
+The export functions are built on [WriteVTK.jl](https://github.com/JuliaVTK/WriteVTK.jl).
 
 ## VTK file
 

--- a/docs/src/generation.md
+++ b/docs/src/generation.md
@@ -1,7 +1,11 @@
 # Grid and particle generation
 
-Grids and particles are generated from a mesh and a property type.
-For a grid, the first field is the coordinate field and is backed by the mesh itself.
+Grid and particle generation starts from the fields that each object should carry.
+In Tesserae, those fields are described by a property type, written either as a `struct` or an `@NamedTuple`.
+
+For grids, the property type defines fields stored at background nodes.
+For particles, it defines fields stored on material points.
+The first field is reserved for position: grid positions are backed by the mesh coordinates, while particle positions are filled by the sampling algorithm used in `generate_particles`.
 
 ```@docs
 generate_grid

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -283,13 +283,11 @@ function main()
             @timeit "Grid computation" begin
                 @. grid.vⁿ = grid.mv / grid.m * !iszero(grid.m)
                 @. grid.v  = grid.vⁿ + Δt * grid.f / grid.m * !iszero(grid.m)
-                CUDA.synchronize() # wait for broadcast kernels before stopping @timeit
             end
 
             @timeit "Apply boundary conditions" begin
                 slip_floor(v) = v .* (true, true, false)
                 @. grid.v[:, :, begin] = slip_floor(grid.v[:, :, begin])
-                CUDA.synchronize() # wait for broadcast kernels before stopping @timeit
             end
 
             @timeit "G2P transfer" begin

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -79,7 +79,7 @@ x = cpu(particles_gpu.x)
 ## GPU arrays
 
 After calling `gpu`, grid fields, particle fields, basis weights, and mesh coordinates in the returned objects are GPU arrays.
-Scalar indexing from CPU code is not allowed:
+Scalar indexing from CPU code falls back to the CPU and is disallowed in non-interactive CUDA.jl execution; see CUDA.jl's [scalar indexing workflow](https://cuda.juliagpu.org/stable/usage/workflow/#UsageWorkflowScalar) for details:
 
 ```julia
 julia> x = gpu(rand(3))
@@ -205,12 +205,14 @@ The main changes are:
 - Rewrite the slip floor boundary condition as a broadcast to avoid scalar indexing on GPU arrays.
 - Copy data back with `cpu` only when writing VTK output.
 
-The following compute-only results were obtained on an NVIDIA GeForce RTX 5090 by disabling VTK output.
+For reference, the compute-only runtime on an NVIDIA GeForce RTX 5090, excluding VTK output, is:
 
 | Precision | # Particles | # Iterations | Execution time (w/o output) |
 | --------- | ----------- | ------------ | ---------------------------- |
 | Float64   | 1.48M       | 1.8k         | 1 min 01 sec                 |
 | Float32   | 1.48M       | 1.8k         | 37 sec                       |
+
+The VTK output is written to `output/taylor_impact_gpu`.
 
 ```julia
 using Tesserae

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -1,7 +1,11 @@
 # GPU computing
 
-Tesserae can move grids, particles, basis weights, and meshes to a GPU with `gpu`.
-The transfer macros then dispatch to GPU kernels when all inputs live on the same GPU backend.
+GPU support in Tesserae is built around the same transfer notation used on CPU.
+Once the mesh, grid, particles, and basis weights are moved to a GPU backend, macros such as [`@P2G`](@ref) and [`@G2P`](@ref) launch GPU kernels instead of CPU loops.
+This keeps the MPM update close to the CPU version while moving the particle-grid work to the GPU.
+
+The code still needs to follow GPU array rules.
+Grid and particle updates should be written as transfer macros, broadcasts, or GPU kernels, and data should be copied back to CPU memory only for inspection or output.
 
 Load the GPU backend package together with Tesserae:
 

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -195,14 +195,22 @@ It should not be expected to remove the main cost of `@P2G`, which is still prop
 
 ## Taylor impact on GPU
 
-The Taylor impact tutorial can be moved to GPU without changing the transfer equations or the material model.
-Compared with the [Taylor impact tutorial](@ref taylor_impact_tutorial), the implementation changes are:
+This section rewrites the [Taylor impact tutorial](@ref taylor_impact_tutorial) as a GPU simulation.
+The transfer equations and the von Mises material model are unchanged; only the execution pattern is adjusted.
+The main changes are:
 
 - Remove CPU threading utilities such as `@threaded`, `ThreadPartition`, and `reorder_particles!`.
 - Move the simulation objects to GPU with `gpu_preserve` after CPU-side setup.
 - Keep grid and particle calculations inside GPU operations, using `@P2G`, `@G2P`, and broadcasts.
 - Rewrite the slip floor boundary condition as a broadcast to avoid scalar indexing on GPU arrays.
 - Copy data back with `cpu` only when writing VTK output.
+
+The following compute-only results were obtained on an NVIDIA GeForce RTX 5090 by disabling VTK output.
+
+| Precision | # Particles | # Iterations | Execution time (w/o output) |
+| --------- | ----------- | ------------ | ---------------------------- |
+| Float64   | 1.48M       | 1.8k         | 1 min 01 sec                 |
+| Float32   | 1.48M       | 1.8k         | 37 sec                       |
 
 ```julia
 using Tesserae
@@ -250,7 +258,7 @@ function main()
     end
 
     ## Background grid
-    grid = generate_grid(GridProp, CartesianMesh(R/12, (-3R,3R), (-3R,3R), (0,L+0.1L)))
+    grid = generate_grid(GridProp, CartesianMesh(T, R/12, (-3R,3R), (-3R,3R), (0,L+0.1L)))
 
     ## Particles
     block = extract(grid.x, (-R,R), (-R,R), (0,L))
@@ -260,7 +268,7 @@ function main()
     @. particles.m = ρ⁰ * particles.V
     @. particles.F = one(particles.F)
     @. particles.Cᵖ⁻¹ = one(particles.Cᵖ⁻¹)
-    particles.v .= Ref(Vec(0.0, 0.0, -227.0)) # Set initial velocity
+    particles.v .= Ref(Vec(T(0), T(0), T(-227))) # Set initial velocity
 
     ## Basis weights
     weights = generate_basis_weights(T, KernelCorrection(BSpline(Quadratic())), grid.x, length(particles))
@@ -331,5 +339,45 @@ function main()
             end
         end
     end
+end
+
+function vonmises_model(Cᵖⁿ⁻¹, ε̄ᵖⁿ, F; λ, μ, H, τ̄y⁰)
+    κ = λ + 2μ/3                             # Bulk modulus
+    J = det(F)                               # Jacobian
+    p = κ * log(J) / J                       # Pressure
+    bᵉᵗʳ = symmetric(F * Cᵖⁿ⁻¹ * F')         # Trial left Cauchy-Green tensor
+    vals, vecs = eigen(bᵉᵗʳ)                 # Eigenvalue decomposition
+    λᵉᵗʳ = sqrt.(vals)                       # Trial stretches
+    nᵗʳₐ = (vecs[:,1], vecs[:,2], vecs[:,3]) # Principal directions
+    τ′ᵗʳ = @. 2μ*log(λᵉᵗʳ) - 2μ/3*log(J)     # Trial Kirchhoff stress
+
+    f(τ) = sqrt(3τ⋅τ/2) - (τ̄y⁰ + H*ε̄ᵖⁿ) # Yield function
+    dfdσ, fᵗʳ = gradient(f, τ′ᵗʳ, :all)
+    if fᵗʳ > 0
+        Δγ = fᵗʳ / (3μ + H)          # Incremental plastic multiplier
+        Δεᵖ = Δγ * dfdσ              # Incremental logarithmic plastic stretch
+        λᵉ = @. exp(log(λᵉᵗʳ) - Δεᵖ) # Elastic stretch
+        τ′ = τ′ᵗʳ - 2μ*Δεᵖ           # Return map
+    else # Elastic response
+        Δγ = zero(H)
+        λᵉ = λᵉᵗʳ
+        τ′ = τ′ᵗʳ
+    end
+
+    ## Update inverse of elastic left Cauchy-Green tensor
+    nₐ = nᵗʳₐ
+    bᵉ = mapreduce((λᵉ,nₐ) -> λᵉ^2 * nₐ^⊗(2), +, λᵉ, nₐ)
+
+    ## Update stress
+    σ′ = τ′ / J    # Principal deviatoric Cauchy stress
+    σ  = @. σ′ + p # Principal Cauchy stress
+    σ  = mapreduce((σ,nₐ) -> σ * nₐ^⊗(2), +, σ, nₐ)
+
+    ## Update state variables
+    F⁻¹ = inv(F)
+    Cᵖ⁻¹ = symmetric(F⁻¹ * bᵉ * F⁻¹') # Update plastic right Cauchy-Green tensor
+    ε̄ᵖ = ε̄ᵖⁿ + Δγ                     # Update equivalent plastic strain
+
+    σ, Cᵖ⁻¹, ε̄ᵖ
 end
 ```

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -42,29 +42,32 @@ particles = generate_particles(ParticleProp, grid.x)
 @. particles.v = zero(particles.v)
 weights = generate_basis_weights(T, BSpline(Quadratic()), grid.x, length(particles))
 
-grid_gpu = gpu(grid)
-particles_gpu = gpu(particles)
-weights_gpu = gpu(weights)
+grid_gpu = gpu(grid);
+particles_gpu = gpu(particles);
+weights_gpu = gpu(weights);
 ```
 
-After that, the transfer code is the same as the CPU version:
+After that, the transfer code is the same as the CPU version.
+A single update step can be written as:
 
 ```julia
-dt = T(1.0e-4)
+function step!(grid_gpu, particles_gpu, weights_gpu, dt)
+    update!(weights_gpu, particles_gpu, grid_gpu.x)
 
-update!(weights_gpu, particles_gpu, grid_gpu.x)
+    @P2G grid_gpu=>i particles_gpu=>p weights_gpu=>ip begin
+        m[i]  = @∑ w[ip] * m[p]
+        mv[i] = @∑ w[ip] * m[p] * v[p]
+        m⁻¹[i] = ifelse(iszero(m[i]), zero(m[i]), inv(m[i]))
+        v[i] = mv[i] * m⁻¹[i]
+    end
 
-@P2G grid_gpu=>i particles_gpu=>p weights_gpu=>ip begin
-    m[i]  = @∑ w[ip] * m[p]
-    mv[i] = @∑ w[ip] * m[p] * v[p]
-    m⁻¹[i] = ifelse(iszero(m[i]), zero(m[i]), inv(m[i]))
-    v[i] = mv[i] * m⁻¹[i]
+    @G2P grid_gpu=>i particles_gpu=>p weights_gpu=>ip begin
+        v[p] = @∑ v[i] * w[ip]
+        x[p] += v[p] * dt
+    end
 end
 
-@G2P grid_gpu=>i particles_gpu=>p weights_gpu=>ip begin
-    v[p] = @∑ v[i] * w[ip]
-    x[p] += v[p] * dt
-end
+step!(grid_gpu, particles_gpu, weights_gpu, T(1.0e-4))
 ```
 
 Use `cpu` to copy GPU data back to CPU memory, for example for output:
@@ -90,6 +93,17 @@ ERROR: Scalar indexing is disallowed.
 ```
 
 The same rule applies to fields such as `grid_gpu.v`, `particles_gpu.x`, and `weights_gpu`.
+
+!!! note
+    In the REPL, displaying an object that contains GPU arrays, such as `particles_gpu` or `grid_gpu`, can hit the same scalar indexing error.
+    Suppress display with `;` when assigning GPU objects:
+
+    ```julia
+    particles_gpu = gpu(particles);
+    ```
+
+    Copy data back with `cpu` before inspecting values on the CPU.
+
 Use array operations such as broadcasting or `map!`, or write the operation inside a transfer macro or a GPU kernel.
 Indexing inside `@P2G` and `@G2P` is fine because the generated code runs in GPU kernels.
 This is also how boundary conditions should be applied on GPU.
@@ -114,17 +128,16 @@ slip_floor(v) = v .* (true, true, false)
 `gpu` returns GPU arrays and, by default, converts floating-point arrays to `Float32`.
 Use `gpu_preserve` instead when the original floating-point type should be preserved on the GPU.
 The conversion applies to arrays and adapted Tesserae objects.
-It does not rewrite scalar constants captured by a kernel, so constants used in GPU code should be written with the intended type:
+It does not rewrite scalar constants captured by a kernel, so write scalar constants with the intended type:
 
-```diff
-- dt = 1.0e-4
-- gravity = Vec(0, -9.81)
-+ T = Float32
-+ dt = T(1.0e-4)
-+ gravity = Vec(T(0), T(-9.81))
+```julia
+T = Float32
+
+dt = T(1.0e-4)
+gravity = Vec(T(0), T(-9.81))
 ```
 
-This is required on Metal, where `Float64` cannot be used in GPU kernels.
+This matters on Metal, where `Float64` cannot be used in GPU kernels.
 
 ## Transfers
 
@@ -162,9 +175,9 @@ The same scalar-indexing rule applies: use `SpArray` through `update_sparsity!`,
 grid = generate_grid(SpArray, GridProp, mesh)
 weights = generate_basis_weights(T, BSpline(Quadratic()), grid.x, length(particles))
 
-grid_gpu = gpu(grid)
-particles_gpu = gpu(particles)
-weights_gpu = gpu(weights)
+grid_gpu = gpu(grid);
+particles_gpu = gpu(particles);
+weights_gpu = gpu(weights);
 
 update_sparsity!(grid_gpu, particles_gpu.x)
 update!(weights_gpu, particles_gpu, grid_gpu.x)
@@ -182,8 +195,14 @@ It should not be expected to remove the main cost of `@P2G`, which is still prop
 
 ## Taylor impact on GPU
 
-The Taylor impact tutorial can be moved to GPU without changing the transfer equations.
-The material model `vonmises_model` is the same as in the [Taylor impact tutorial](@ref taylor_impact_tutorial); the main changes are removing CPU threading utilities, moving the simulation objects with `gpu_preserve`, rewriting the slip floor boundary condition as a broadcast, and copying data back with `cpu` before writing output.
+The Taylor impact tutorial can be moved to GPU without changing the transfer equations or the material model.
+Compared with the [Taylor impact tutorial](@ref taylor_impact_tutorial), the implementation changes are:
+
+- Remove CPU threading utilities such as `@threaded`, `ThreadPartition`, and `reorder_particles!`.
+- Move the simulation objects to GPU with `gpu_preserve` after CPU-side setup.
+- Keep grid and particle calculations inside GPU operations, using `@P2G`, `@G2P`, and broadcasts.
+- Rewrite the slip floor boundary condition as a broadcast to avoid scalar indexing on GPU arrays.
+- Copy data back with `cpu` only when writing VTK output.
 
 ```julia
 using Tesserae
@@ -256,84 +275,61 @@ function main()
     fps = T(300e3)
     savepoints = collect(LinRange(t, t_stop, round(Int, t_stop*fps)+1))
 
-    reset_timer!()
-
     # Move the simulation state to the GPU after CPU-side setup; the time loop below stays on GPU.
     let (grid, particles, weights) = (grid, particles, weights) .|> gpu_preserve
 
         Tesserae.@showprogress while t < t_stop
 
-            @timeit "Update timestep" begin
-                @. particles.c = sqrt((λ+2μ) / (particles.m/particles.V)) + norm(particles.v)
-                Δt = CFL * spacing(grid.x) / maximum(particles.c)
+            @. particles.c = sqrt((λ+2μ) / (particles.m/particles.V)) + norm(particles.v)
+            Δt = CFL * spacing(grid.x) / maximum(particles.c)
+
+            update!(weights, particles, grid.x)
+
+            @P2G grid=>i particles=>p weights=>ip begin
+                m[i]  = @∑ w[ip] * m[p]
+                mv[i] = @∑ w[ip] * m[p] * v[p]
+                f[i]  = @∑ -V[p] * σ[p] * ∇w[ip]
+                vⁿ[i] = mv[i] / m[i] * !iszero(m[i])
+                v[i]  = vⁿ[i] + Δt * f[i] / m[i] * !iszero(m[i])
             end
 
-            @timeit "Update basis weights" begin
-                update!(weights, particles, grid.x)
-            end
+            slip_floor(v) = v .* (true, true, false)
+            @. grid.vⁿ[:, :, begin] = slip_floor(grid.vⁿ[:, :, begin])
+            @. grid.v[:, :, begin] = slip_floor(grid.v[:, :, begin])
 
-            @timeit "P2G transfer" begin
-                @P2G grid=>i particles=>p weights=>ip begin
-                    m[i]  = @∑ w[ip] * m[p]
-                    mv[i] = @∑ w[ip] * m[p] * v[p]
-                    f[i]  = @∑ -V[p] * σ[p] * ∇w[ip]
-                end
-            end
-
-            @timeit "Grid computation" begin
-                @. grid.vⁿ = grid.mv / grid.m * !iszero(grid.m)
-                @. grid.v  = grid.vⁿ + Δt * grid.f / grid.m * !iszero(grid.m)
-            end
-
-            @timeit "Apply boundary conditions" begin
-                slip_floor(v) = v .* (true, true, false)
-                @. grid.v[:, :, begin] = slip_floor(grid.v[:, :, begin])
-            end
-
-            @timeit "G2P transfer" begin
-                @G2P grid=>i particles=>p weights=>ip begin
-                    v[p] += @∑ w[ip] * (v[i] - vⁿ[i])
-                    ∇v[p] = @∑ v[i] ⊗ ∇w[ip]
-                    x[p] += @∑ w[ip] * v[i] * Δt
-                end
-            end
-
-            @timeit "Particle computation" begin
-                # Reuse @G2P only as a particle-parallel GPU loop; this block does not interpolate from grid to particles.
-                @G2P grid=>i particles=>p weights=>ip begin
-                    ΔFₚ = I + Δt * ∇v[p]
-                    Fₚ = ΔFₚ * F[p]
-                    σₚ, Cᵖ⁻¹ₚ, ε̄ᵖₚ = vonmises_model(Cᵖ⁻¹[p], ε̄ᵖ[p], Fₚ; λ, μ, H, τ̄y⁰)
-                    σ[p] = σₚ
-                    F[p] = Fₚ
-                    V[p] = det(ΔFₚ) * V[p]
-                    Cᵖ⁻¹[p] = Cᵖ⁻¹ₚ
-                    ε̄ᵖ[p] = ε̄ᵖₚ
-                end
+            @G2P grid=>i particles=>p weights=>ip begin
+                v[p] += @∑ w[ip] * (v[i] - vⁿ[i])
+                ∇v[p] = @∑ v[i] ⊗ ∇w[ip]
+                x[p] += @∑ w[ip] * v[i] * Δt
+                ΔFₚ = I + Δt * ∇v[p]
+                Fₚ = ΔFₚ * F[p]
+                σₚ, Cᵖ⁻¹ₚ, ε̄ᵖₚ = vonmises_model(Cᵖ⁻¹[p], ε̄ᵖ[p], Fₚ; λ, μ, H, τ̄y⁰)
+                σ[p] = σₚ
+                F[p] = Fₚ
+                V[p] = det(ΔFₚ) * V[p]
+                Cᵖ⁻¹[p] = Cᵖ⁻¹ₚ
+                ε̄ᵖ[p] = ε̄ᵖₚ
             end
 
             t += Δt
             step += 1
 
             if t > first(savepoints)
-                @timeit "Write results" begin
-                    popfirst!(savepoints)
-                    openpvd(pvdfile; append=true) do pvd
-                        openvtm(string(pvdfile, step)) do vtm
-                            openvtk(vtm, cpu(particles.x)) do vtk
-                                vtk["velocity"] = cpu(particles.v)
-                                vtk["plastic strain"] = cpu(particles.ε̄ᵖ)
-                            end
-                            openvtk(vtm, cpu(grid.x)) do vtk
-                                vtk["velocity"] = cpu(grid.v)
-                            end
-                            pvd[t] = vtm
+                popfirst!(savepoints)
+                openpvd(pvdfile; append=true) do pvd
+                    openvtm(string(pvdfile, step)) do vtm
+                        openvtk(vtm, cpu(particles.x)) do vtk
+                            vtk["velocity"] = cpu(particles.v)
+                            vtk["plastic strain"] = cpu(particles.ε̄ᵖ)
                         end
+                        openvtk(vtm, cpu(grid.x)) do vtk
+                            vtk["velocity"] = cpu(grid.v)
+                        end
+                        pvd[t] = vtm
                     end
                 end
             end
         end
     end
-    print_timer()
 end
 ```

--- a/docs/src/implicit_utils.md
+++ b/docs/src/implicit_utils.md
@@ -1,6 +1,7 @@
 # Utilities for implicit methods
 
-This page collects helper types and macros used by implicit tutorials, such as degree-of-freedom maps, sparse matrices, matrix assembly, and nonlinear solvers.
+Implicit MPM formulations often need degree-of-freedom maps, sparse matrices, matrix assembly, and nonlinear iteration.
+Tesserae provides small utilities for those parts of an implicit formulation.
 
 ## Degrees of freedom (DoF) mapping
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,7 +31,9 @@ If you are new to Tesserae, start with the [Getting started](@ref) tutorial. It 
 5. Transfer grid data back to particles with [`@G2P`](@ref).
 6. Update particle state and write or plot results.
 
-After that, the [Transfer schemes](@ref) tutorial is a good next step for comparing FLIP, APIC, TPIC, and XPIC. For larger simulations, see [Multi-threading](@ref) and [GPU computing](@ref).
+After that, the [Transfer schemes](@ref) tutorial is a good next step for comparing FLIP, APIC, TPIC, and XPIC.
+The [Manual overview](@ref manual_overview) connects the tutorial workflow to the individual API pages.
+For larger simulations, see [Multi-threading](@ref) and [GPU computing](@ref).
 
 ## Installation
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -1,0 +1,41 @@
+# [Manual overview](@id manual_overview)
+
+Tesserae is organized around the data flow of an MPM simulation.
+The core objects are deliberately small: a background mesh, grid fields, particles, basis weights, and transfer macros.
+Most explicit simulations follow the same loop:
+
+```julia
+mesh = CartesianMesh(...)
+grid = generate_grid(GridProp, mesh)
+particles = generate_particles(ParticleProp, grid.x)
+weights = generate_basis_weights(BSpline(Quadratic()), grid.x, length(particles))
+
+for step in 1:nsteps
+    update!(weights, particles, grid.x)
+
+    @P2G grid=>i particles=>p weights=>ip begin
+        # scatter particle mass, momentum, and forces to the grid
+    end
+
+    for i in eachindex(grid)
+        # update grid velocities and apply boundary conditions
+    end
+
+    @G2P grid=>i particles=>p weights=>ip begin
+        # gather grid updates back to particles
+    end
+end
+```
+
+The explicit loop is built from five parts.
+[Mesh](mesh.md) covers the geometric background domain separated from grid state fields.
+[Grid and particle generation](generation.md) provides the state containers used by simulations.
+[Basis Functions](basis.md) provides the particle-grid connectivity used by transfer macros.
+[Transfer between grid and particles](@ref manual) provides the syntax for particle-to-grid and grid-to-particle updates.
+[Export](export.md) writes grid and particle fields for visualization.
+
+Larger simulations keep the same objects while changing execution or storage.
+[Multi-threading](multithreading.md) adds CPU thread parallelism.
+[GPU computing](gpu.md) uses GPU-backed arrays and transfer kernels.
+[SpArray](sparray.md) stores grid fields sparsely on Cartesian meshes.
+Implicit formulations use a different update structure; [Utilities for implicit methods](implicit_utils.md) provides the degree-of-freedom maps, sparse matrices, matrix assembly tools, and nonlinear solvers used by those methods.

--- a/docs/src/mesh.md
+++ b/docs/src/mesh.md
@@ -1,7 +1,11 @@
 # Mesh
 
-Meshes define the background coordinates used by grids, particles, and basis weights.
-In a typical MPM simulation, the mesh is created first, then `generate_grid`, `generate_particles`, and `generate_basis_weights` are built from it.
+A background mesh and a background grid are often used interchangeably in MPM literature, but Tesserae keeps them separate.
+A mesh stores the geometry of the background domain, while a grid is a state container generated from that mesh.
+Grid fields such as mass, momentum, velocity, and force live on the grid; coordinates and spacing come from the mesh.
+
+A simulation typically shares one mesh between the grid, particles, and basis weights.
+This keeps coordinates and particle-grid connectivity consistent across the calculation.
 
 !!! info
     Currently, only the Cartesian mesh is available.

--- a/docs/src/multithreading.md
+++ b/docs/src/multithreading.md
@@ -1,8 +1,16 @@
 # Multi-threading
 
-Tesserae.jl provides a [`@threaded`](@ref) macro to enable multi-threading. It behaves similarly to Julia’s built-in Threads.@threads, but is specifically designed to work with particle-grid transfer macros such as [`@G2P`](@ref), [`@P2G`](@ref), [`@G2P2G`](@ref), and [`@P2G_Matrix`](@ref).
+Multi-threading in Tesserae parallelizes CPU work over particles, grid nodes, and particle-grid transfers.
+The [`@threaded`](@ref) macro adds this parallelism while keeping transfer expressions close to their sequential form.
+It behaves similarly to Julia's built-in `Threads.@threads`, but is designed to work with particle-grid transfer macros such as [`@G2P`](@ref), [`@P2G`](@ref), [`@G2P2G`](@ref), and [`@P2G_Matrix`](@ref).
 
 ## Usage guidelines
+
+Particle-grid transfers have two directions: gathering and scattering.
+In a gathering transfer, each particle reads values from nearby grid nodes, so the operation can be threaded directly.
+In a scattering transfer, particles write contributions to grid nodes.
+If multiple threads update the same grid node at the same time, this is a data race; see Julia's discussion of [data races between threads](https://docs.julialang.org/en/v1/manual/multi-threading/#Communication-and-data-races-between-threads).
+Threaded scattering therefore uses a [`ThreadPartition`](@ref).
 
 ### Gathering (`@G2P`)
 

--- a/docs/src/sparray.md
+++ b/docs/src/sparray.md
@@ -72,7 +72,7 @@ Move the grid, particles, and basis weights to the GPU, then update the sparse g
 grid = generate_grid(SpArray, GridProp, mesh)
 weights = generate_basis_weights(Float32, BSpline(Quadratic()), grid.x, length(particles))
 
-grid, particles, weights = (grid, particles, weights) .|> gpu
+grid, particles, weights = (grid, particles, weights) .|> gpu;
 
 update_sparsity!(grid, particles.x)
 update!(weights, particles, grid.x)

--- a/docs/src/sparray.md
+++ b/docs/src/sparray.md
@@ -4,6 +4,8 @@
 It has the same logical size as a dense array, but allocates storage only for active blocks.
 
 The main use case is a large Cartesian mesh where the simulated material occupies only a small part of the domain.
+The MPM loop still sees the same grid fields and transfer macros, but grid storage and grid-wide operations are restricted to active blocks.
+
 At this stage, `SpArray` is mainly a way to avoid allocating grid fields over empty regions.
 It should not be expected to make every computation much faster, but it can substantially reduce memory use when a dense grid would contain many nodes that are never touched by particles.
 

--- a/docs/src/transfer.md
+++ b/docs/src/transfer.md
@@ -1,7 +1,11 @@
 # [Transfer between grid and particles](@id manual)
 
-Transfer macros express the two directions of MPM data movement: particle-to-grid scattering and grid-to-particle gathering.
-The same macro body can include the transfer itself and the local grid or particle calculations that follow it.
+Transfer macros describe how quantities move between particles and grid nodes.
+[`@P2G`](@ref) evaluates particle-to-grid operations, such as scattering mass, momentum, or internal force to the grid.
+[`@G2P`](@ref) evaluates grid-to-particle operations, such as updating particle velocity, position, or deformation state from grid values.
+
+Inside a transfer macro, grid fields, particle fields, and basis weights are written with indexed notation.
+This notation keeps the code close to the transfer equations while letting Tesserae choose the execution backend, including sequential CPU execution, threaded CPU execution, and GPU kernels.
 
 ## Transfer macros
 


### PR DESCRIPTION
- Add a manual overview that connects the MPM workflow to the individual manual pages.
- Reorganize the manual navigation around core workflow, scaling simulations, and advanced methods.
- Clarify the introductory text for mesh, grid/particle generation, basis functions, transfers, export, multithreading, GPU execution, sparse grids, and implicit utilities.