### PR TITLE
Support sliced @foreach loops

### DIFF
--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -114,17 +114,18 @@ This is also how boundary conditions should be applied on GPU.
 For example, on a 3D grid, a CPU slip floor boundary condition can be written as
 
 ```julia
-for i in eachindex(grid)[:, :, begin]
+for i in eachindex(grid)[:,:,begin]
     grid.v[i] = grid.v[i] .* (true, true, false)
 end
 ```
 
-On GPU, write the same operation as a broadcast:
+On GPU, write the same operation with [`@foreach`](@ref), which dispatches the
+boundary slice as a GPU kernel:
 
 ```julia
-slip_floor(v) = v .* (true, true, false)
-
-@. grid_gpu.v[:, :, begin] = slip_floor(grid_gpu.v[:, :, begin])
+@foreach grid_gpu[:,:,begin]=>i begin
+    v[i] = v[i] .* (true, true, false)
+end
 ```
 
 ## Floating-point type
@@ -205,8 +206,8 @@ The main changes are:
 
 - Remove CPU threading utilities such as `@threaded`, `ThreadPartition`, and `reorder_particles!`.
 - Move the simulation objects to GPU with `gpu_preserve` after CPU-side setup.
-- Keep grid and particle calculations inside GPU operations, using `@P2G`, `@G2P`, and broadcasts.
-- Rewrite the slip floor boundary condition as a broadcast to avoid scalar indexing on GPU arrays.
+- Keep grid and particle calculations inside GPU operations, using `@P2G`, `@G2P`, and `@foreach`.
+- Rewrite the slip floor boundary condition with a boundary-slice `@foreach` loop to avoid scalar indexing on GPU arrays.
 - Copy data back with `cpu` only when writing VTK output.
 
 For reference, the compute-only runtime on an NVIDIA GeForce RTX 5090, excluding VTK output, is:
@@ -307,9 +308,10 @@ function main()
                 v[i]  = vⁿ[i] + Δt * f[i] / m[i] * !iszero(m[i])
             end
 
-            slip_floor(v) = v .* (true, true, false)
-            @. grid.vⁿ[:, :, begin] = slip_floor(grid.vⁿ[:, :, begin])
-            @. grid.v[:, :, begin] = slip_floor(grid.v[:, :, begin])
+            @foreach grid[:,:,begin]=>i begin
+                vⁿ[i] = vⁿ[i] .* (true, true, false)
+                v[i] = v[i] .* (true, true, false)
+            end
 
             @G2P grid=>i particles=>p weights=>ip begin
                 v[p] += @∑ w[ip] * (v[i] - vⁿ[i])

