### PR TITLE
Rename neighboringnodes to supportnodes

### DIFF
--- a/src/Basis/gimp.jl
+++ b/src/Basis/gimp.jl
@@ -19,7 +19,7 @@ support_width(::uGIMP) = 3
 
 @inline function supportnodes(::uGIMP, pt, mesh::CartesianMesh)
     h⁻¹ = spacing_inv(mesh)
-    neighboringnodes(getx(pt), 1+pt.l*h⁻¹, mesh)
+    supportnodes(getx(pt), 1+pt.l*h⁻¹, mesh)
 end
 
 # simple uGIMP calculation

--- a/src/Tesserae.jl
+++ b/src/Tesserae.jl
@@ -87,7 +87,6 @@ export
 # BasisWeight
     generate_basis_weights,
     generate_interpolation_weights,
-    neighboringnodes,
     supportnodes,
     basis,
     BasisWeight,

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -19,3 +19,4 @@ Base.@deprecate_binding ColorPartition ThreadPartition
 @deprecate neighboringnodes(bw::BasisWeight) supportnodes(bw)
 @deprecate neighboringnodes(bw::BasisWeight, domain) supportnodes(bw, domain)
 @deprecate neighboringnodes(basis::Basis, pt, mesh::AbstractMesh) supportnodes(basis, pt, mesh)
+@deprecate neighboringnodes(x::Vec, r::Real, mesh::CartesianMesh) supportnodes(x, r, mesh)

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -158,9 +158,9 @@ end
 end
 
 """
-    neighboringnodes(x::Vec, r::Real, mesh::CartesianMesh)
+    supportnodes(x::Vec, r::Real, mesh::CartesianMesh)
 
-Return `CartesianIndices` for neighboring nodes around `x`.
+Return `CartesianIndices` for support nodes around `x`.
 `r` denotes the range for searching area. In 1D, for example, the range `a`
 becomes ` x-r*h ≤ a < x+r*h` where `h` is `spacing(mesh)`.
 
@@ -175,14 +175,14 @@ julia> mesh = CartesianMesh(1, (0,5))
  [4.0]
  [5.0]
 
-julia> neighboringnodes(Vec(1.5), 1, mesh)
+julia> supportnodes(Vec(1.5), 1, mesh)
 CartesianIndices((2:3,))
 
-julia> neighboringnodes(Vec(1.5), 3, mesh)
+julia> supportnodes(Vec(1.5), 3, mesh)
 CartesianIndices((1:5,))
 ```
 """
-@inline function neighboringnodes(x::Vec, r::Real, mesh::CartesianMesh{dim, T}) where {dim, T}
+@inline function supportnodes(x::Vec, r::Real, mesh::CartesianMesh{dim, T}) where {dim, T}
     ξ = Tuple(normalize(x, mesh))
     dims = size(mesh)
     isinside(ξ, dims) || return EmptyCartesianIndices(Val(dim))

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -51,16 +51,16 @@
     @test (@inferred Tesserae.isinside(Vec(-1.0,3.0), mesh)) === false
     @test (@inferred Tesserae.isinside(Vec(1.0,-3.0), mesh)) === false
 
-    # neighboringnodes
-    @test (@inferred neighboringnodes(Vec(0.1,0.1), 1, mesh)) === CartesianIndices((1:2,1:2))
-    @test (@inferred neighboringnodes(Vec(0.3,0.1), 2, mesh)) === CartesianIndices((1:4,1:3))
-    @test (@inferred neighboringnodes(Vec(0.1,0.3), 2, mesh)) === CartesianIndices((1:3,1:4))
+    # supportnodes
+    @test (@inferred supportnodes(Vec(0.1,0.1), 1, mesh)) === CartesianIndices((1:2,1:2))
+    @test (@inferred supportnodes(Vec(0.3,0.1), 2, mesh)) === CartesianIndices((1:4,1:3))
+    @test (@inferred supportnodes(Vec(0.1,0.3), 2, mesh)) === CartesianIndices((1:3,1:4))
     ## exactly on the node
-    @test (@inferred neighboringnodes(Vec(0.2,0.4), 1, mesh)) === CartesianIndices((2:3,3:4))
-    @test (@inferred neighboringnodes(Vec(0.2,0.4), 2, mesh)) === CartesianIndices((1:4,2:5))
-    @test (@inferred neighboringnodes(Vec(3.0,4.0), 2, mesh)) === CartesianIndices((1:0,1:0))
+    @test (@inferred supportnodes(Vec(0.2,0.4), 1, mesh)) === CartesianIndices((2:3,3:4))
+    @test (@inferred supportnodes(Vec(0.2,0.4), 2, mesh)) === CartesianIndices((1:4,2:5))
+    @test (@inferred supportnodes(Vec(3.0,4.0), 2, mesh)) === CartesianIndices((1:0,1:0))
     ## outside
-    @test (@inferred neighboringnodes(Vec(-0.1,3.05), 3, mesh)) === CartesianIndices((1:0,1:0))
+    @test (@inferred supportnodes(Vec(-0.1,3.05), 3, mesh)) === CartesianIndices((1:0,1:0))
 
     # findcell
     @test findcell(Vec(0.1,0.1), mesh) === CartesianIndex(1,1)


### PR DESCRIPTION
Renames the Cartesian support-node helper from `neighboringnodes` to `supportnodes` so the live API matches the rest of the basis-weight terminology.

Keeps deprecated `neighboringnodes` entry points for compatibility, removes the old name from exports, and updates the uGIMP call site and mesh tests.