### PR TITLE
Require explicit ndofs for sparse matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ macros.
 
 ### Breaking Changes
 
+- `create_sparse_matrix` now requires the `ndofs` keyword to be specified
+  explicitly. The previous default based on the mesh dimension was removed.
 - The `PoissonDiskSampling` keyword `multithreading` has been renamed to
   `threaded`. The old keyword is no longer accepted. (#113)
 - `reorder_particles!` now returns a `Bool` indicating whether particles were

--- a/docs/literate/tutorials/implicit_jacobian_based.jl
+++ b/docs/literate/tutorials/implicit_jacobian_based.jl
@@ -90,7 +90,7 @@ function main()
     end
 
     ## Sparse matrix
-    A = create_sparse_matrix(basis, grid.X)
+    A = create_sparse_matrix(basis, grid.X; ndofs=2)
 
     ## Outputs
     outdir = mkpath(joinpath("output", "implicit_jacobian_based"))

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -71,12 +71,12 @@ function (dofmap::DofMap)(A::AbstractArray{T}) where {T <: Real}
 end
 
 """
-    create_sparse_matrix(basis, mesh; ndofs = ndims(mesh))
+    create_sparse_matrix(basis, mesh; ndofs)
 
 Create a sparse matrix.
 Since the created matrix accounts for all nodes in the mesh,
 it needs to be extracted for active nodes using the `DofMap`.
-`ndofs` represents the number of DoFs for a field.
+`ndofs` specifies the number of DoFs for a field and must be provided explicitly.
 
 ```jldoctest
 julia> mesh = CartesianMesh(1, (0,10), (0,10));
@@ -123,11 +123,11 @@ julia> extract(A, dofmap)
   ⋅    ⋅    ⋅    ⋅   0.0  0.0   ⋅   0.0  0.0
 ```
 """
-function create_sparse_matrix(basis::Basis, mesh::AbstractMesh; ndofs = ndims(mesh))
+function create_sparse_matrix(basis::Basis, mesh::AbstractMesh; ndofs)
     _create_sparse_matrix(Float64, basis, mesh, ndofs)
 end
 
-function create_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh; ndofs = ndims(mesh)) where {T}
+function create_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh; ndofs) where {T}
     _create_sparse_matrix(T, basis, mesh, ndofs)
 end
 
@@ -190,18 +190,18 @@ function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Tuple{Int,In
     sparse(I, J, zeros(T, length(I)), length(gdofs1), length(gdofs2))
 end
 
-function create_sparse_matrix(::IGABasis, mesh::IGAMesh{dim}; ndofs = dim) where {dim}
+function create_sparse_matrix(::IGABasis, mesh::IGAMesh{dim}; ndofs) where {dim}
     _create_sparse_matrix(Float64, mesh, ndofs)
 end
-function create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh{dim}; ndofs = dim) where {T, dim}
+function create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh{dim}; ndofs) where {T, dim}
     _create_sparse_matrix(T, mesh, ndofs)
 end
 _create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Int) where {T} = _create_sparse_matrix(T, mesh, ndofs)
 _create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T} = _create_sparse_matrix(T, mesh, ndofs)
 _create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Int) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
 _create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
-create_sparse_matrix(::Type{T}, mesh::IGAMesh{dim}; ndofs = dim) where {T, dim} = _create_sparse_matrix(T, mesh, ndofs)
-create_sparse_matrix(mesh::IGAMesh{dim}; ndofs = dim) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
+create_sparse_matrix(::Type{T}, mesh::IGAMesh{dim}; ndofs) where {T, dim} = _create_sparse_matrix(T, mesh, ndofs)
+create_sparse_matrix(mesh::IGAMesh{dim}; ndofs) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
 
 function create_sparse_matrix(::Type{T}, (mesh1,mesh2)::Tuple{FEMesh, FEMesh}; ndofs::Tuple{Int, Int}) where {T}
     mesh1 === mesh2 && return _create_cell_support_sparse_matrix(T, mesh1, ndofs)
