### PR TITLE
Support CUDA 6 and use public GPU adaptors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,7 +37,7 @@ TesseraeMetalExt = "Metal"
 [compat]
 Adapt = "4"
 Atomix = "1"
-CUDA = "5"
+CUDA = "5, 6"
 GPUArraysCore = "0.2"
 Gmsh = "0.3.1"
 Graphs = "1.4"

--- a/ext/TesseraeCUDAExt.jl
+++ b/ext/TesseraeCUDAExt.jl
@@ -4,7 +4,6 @@ using Tesserae
 using Tesserae: CUDADevice, EltypePolicy, CastFloat32, PreserveEltype
 
 using CUDA
-using CUDA: default_memory
 
 using KernelAbstractions
 using Adapt
@@ -14,7 +13,7 @@ Tesserae.get_device(x::CUDABackend) = CUDADevice{EltypePolicy}()
 Tesserae.has_device(x::CUDADevice) = true
 
 function Adapt.adapt_storage(::CUDADevice{CastFloat32}, A::AbstractArray)
-    adapt(CUDA.CuArrayKernelAdaptor{default_memory}(), A)
+    cu(A)
 end
 
 function Adapt.adapt_storage(::CUDADevice{PreserveEltype}, A::AbstractArray)

--- a/ext/TesseraeMetalExt.jl
+++ b/ext/TesseraeMetalExt.jl
@@ -4,7 +4,6 @@ using Tesserae
 using Tesserae: MetalDevice, EltypePolicy, CastFloat32, PreserveEltype
 
 using Metal
-using Metal: DefaultStorageMode
 
 using KernelAbstractions
 using Adapt
@@ -14,7 +13,7 @@ Tesserae.get_device(x::MetalBackend) = MetalDevice{EltypePolicy}()
 Tesserae.has_device(x::MetalDevice) = true
 
 function Adapt.adapt_storage(::MetalDevice{CastFloat32}, A::AbstractArray)
-    adapt(Metal.MtlArrayAdaptor{DefaultStorageMode}(), A)
+    mtl(A)
 end
 
 function Adapt.adapt_storage(::MetalDevice{PreserveEltype}, A::AbstractArray)


### PR DESCRIPTION
Allow CUDA.jl 6 and replace direct use of backend-internal array adaptors with the public `cu` and `mtl` APIs. This preserves the existing Float32 conversion behavior while avoiding dependencies on private CUDA.jl and Metal.jl implementation details.