### PR TITLE
Clarify FEM notation and support status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ macros.
   including threaded transfers and matrix assembly. (#126)
 - `@foreach` provides backend-aware loops over grids, particles, and active
   sparse grid nodes without abusing transfer macros as generic loop kernels.
+- FEM support is no longer experimental, with a documented workflow for mesh
+  generation, quadrature, assembly, and boundary conditions. (#157)
 - Experimental NURBS and IGA support has been added, including rational B-spline
   control nets, geometry operations, and conversion to `IGAMesh`.
 - Gmsh `.msh` files can now be read directly as physical-group meshes through

--- a/docs/src/fem.md
+++ b/docs/src/fem.md
@@ -6,12 +6,12 @@ after [`feupdate!`](@ref) fills the quadrature weights and basis data, the same
 [`@P2G`](@ref) and [`@P2G_Matrix`](@ref) macros used for MPM assemble
 finite-element vectors and matrices.
 
-For quadrature point `q` in element `e`, define a particle `p` by
+For quadrature point `q` in cell `c`, define a particle `p` by
 
 ```math
-\bm{x}_p = \bm{x}_e(\bm{\xi}_q),
+\bm{x}_p = \bm{x}_c(\bm{\xi}_q),
 \qquad
-V_p = \omega_q \det \bm{J}_e(\bm{\xi}_q).
+V_p = \omega_q \det \bm{J}_c(\bm{\xi}_q).
 ```
 
 Then a particle sum is the usual FEM quadrature rule:
@@ -19,9 +19,9 @@ Then a particle sum is the usual FEM quadrature rule:
 ```math
 \sum_p f(\bm{x}_p) V_p
 =
-\sum_e \sum_q
-f(\bm{x}_e(\bm{\xi}_q))
-\omega_q \det \bm{J}_e(\bm{\xi}_q).
+\sum_c \sum_q
+f(\bm{x}_c(\bm{\xi}_q))
+\omega_q \det \bm{J}_c(\bm{\xi}_q).
 ```
 
 The particle arrays in this page store fixed Gauss points, not moving MPM


### PR DESCRIPTION
Aligns the FEM quadrature notation with the `cell` terminology used by the implementation and records that FEM support is no longer experimental in the changelog.