@@ -231,8 +231,8 @@ function create_sparse_matrix(::Type{T}, (mesh1,mesh2)::Tuple{FEMesh, FEMesh}; n
     sparse(I, J, zeros(T, length(I)), nrow, ncol)
 end
 create_sparse_matrix(meshes::Tuple{FEMesh, FEMesh}; ndofs::Tuple{Int, Int}) = create_sparse_matrix(Float64, meshes; ndofs)
-create_sparse_matrix(::Type{T}, mesh::FEMesh{<: Any, dim}; ndofs::Int = dim) where {T, dim} = create_sparse_matrix(T, (mesh,mesh); ndofs=(ndofs,ndofs))
-create_sparse_matrix(mesh::FEMesh{<: Any, dim}; ndofs::Int = dim) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
+create_sparse_matrix(::Type{T}, mesh::FEMesh{<: Any, dim}; ndofs::Int) where {T, dim} = create_sparse_matrix(T, (mesh,mesh); ndofs=(ndofs,ndofs))
+create_sparse_matrix(mesh::FEMesh{<: Any, dim}; ndofs::Int) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
 
 """
     extract(matrix::AbstractMatrix, dofmap_row::DofMap, dofmap_col::DofMap = dofmap_row)

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -294,6 +294,9 @@ const nurbs_cubic = Tesserae.NURBS.cubic
             Set(zip(I, J))
         end
 
+        @test_throws UndefKeywordError create_sparse_matrix(mesh)
+        @test_throws UndefKeywordError create_sparse_matrix(basis, mesh)
+
         # The scalar matrix pattern must be exactly the union of each cell's
         # support-node pairings. Values are assembled later by @P2G_Matrix.
         scalar_pattern = Set{Tuple{Int,Int}}()

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -8,9 +8,11 @@
     weights = generate_basis_weights(basis, mesh, length(particles))
     update!(weights, particles, mesh)
 
+    @test_throws UndefKeywordError create_sparse_matrix(basis, mesh)
+
     @testset "square matrix" begin
-        A = create_sparse_matrix(basis, mesh)
-        B = create_sparse_matrix(basis, mesh)
+        A = create_sparse_matrix(basis, mesh; ndofs=2)
+        B = create_sparse_matrix(basis, mesh; ndofs=2)
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             A[i,j] = @∑ w[ip] * sum(∇w[jp])
         end
@@ -22,10 +24,10 @@
         @test A ≈ B
     end
     @testset "multiple matrices" begin
-        A = create_sparse_matrix(basis, mesh)
-        B = create_sparse_matrix(basis, mesh)
-        Aref = create_sparse_matrix(basis, mesh)
-        Bref = create_sparse_matrix(basis, mesh)
+        A = create_sparse_matrix(basis, mesh; ndofs=2)
+        B = create_sparse_matrix(basis, mesh; ndofs=2)
+        Aref = create_sparse_matrix(basis, mesh; ndofs=2)
+        Bref = create_sparse_matrix(basis, mesh; ndofs=2)
 
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             A[i,j] = @∑ w[ip] * w[jp]
@@ -304,6 +306,8 @@ end
     cmesh = CartesianMesh(1, (0,1), (0,1))
     quad4 = FEMesh(Tesserae.Quad4(), cmesh)
     quad9 = FEMesh(Tesserae.Quad9(), cmesh)
+
+    @test_throws UndefKeywordError create_sparse_matrix(quad4)
 
     A = create_sparse_matrix((quad9, quad4); ndofs=(2, 1))
     @test size(A) == (2length(quad9), length(quad4))


### PR DESCRIPTION
Require callers to specify `ndofs` when creating sparse matrices instead of inferring it from the mesh dimension.

Update affected examples and tests, and document the breaking change in the v0.7.0 changelog.