--- a/docs/src/transfer.md
+++ b/docs/src/transfer.md
@@ -32,6 +32,16 @@ end
 end
 ```
 
+Index the collection argument to visit a slice.
+This is useful for boundary conditions and uses the same CPU, GPU, sparse-grid,
+and threading dispatch as the full loop:
+
+```julia
+@foreach grid[:,:,begin]=>i begin
+    v[i] = v[i] .* (true, true, false)
+end
+```
+
 On dense grids, [`@foreach`](@ref) visits all grid nodes.
 On `SpGrid`, it visits only active sparse nodes.
 When the collection is on GPU, the loop is dispatched as a GPU kernel.

--- a/src/foreach.jl
+++ b/src/foreach.jl
@@ -3,10 +3,16 @@
         statements...
     end
 
+    @foreach collection[:,begin]=>i begin
+        statements...
+    end
+
 Run `statements` for each index of `collection`.
 Inside the block, `field[i]` is resolved to `collection.field[i]`, matching the
 field-access convention used by transfer macros.
 Use `\$(expr)` to evaluate an outer expression once before the generated loop.
+Index the collection in the `collection=>i` argument to restrict the loop to a
+slice, for example `grid[:,:,begin]=>i` or `grid[:,end]=>i`.
 
 For `SpGrid`, only active sparse indices are visited. On GPU, the loop is
 dispatched as a backend kernel.
@@ -20,7 +26,7 @@ macro foreach(schedule::QuoteNode, collection_i, body)
 end
 
 function foreach_expr(schedule::QuoteNode, collection_i, body)
-    collection, i = unpair(collection_i)
+    collection, i, slice = parse_foreach_collection(collection_i)
     interpolations = Pair{Symbol, Any}[]
     body = extract_transfer_interpolations(body, interpolations)
     scope = TransferScope([collection=>i])
@@ -28,13 +34,93 @@ function foreach_expr(schedule::QuoteNode, collection_i, body)
     if !DEBUG
         body = :(@inbounds $body)
     end
-    code = quote
-        Tesserae.foreach_loop(($collection, $i) -> $body,
-                              Tesserae.get_device($collection),
-                              Val($schedule), $collection)
+    code = if slice === nothing
+        :(Tesserae.foreach_loop(($collection, $i) -> $body, Tesserae.get_device($collection), Val($schedule), $collection))
+    else
+        :(Tesserae.foreach_loop(($collection, $i) -> $body, Tesserae.get_device($collection), Val($schedule), $collection, $slice))
     end
     code = interpolate_transfer_values(code, TransferProgram(TransferEquation[], interpolations))
     esc(prettify(code; lines=true, alias=false))
+end
+
+function parse_foreach_collection(ex)
+    if Meta.isexpr(ex, :call, 3) && ex.args[1] == :(=>)
+        collection_expr, i = ex.args[2], ex.args[3]
+        i isa Symbol || error("@foreach index must be a symbol, got `$i`")
+        if Meta.isexpr(collection_expr, :ref)
+            collection = first(collection_expr.args)
+            collection isa Symbol || error("@foreach collection must be a symbol, got `$collection`")
+            selectors = collection_expr.args[2:end]
+            return collection, i, foreach_slice_expr(collection, selectors)
+        else
+            collection = collection_expr
+            collection isa Symbol || error("@foreach collection must be a symbol, got `$collection`")
+            return collection, i, nothing
+        end
+    else
+        collection, i = unpair(ex)
+        collection isa Symbol || error("@foreach collection must be a symbol, got `$collection`")
+        i isa Symbol || error("@foreach index must be a symbol, got `$i`")
+        return collection, i, nothing
+    end
+end
+
+function foreach_slice_expr(collection, selectors)
+    ranges = map(enumerate(selectors)) do (d, selector)
+        if selector == :(:)
+            :(Base.OneTo(size($collection, $d)))
+        else
+            selector = replace_foreach_slice_bounds(selector, collection, d)
+            :(Tesserae.foreach_slice_range($selector))
+        end
+    end
+    :(Tesserae.ForeachSlice(tuple($(ranges...))))
+end
+
+function replace_foreach_slice_bounds(expr, collection, d)
+    MacroTools.postwalk(expr) do ex
+        ex === :begin && return 1
+        ex === :end && return :(size($collection, $d))
+        ex
+    end
+end
+
+struct ForeachSlice{N, R <: NTuple{N, AbstractRange{<: Integer}}}
+    ranges::R
+end
+
+foreach_slice_range(index::Integer) = index:index
+foreach_slice_range(range::AbstractRange{<: Integer}) = range
+function foreach_slice_range(selector)
+    throw(ArgumentError("@foreach slice indices must be `:`, integers, or integer ranges, got `$(selector)`"))
+end
+
+function foreach_check_slice(collection, slice::ForeachSlice)
+    ndims(collection) == length(slice.ranges) ||
+        throw(ArgumentError("@foreach slice has $(length(slice.ranges)) indices but collection has $(ndims(collection)) dimensions"))
+    for d in eachindex(slice.ranges)
+        foreach_check_slice_range(collection, slice.ranges[d], d)
+    end
+    nothing
+end
+
+function foreach_check_slice_range(collection, range, d)
+    isempty(range) && return nothing
+    bounds = Base.OneTo(size(collection, d))
+    checkbounds(Bool, bounds, first(range)) || throw(BoundsError(collection, first(range)))
+    checkbounds(Bool, bounds, last(range)) || throw(BoundsError(collection, last(range)))
+    nothing
+end
+
+foreach_slice_ndrange(slice::ForeachSlice) = map(length, slice.ranges)
+
+@inline function foreach_slice_index(slice::ForeachSlice, j::CartesianIndex)
+    @inbounds CartesianIndex(map(getindex, slice.ranges, Tuple(j)))
+end
+
+@inline function foreach_slice_spindex(spinds, slice::ForeachSlice, j::CartesianIndex)
+    I = foreach_slice_index(slice, j)
+    @inbounds spinds[I]
 end
 
 foreach_indices(collection) = eachindex(collection)
@@ -58,6 +144,25 @@ function foreach_loop(f, ::CPUDevice, ::Val{scheduler}, collection::SpGrid) wher
     end
 end
 
+function foreach_loop(f, ::CPUDevice, ::Val{scheduler}, collection, slice::ForeachSlice) where {scheduler}
+    foreach_check_slice(collection, slice)
+    ndrange = foreach_slice_ndrange(slice)
+    tforeach(CartesianIndices(ndrange), scheduler) do j
+        i = foreach_slice_index(slice, j)
+        @inline f(collection, i)
+    end
+end
+
+function foreach_loop(f, ::CPUDevice, ::Val{scheduler}, collection::SpGrid, slice::ForeachSlice) where {scheduler}
+    foreach_check_slice(collection, slice)
+    ndrange = foreach_slice_ndrange(slice)
+    spinds = get_spinds(collection)
+    tforeach(CartesianIndices(ndrange), scheduler) do j
+        i = foreach_slice_spindex(spinds, slice, j)
+        isactive(i) && @inline f(collection, i)
+    end
+end
+
 @kernel function gpukernel_foreach(f, collection)
     i = @index(Global, Cartesian)
     f(collection, i)
@@ -76,6 +181,20 @@ end
     end
 end
 
+@kernel function gpukernel_foreach_slice(f, collection, slice)
+    j = @index(Global, Cartesian)
+    i = foreach_slice_index(slice, j)
+    f(collection, i)
+end
+
+@kernel function gpukernel_foreach_slice_spgrid(f, collection, slice, @Const(spinds))
+    j = @index(Global, Cartesian)
+    i = foreach_slice_spindex(spinds, slice, j)
+    if isactive(i)
+        @inbounds f(collection, i)
+    end
+end
+
 function foreach_loop(f, device::GPUDevice, ::Val{scheduler}, collection) where {scheduler}
     scheduler == :nothing || @warn "Multi-threading is disabled for GPU" maxlog=1
     backend = get_backend(device)
@@ -89,5 +208,20 @@ function foreach_loop(f, device::GPUDevice, ::Val{scheduler}, collection) where 
     else
         kernel = gpukernel_foreach(backend)
         kernel(f, collection; ndrange=size(collection))
+    end
+end
+
+function foreach_loop(f, device::GPUDevice, ::Val{scheduler}, collection, slice::ForeachSlice) where {scheduler}
+    scheduler == :nothing || @warn "Multi-threading is disabled for GPU" maxlog=1
+    foreach_check_slice(collection, slice)
+    ndrange = foreach_slice_ndrange(slice)
+    backend = get_backend(device)
+    if collection isa SpGrid
+        spinds = get_spinds(collection)
+        kernel = gpukernel_foreach_slice_spgrid(backend)
+        kernel(f, collection, slice, spinds; ndrange)
+    else
+        kernel = gpukernel_foreach_slice(backend)
+        kernel(f, collection, slice; ndrange)
     end
 end

--- a/test/foreach.jl
+++ b/test/foreach.jl
@@ -20,6 +20,58 @@
         @test all(i -> grid.v[i] == grid.x[i] - grid.mv[i] / grid.m[i], eachindex(grid))
     end
 
+    @testset "Grid slices" begin
+        mesh = CartesianMesh(1.0, (0,2), (0,2), (0,2))
+        grid = generate_grid(@NamedTuple{x::Vec{3,Float64}, m::Float64}, mesh)
+        indices = CartesianIndices(size(grid))
+
+        fillzero!(grid.m)
+        @foreach grid[:,:,begin]=>i begin
+            m[i] = 1
+        end
+
+        @test all(i -> grid.m[i] == (i[3] == 1 ? 1 : 0), indices)
+
+        fillzero!(grid.m)
+        @threaded @foreach grid[end,:,:]=>i begin
+            m[i] = 2
+        end
+
+        @test all(i -> grid.m[i] == (i[1] == size(grid, 1) ? 2 : 0), indices)
+
+        fillzero!(grid.m)
+        @foreach grid[begin+1:end-1,:,:]=>i begin
+            m[i] = 3
+        end
+
+        @test all(i -> grid.m[i] == (1 < i[1] < size(grid, 1) ? 3 : 0), indices)
+
+        fillzero!(grid.m)
+        @foreach grid[begin:2:end,:,end]=>i begin
+            m[i] = 4
+        end
+
+        @test all(i -> grid.m[i] == (isodd(i[1]) && i[3] == size(grid, 3) ? 4 : 0), indices)
+    end
+
+    @testset "Grid slice bounds" begin
+        mesh = CartesianMesh(1.0, (0,2), (0,2))
+        grid = generate_grid(@NamedTuple{x::Vec{2,Float64}, m::Float64}, mesh)
+
+        @test_throws BoundsError @foreach grid[begin-1,:]=>i begin
+            m[i] = 1
+        end
+    end
+
+    @testset "Grid slice dimensions" begin
+        mesh = CartesianMesh(1.0, (0,2), (0,2))
+        grid = generate_grid(@NamedTuple{x::Vec{2,Float64}, m::Float64}, mesh)
+
+        @test_throws ArgumentError @foreach grid[:,:,begin]=>i begin
+            m[i] = 1
+        end
+    end
+
     @testset "Particles" begin
         mesh = CartesianMesh(1.0, (0,2), (0,2))
         ParticleProp = @NamedTuple{x::Vec{2,Float64}, v::Vec{2,Float64}}
@@ -33,6 +85,18 @@
         end
 
         @test particles.x == x0 .+ particles.v .* Δt
+    end
+
+    @testset "Particle slices" begin
+        mesh = CartesianMesh(1.0, (0,2), (0,2))
+        particles = generate_particles(@NamedTuple{x::Vec{2,Float64}, v::Vec{2,Float64}}, mesh; alg=GridSampling())
+        @. particles.v = Vec(0.25, -0.5)
+
+        @foreach particles[begin:end]=>p begin
+            v[p] = -v[p]
+        end
+
+        @test particles.v == fill(Vec(-0.25, 0.5), length(particles))
     end
 
     @testset "Interpolation" begin
@@ -67,5 +131,28 @@
         @test all(i -> grid.v[i] == grid.x[i], active)
         @test all(i -> iszero(grid.m[i]), filter(i -> !Tesserae.isactive(grid.m, i), eachindex(grid.m)))
         @test all(i -> iszero(grid.v[i]), filter(i -> !Tesserae.isactive(grid.v, i), eachindex(grid.v)))
+    end
+
+    @testset "SpGrid slices" begin
+        mesh = CartesianMesh(1.0, (0,8), (0,8))
+        grid = generate_grid(SpArray, @NamedTuple{x::Vec{2,Float64}, m::Float64, v::Vec{2,Float64}}, mesh)
+        update_sparsity!(grid, trues(Tesserae.nblocks(mesh)))
+
+        @. grid.m = 0
+        @foreach grid[:,begin]=>i begin
+            m[i] = 2
+            v[i] = x[i]
+        end
+
+        active = collect(Tesserae.activeindices(grid.m))
+        @test !isempty(active)
+        @test all(active) do i
+            I = Tesserae.logicalindex(i)
+            if I[2] == 1
+                grid.m[i] == 2 && grid.v[i] == grid.x[i]
+            else
+                iszero(grid.m[i]) && iszero(grid.v[i])
+            end
+        end
     end
 end

--- a/test/foreach.jl
+++ b/test/foreach.jl
@@ -20,6 +20,19 @@
         @test all(i -> grid.v[i] == grid.x[i] - grid.mv[i] / grid.m[i], eachindex(grid))
     end
 
+    @testset "Grid argument forms" begin
+        mesh = CartesianMesh(1.0, (0,2), (0,2))
+        grid = generate_grid(@NamedTuple{x::Vec{2,Float64}, m::Float64}, mesh)
+
+        @foreach begin
+            grid=>i
+        end begin
+            m[i] = 1
+        end
+
+        @test all(i -> grid.m[i] == 1, eachindex(grid))
+    end
+
     @testset "Grid slices" begin
         mesh = CartesianMesh(1.0, (0,2), (0,2), (0,2))
         grid = generate_grid(@NamedTuple{x::Vec{3,Float64}, m::Float64}, mesh)

--- a/test/foreach.jl
+++ b/test/foreach.jl
@@ -52,6 +52,25 @@
         end
 
         @test all(i -> grid.m[i] == (isodd(i[1]) && i[3] == size(grid, 3) ? 4 : 0), indices)
+
+        fillzero!(grid.m)
+        @foreach grid[begin,end,begin]=>i begin
+            m[i] = 5
+        end
+
+        fixed_index = CartesianIndex(1, size(grid, 2), 1)
+        @test all(i -> grid.m[i] == (i == fixed_index ? 5 : 0), indices)
+    end
+
+    @testset "Grid empty slices" begin
+        mesh = CartesianMesh(1.0, (0,1), (0,1))
+        grid = generate_grid(@NamedTuple{x::Vec{2,Float64}, m::Float64}, mesh)
+
+        @foreach grid[begin+1:end-1,:]=>i begin
+            m[i] = 1
+        end
+
+        @test all(iszero, grid.m)
     end
 
     @testset "Grid slice bounds" begin
@@ -59,6 +78,19 @@
         grid = generate_grid(@NamedTuple{x::Vec{2,Float64}, m::Float64}, mesh)
 
         @test_throws BoundsError @foreach grid[begin-1,:]=>i begin
+            m[i] = 1
+        end
+
+        @test_throws BoundsError @foreach grid[:,end+1]=>i begin
+            m[i] = 1
+        end
+    end
+
+    @testset "Grid slice selectors" begin
+        mesh = CartesianMesh(1.0, (0,2), (0,2))
+        grid = generate_grid(@NamedTuple{x::Vec{2,Float64}, m::Float64}, mesh)
+
+        @test_throws ArgumentError @foreach grid[[1,2],:]=>i begin
             m[i] = 1
         end
     end
@@ -97,6 +129,14 @@
         end
 
         @test particles.v == fill(Vec(-0.25, 0.5), length(particles))
+
+        @threaded @foreach particles[begin+1:end-1]=>p begin
+            v[p] = Vec(1, -1)
+        end
+
+        @test particles.v[begin] == Vec(-0.25, 0.5)
+        @test particles.v[end] == Vec(-0.25, 0.5)
+        @test all(p -> particles.v[p] == Vec(1, -1), 2:(length(particles)-1))
     end
 
     @testset "Interpolation" begin
@@ -111,6 +151,17 @@
 
         @test calls[] == 1
         @test all(i -> grid.m[i] == 3 * (grid.x[i][1] + 1), eachindex(grid))
+
+        fillzero!(grid.m)
+        @foreach grid[:,end]=>i begin
+            m[i] = $(scale()) * (x[i][2] + 1)
+        end
+
+        @test calls[] == 2
+        @test all(eachindex(grid)) do i
+            expected = i[2] == size(grid, 2) ? 3 * (grid.x[i][2] + 1) : 0
+            grid.m[i] == expected
+        end
     end
 
     @testset "SpGrid" begin
@@ -154,5 +205,32 @@
                 iszero(grid.m[i]) && iszero(grid.v[i])
             end
         end
+
+        fillzero!(grid.m)
+        @threaded @foreach grid[end,:]=>i begin
+            m[i] = 3
+        end
+
+        @test all(active) do i
+            I = Tesserae.logicalindex(i)
+            I[1] == size(grid, 1) ? grid.m[i] == 3 : iszero(grid.m[i])
+        end
+
+        sparse_grid = generate_grid(SpArray, @NamedTuple{x::Vec{2,Float64}, m::Float64}, mesh)
+        update_sparsity!(sparse_grid, [Vec(1.0, 1.0), Vec(7.0, 7.0)])
+
+        @foreach sparse_grid[:,begin]=>i begin
+            m[i] = 4
+        end
+
+        sparse_active = collect(Tesserae.activeindices(sparse_grid.m))
+        @test any(i -> Tesserae.logicalindex(i)[2] == 1, sparse_active)
+        @test all(sparse_active) do i
+            I = Tesserae.logicalindex(i)
+            I[2] == 1 ? sparse_grid.m[i] == 4 : iszero(sparse_grid.m[i])
+        end
+
+        sparse_inactive = filter(i -> !Tesserae.isactive(sparse_grid.m, i), eachindex(sparse_grid.m))
+        @test all(i -> iszero(sparse_grid.m[i]), sparse_inactive)
     end
 end


### PR DESCRIPTION
Adds slice syntax to `@foreach`, such as `grid[:,:,begin]=>i`, for boundary-oriented local loops.

The sliced loop path works across dense grids, sparse grids, CPU threading, and GPU dispatch. The GPU sparse-grid path launches over the requested slice and checks active sparse indices before running the loop body.

Documentation now shows boundary conditions using sliced `@foreach` instead of GPU broadcasts.