### PR TITLE
Generalize quadrature rule generation

### DIFF
--- a/src/Basis/iga.jl
+++ b/src/Basis/iga.jl
@@ -21,53 +21,20 @@ end
 generate_basis_weights(::Type{T}, mesh::IGAMesh, dims...; kwargs...) where {T} = _generate_basis_weights(T, igabasis(mesh), mesh, _todims(dims...); kwargs...)
 generate_basis_weights(mesh::IGAMesh, dims...; kwargs...) = generate_basis_weights(Float64, mesh, dims...; kwargs...)
 
-quadrature_rule(basis::IGABasis) = quadrature_rule(Float64, basis)
+"""
+    generate_quadrature_rule(basis::IGABasis)
+    generate_quadrature_rule(T, basis::IGABasis)
 
-function quadrature_rule(::Type{T}, basis::IGABasis{dim}) where {T, dim}
-    rules = map(degree -> gauss_legendre_rule(T, degree), degrees(basis))
-    qpts1d = map(first, rules)
-    qwts1d = map(last, rules)
-    indices = CartesianIndices(map(length, qpts1d))
-    qpts = vec(map(I -> Vec(map(getindex, qpts1d, Tuple(I))), indices))
-    qwts = vec(map(I -> prod(map(getindex, qwts1d, Tuple(I))), indices))
-    QuadratureRule(qpts, qwts)
+Generate the standard [`QuadratureRule`](@ref) for `basis`, using `p + 1`
+Gauss–Legendre points in each parametric direction of degree `p`. `T` may be
+`Float16`, `Float32`, or `Float64` and defaults to `Float64`.
+"""
+generate_quadrature_rule(basis::IGABasis) = generate_quadrature_rule(Float64, basis)
+function generate_quadrature_rule(::Type{T}, basis::IGABasis{dim}) where {T, dim}
+    _check_quadrature_float(T)
+    rules = map(degree -> _gauss_legendre_rule(T, degree), degrees(basis))
+    _tensor_product_quadrature_rule(rules)
 end
-
-function gauss_legendre_rule(::Type{T}, ::Degree{0}) where {T}
-    SVector{1, T}((0,)), SVector{1, T}((2,))
-end
-function gauss_legendre_rule(::Type{T}, ::Degree{1}) where {T}
-    x = sqrt(T(1) / 3)
-    SVector{2, T}((-x, x)), SVector{2, T}((1, 1))
-end
-function gauss_legendre_rule(::Type{T}, ::Degree{2}) where {T}
-    x = sqrt(T(3) / 5)
-    SVector{3, T}((-x, 0, x)), SVector{3, T}((T(5)/9, T(8)/9, T(5)/9))
-end
-function gauss_legendre_rule(::Type{T}, ::Degree{3}) where {T}
-    x1 = sqrt(T(3)/7 - T(2)/7 * sqrt(T(6)/5))
-    x2 = sqrt(T(3)/7 + T(2)/7 * sqrt(T(6)/5))
-    w1 = (18 + sqrt(T(30))) / 36
-    w2 = (18 - sqrt(T(30))) / 36
-    SVector{4, T}((-x2, -x1, x1, x2)), SVector{4, T}((w2, w1, w1, w2))
-end
-function gauss_legendre_rule(::Type{T}, ::Degree{4}) where {T}
-    x1 = sqrt(T(5) - 2sqrt(T(10)/7)) / 3
-    x2 = sqrt(T(5) + 2sqrt(T(10)/7)) / 3
-    w1 = (322 + 13sqrt(T(70))) / 900
-    w2 = (322 - 13sqrt(T(70))) / 900
-    SVector{5, T}((-x2, -x1, 0, x1, x2)), SVector{5, T}((w2, w1, T(128)/225, w1, w2))
-end
-function gauss_legendre_rule(::Type{T}, ::Degree{5}) where {T}
-    x1 = T(0.2386191860831969)
-    x2 = T(0.6612093864662645)
-    x3 = T(0.9324695142031521)
-    w1 = T(0.4679139345726910)
-    w2 = T(0.3607615730481386)
-    w3 = T(0.1713244923791704)
-    SVector{6, T}((-x3, -x2, -x1, x1, x2, x3)), SVector{6, T}((w3, w2, w1, w1, w2, w3))
-end
-gauss_legendre_rule(::Type{T}, degree::Degree) where {T} = throw(ArgumentError("IGA quadrature is implemented up to quintic degree"))
 
 # Map parent Gauss points from [-1, 1]^dim to the selected knot span.
 span_point(patch::IGAPatch, span::CartesianIndex, X::Vec) = Vec(map(span_point, patch.knot_vectors, Tuple(span), Tuple(X)))

--- a/src/Tesserae.jl
+++ b/src/Tesserae.jl
@@ -5,6 +5,7 @@ using Base.Broadcast: Broadcasted, ArrayStyle
 using Base.Cartesian: @ntuple, @nall, @nexprs
 
 using SparseArrays
+using LinearAlgebra: SymTridiagonal, eigen
 using Printf
 
 using Reexport
@@ -62,6 +63,8 @@ export
     SpGrid,
     generate_grid,
     spacing,
+# Quadrature
+    generate_quadrature_rule,
 # Particles
     generate_particles,
     reorder_particles!,
@@ -124,6 +127,7 @@ include("progress.jl")
 import .Progress: @showprogress
 
 include("shapes.jl")
+include("quadrature.jl")
 include("NURBS/NURBS.jl")
 
 include("mesh.jl")

--- a/src/fem.jl
+++ b/src/fem.jl
@@ -7,8 +7,8 @@ end
 end
 
 """
-    feupdate!(weights, mesh[, nodes]; measure=nothing, quadrature_rule=quadrature_rule(cellshape(mesh)))
-    feupdate!(weights, boundary_mesh[, nodes]; measure=nothing, normal=nothing, quadrature_rule=quadrature_rule(cellshape(boundary_mesh)))
+    feupdate!(weights, mesh[, nodes]; measure=nothing, quadrature_rule=generate_quadrature_rule(cellshape(mesh)))
+    feupdate!(weights, boundary_mesh[, nodes]; measure=nothing, normal=nothing, quadrature_rule=generate_quadrature_rule(cellshape(boundary_mesh)))
 
 Fill finite-element basis data at quadrature points.
 
@@ -44,7 +44,7 @@ function feupdate!(
         weights::AbstractArray{<: BasisWeight{S}}, mesh::FEMesh{S, dim},
         nodes::AbstractArray{<: Vec{dim}} = mesh;
         measure::Union{Nothing, AbstractArray} = nothing,
-        quadrature_rule::QuadratureRule = quadrature_rule(cellshape(mesh)),
+        quadrature_rule::QuadratureRule = generate_quadrature_rule(cellshape(mesh)),
     ) where {dim, S <: Shape{dim}}
     qpts, qwts = quadrature_rule.points, quadrature_rule.weights
     qdata = jet.(Ref(Order(1)), Ref(cellshape(mesh)), qpts)
@@ -55,7 +55,7 @@ function feupdate!(
         weights::AbstractArray{<: BasisWeight{<: IGABasis}}, mesh::IGAMesh{dim, dim, T},
         nodes::AbstractArray{<: Vec{dim}} = mesh;
         measure::Union{Nothing, AbstractArray} = nothing,
-        quadrature_rule::QuadratureRule = quadrature_rule(igabasis(mesh)),
+        quadrature_rule::QuadratureRule = generate_quadrature_rule(igabasis(mesh)),
     ) where {dim, T}
     qpts, qwts = quadrature_rule.points, quadrature_rule.weights
     _feupdate!(Val(:domain), weights, mesh, nodes, measure, nothing, qpts, qwts)
@@ -137,7 +137,7 @@ function feupdate!(
         weights::AbstractArray{<: BasisWeight{S}}, mesh::FEMesh{S, dim},
         nodes::AbstractArray{<: Vec{dim}} = mesh;
         measure::Union{Nothing, AbstractArray} = nothing, normal::Union{Nothing, AbstractArray} = nothing,
-        quadrature_rule::QuadratureRule = quadrature_rule(cellshape(mesh)),
+        quadrature_rule::QuadratureRule = generate_quadrature_rule(cellshape(mesh)),
     ) where {S <: Shape, dim}
     qpts, qwts = quadrature_rule.points, quadrature_rule.weights
     qdata = jet.(Ref(Order(1)), Ref(cellshape(mesh)), qpts)
@@ -148,7 +148,7 @@ function feupdate!(
         weights::AbstractArray{<: BasisWeight{<: IGABasis}}, mesh::IGAMesh{dim, pdim, T},
         nodes::AbstractArray{<: Vec{dim}} = mesh;
         measure::Union{Nothing, AbstractArray} = nothing, normal::Union{Nothing, AbstractArray} = nothing,
-        quadrature_rule::QuadratureRule = quadrature_rule(igabasis(mesh)),
+        quadrature_rule::QuadratureRule = generate_quadrature_rule(igabasis(mesh)),
     ) where {dim, T, pdim}
     qpts, qwts = quadrature_rule.points, quadrature_rule.weights
     _feupdate!(Val(:boundary), weights, mesh, nodes, measure, normal, qpts, qwts)

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -21,8 +21,8 @@ struct CellSampling{V <: Union{AbstractVector{<: Vec}, Tuple{Vararg{Vec}}}} <: S
     qpts::V
 end
 
-cell_sampling(mesh::FEMesh) = CellSampling(quadpoints(cellshape(mesh)))
-cell_sampling(mesh::IGAMesh) = CellSampling(quadrature_rule(igabasis(mesh)).points)
+cell_sampling(mesh::FEMesh) = CellSampling(generate_quadrature_rule(cellshape(mesh)).points)
+cell_sampling(mesh::IGAMesh) = CellSampling(generate_quadrature_rule(igabasis(mesh)).points)
 
 function generate_points(alg::CellSampling, mesh::Union{FEMesh, IGAMesh})
     qpts = alg.qpts

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -1,0 +1,242 @@
+"""
+    QuadratureRule(points, weights)
+
+Points and weights for integration on a reference cell.
+"""
+struct QuadratureRule{dim, T, P <: AbstractVector{Vec{dim, T}}, W <: AbstractVector{<: T}}
+    points::P
+    weights::W
+end
+
+_reference_cell_family(::S) where {S <: Shape} = S
+_reference_cell_family(::Line) = Line
+_reference_cell_family(::Quad) = Quad
+_reference_cell_family(::Hex) = Hex
+_reference_cell_family(::Tri) = Tri
+_reference_cell_family(::Tet) = Tet
+
+_order_value(::Order{p}) where {p} = p
+
+"""
+    generate_quadrature_rule(shape::Shape)
+    generate_quadrature_rule(T, shape::Shape)
+
+Generate the standard [`QuadratureRule`](@ref) for `shape`. For interpolation
+order `p`, the rule integrates degree `2p` in each reference coordinate for
+tensor-product shapes and total degree `2p` for simplex shapes. `T` may be
+`Float16`, `Float32`, or `Float64` and defaults to `Float64`. The selection
+depends only on the interpolation order of `shape`.
+"""
+generate_quadrature_rule(shape::Shape) = generate_quadrature_rule(Float64, shape)
+function generate_quadrature_rule(::Type{T}, shape::Shape) where {T}
+    generate_quadrature_rule(T, _reference_cell_family(shape), 2 * _order_value(get_order(shape)))
+end
+
+"""
+    generate_quadrature_rule(family, exactness)
+    generate_quadrature_rule(T, family, exactness)
+
+Generate a rule for the FEM reference-cell `family` with at least the requested
+polynomial `exactness`. For `Quad` and `Hex`, exactness applies in each
+reference coordinate; for `Tri` and `Tet`, it applies to total degree.
+
+`Line`, `Quad`, and `Hex` accept any nonnegative exactness, `Tri` supports
+exactness from 0 through 6, and `Tet` from 0 through 7. `T` may be `Float16`,
+`Float32`, or `Float64` and defaults to `Float64`.
+"""
+const ReferenceShapeFamily = Union{Line, Quad, Hex, Tri, Tet}
+
+function _check_quadrature_float(::Type{T}) where {T}
+    T in (Float16, Float32, Float64) || throw(ArgumentError("quadrature rule scalar type must be Float16, Float32, or Float64; got $T"))
+    T
+end
+
+generate_quadrature_rule(family::Type{<: ReferenceShapeFamily}, exactness::Int) = generate_quadrature_rule(Float64, family, exactness)
+generate_quadrature_rule(::Type{T}, ::Type{Line}, exactness::Int) where {T} = _generate_tensor_quadrature_rule(_check_quadrature_float(T), Line, exactness, Val(1))
+generate_quadrature_rule(::Type{T}, ::Type{Quad}, exactness::Int) where {T} = _generate_tensor_quadrature_rule(_check_quadrature_float(T), Quad, exactness, Val(2))
+generate_quadrature_rule(::Type{T}, ::Type{Hex}, exactness::Int) where {T} = _generate_tensor_quadrature_rule(_check_quadrature_float(T), Hex, exactness, Val(3))
+generate_quadrature_rule(::Type{T}, ::Type{Tri}, exactness::Int) where {T} = _generate_simplex_quadrature_rule(_check_quadrature_float(T), Tri, exactness)
+generate_quadrature_rule(::Type{T}, ::Type{Tet}, exactness::Int) where {T} = _generate_simplex_quadrature_rule(_check_quadrature_float(T), Tet, exactness)
+
+function _check_quadrature_exactness(family, exactness::Int, maximum::Int)
+    0 ≤ exactness ≤ maximum || throw(ArgumentError("$family quadrature supports exactness from 0 through $maximum; got $exactness"))
+end
+
+function _generate_tensor_quadrature_rule(::Type{T}, family, exactness::Int, ::Val{dim}) where {T, dim}
+    exactness ≥ 0 || throw(ArgumentError("$family quadrature exactness must be nonnegative; got $exactness"))
+    rule1d = _gauss_legendre_rule(T, Val(fld(exactness, 2) + 1))
+    _tensor_product_quadrature_rule(ntuple(_ -> rule1d, Val(dim)))
+end
+
+function _tensor_product_quadrature_rule(rules::Tuple{Vararg{Tuple{<: StaticVector, <: StaticVector}, dim}}) where {dim}
+    qpts1d = map(first, rules)
+    qwts1d = map(last, rules)
+    indices = CartesianIndices(map(length, qpts1d))
+    npoints = length(indices)
+    qpts = SVector{npoints}(map(I -> Vec(map(getindex, qpts1d, Tuple(I))), indices))
+    qwts = SVector{npoints}(map(I -> prod(map(getindex, qwts1d, Tuple(I))), indices))
+    QuadratureRule(qpts, qwts)
+end
+
+function _tensor_product_quadrature_rule(rules::Tuple{Vararg{Any, dim}}) where {dim}
+    qpts1d = map(first, rules)
+    qwts1d = map(last, rules)
+    indices = CartesianIndices(map(length, qpts1d))
+    qpts = vec(map(I -> Vec(map(getindex, qpts1d, Tuple(I))), indices))
+    qwts = vec(map(I -> prod(map(getindex, qwts1d, Tuple(I))), indices))
+    QuadratureRule(qpts, qwts)
+end
+
+_gauss_legendre_rule(::Type{T}, ::Degree{p}) where {T, p} = _gauss_legendre_rule(T, Val(p + 1))
+
+function _gauss_legendre_rule(::Type{T}, ::Val{1}) where {T}
+    SVector{1, T}((0,)), SVector{1, T}((2,))
+end
+function _gauss_legendre_rule(::Type{T}, ::Val{2}) where {T}
+    x = T(0.57735026918962576451)
+    SVector{2, T}((-x, x)), SVector{2, T}((1, 1))
+end
+function _gauss_legendre_rule(::Type{T}, ::Val{3}) where {T}
+    x = T(0.77459666924148337704)
+    w1 = T(0.55555555555555555556)
+    w2 = T(0.88888888888888888889)
+    SVector{3, T}((-x, 0, x)), SVector{3, T}((w1, w2, w1))
+end
+function _gauss_legendre_rule(::Type{T}, ::Val{4}) where {T}
+    x1 = T(0.33998104358485626480)
+    x2 = T(0.86113631159405257522)
+    w1 = T(0.65214515486254614263)
+    w2 = T(0.34785484513745385737)
+    SVector{4, T}((-x2, -x1, x1, x2)), SVector{4, T}((w2, w1, w1, w2))
+end
+function _gauss_legendre_rule(::Type{T}, ::Val{5}) where {T}
+    x1 = T(0.53846931010568309104)
+    x2 = T(0.90617984593866399280)
+    w1 = T(0.47862867049936646804)
+    w2 = T(0.23692688505618908751)
+    w3 = T(0.56888888888888888889)
+    SVector{5, T}((-x2, -x1, 0, x1, x2)), SVector{5, T}((w2, w1, w3, w1, w2))
+end
+function _gauss_legendre_rule(::Type{T}, ::Val{6}) where {T}
+    x1 = T(0.23861918608319690863)
+    x2 = T(0.66120938646626451366)
+    x3 = T(0.93246951420315202781)
+    w1 = T(0.46791393457269104739)
+    w2 = T(0.36076157304813860757)
+    w3 = T(0.17132449237917034504)
+    SVector{6, T}((-x3, -x2, -x1, x1, x2, x3)), SVector{6, T}((w3, w2, w1, w1, w2, w3))
+end
+
+function _gauss_legendre_rule(::Type{T}, ::Val{n}) where {T, n}
+    n ≥ 1 || throw(ArgumentError("Gauss–Legendre quadrature requires at least one point; got $n"))
+    β = [i / sqrt(4i^2 - 1) for i in 1:n-1]
+    decomposition = eigen(SymTridiagonal(zeros(n), β))
+    T.(decomposition.values), T.(2 .* abs2.(decomposition.vectors[1,:]))
+end
+
+# Positive symmetric simplex rules of Witherden and Vincent (2015).
+_simplex_rule_degrees(::Type{Tri}) = (1, 1, 2, 4, 4, 6, 6)
+_simplex_rule_degrees(::Type{Tet}) = (1, 1, 2, 5, 5, 5, 7, 7)
+
+function _generate_simplex_quadrature_rule(::Type{T}, family, exactness::Int) where {T}
+    rule_degrees = _simplex_rule_degrees(family)
+    _check_quadrature_exactness(family, exactness, length(rule_degrees) - 1)
+    _simplex_quadrature_rule(T, family, Val(rule_degrees[exactness + 1]))
+end
+
+@inline _triangle_orbit3(a::T, b::T) where {T} = SVector{3, Vec{2, T}}(((a, a), (a, b), (b, a)))
+@inline _triangle_orbit6(a::T, b::T, c::T) where {T} = SVector{6, Vec{2, T}}(((a, b), (b, a), (a, c), (c, a), (b, c), (c, b)))
+
+function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{1}) where {T}
+    a = T(0.33333333333333333333)
+    w = T(0.50000000000000000000)
+    QuadratureRule(SVector{1, Vec{2, T}}(((a, a),)), SVector{1, T}((w,)))
+end
+
+function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{2}) where {T}
+    a = T(0.16666666666666666667)
+    b = T(0.66666666666666666667)
+    w = T(0.16666666666666666667)
+    QuadratureRule(_triangle_orbit3(a, b), SVector{3, T}((w, w, w)))
+end
+
+function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{4}) where {T}
+    a1 = T(0.44594849091596488632)
+    b1 = T(0.10810301816807022736)
+    w1 = T(0.11169079483900573285)
+    a2 = T(0.09157621350977074346)
+    b2 = T(0.81684757298045851308)
+    w2 = T(0.05497587182766093382)
+    points = SVector{6, Vec{2, T}}((_triangle_orbit3(a1, b1)..., _triangle_orbit3(a2, b2)...))
+    QuadratureRule(points, SVector{6, T}((w1, w1, w1, w2, w2, w2)))
+end
+
+function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{6}) where {T}
+    a1 = T(0.06308901449150222662)
+    b1 = T(0.87382197101699554676)
+    w1 = T(0.02542245318510340940)
+    a2 = T(0.24928674517091042873)
+    b2 = T(0.50142650965817914255)
+    w2 = T(0.05839313786318968413)
+    a3 = T(0.63650249912139866826)
+    b3 = T(0.31035245103378439335)
+    c3 = T(0.05314504984481693839)
+    w3 = T(0.04142553780918678541)
+    points = SVector{12, Vec{2, T}}((_triangle_orbit3(a1, b1)..., _triangle_orbit3(a2, b2)..., _triangle_orbit6(a3, b3, c3)...))
+    weights = SVector{12, T}((w1, w1, w1, w2, w2, w2, w3, w3, w3, w3, w3, w3))
+    QuadratureRule(points, weights)
+end
+
+@inline _tetrahedron_orbit4(a::T, b::T) where {T} = SVector{4, Vec{3, T}}(((a, b, b), (b, a, b), (b, b, a), (b, b, b)))
+@inline _tetrahedron_orbit6(a::T, b::T) where {T} = SVector{6, Vec{3, T}}(((b, b, a), (b, a, a), (a, a, b), (a, b, a), (b, a, b), (a, b, b)))
+@inline _tetrahedron_orbit12(a::T, b::T, c::T) where {T} = SVector{12, Vec{3, T}}(((a, a, b), (a, b, a), (b, a, a), (a, a, c), (a, c, a), (c, a, a), (a, b, c), (a, c, b), (b, c, a), (b, a, c), (c, a, b), (c, b, a)))
+
+function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{1}) where {T}
+    a = T(0.25000000000000000000)
+    w = T(0.16666666666666666667)
+    QuadratureRule(SVector{1, Vec{3, T}}(((a, a, a),)), SVector{1, T}((w,)))
+end
+
+function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{2}) where {T}
+    a = T(0.58541019662496845446)
+    b = T(0.13819660112501051518)
+    w = T(0.04166666666666666667)
+    QuadratureRule(_tetrahedron_orbit4(a, b), SVector{4, T}((w, w, w, w)))
+end
+
+function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{5}) where {T}
+    a1 = T(0.31088591926330060980)
+    b1 = T(0.06734224221009817060)
+    w1 = T(0.01878132095300264180)
+    a2 = T(0.09273525031089122640)
+    b2 = T(0.72179424906732632079)
+    w2 = T(0.01224884051939365826)
+    a3 = T(0.04550370412564964949)
+    b3 = T(0.45449629587435035051)
+    w3 = T(0.00709100346284691107)
+    points = SVector{14, Vec{3, T}}((_tetrahedron_orbit4(b1, a1)..., _tetrahedron_orbit4(b2, a2)..., _tetrahedron_orbit6(a3, b3)...))
+    weights = SVector{14, T}((w1, w1, w1, w1, w2, w2, w2, w2, w3, w3, w3, w3, w3, w3))
+    QuadratureRule(points, weights)
+end
+
+function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{7}) where {T}
+    q = T(0.25000000000000000000)
+    w0 = T(0.01591421491068847546)
+    a1 = T(0.31570114977820279423)
+    b1 = T(0.05289655066539161732)
+    w1 = T(0.00705493020166117132)
+    a2 = T(0.44951017740160364999)
+    b2 = T(0.05048982259839635001)
+    w2 = T(0.00531615463880959638)
+    a3 = T(0.18883383102600115322)
+    b3 = T(0.57517163758699996201)
+    c3 = T(0.04716070036099773155)
+    w3 = T(0.00620118845472243663)
+    a4 = T(0.02126547254148325461)
+    b4 = T(0.81083024109854862083)
+    c4 = T(0.14663881381848486996)
+    w4 = T(0.00135179513831722360)
+    points = SVector{35, Vec{3, T}}(((q, q, q), _tetrahedron_orbit4(b1, a1)..., _tetrahedron_orbit6(a2, b2)..., _tetrahedron_orbit12(a3, b3, c3)..., _tetrahedron_orbit12(a4, b4, c4)...))
+    weights = SVector{35, T}((w0, w1, w1, w1, w1, w2, w2, w2, w2, w2, w2, w3, w3, w3, w3, w3, w3, w3, w3, w3, w3, w3, w3, w4, w4, w4, w4, w4, w4, w4, w4, w4, w4, w4, w4))
+    QuadratureRule(points, weights)
+end

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -3,20 +3,10 @@
 abstract type Shape{dim} end
 
 localnodes(s::Shape) = localnodes(Float64, s)
-quadpoints(s::Shape) = quadpoints(Float64, s)
-quadweights(s::Shape) = quadweights(Float64, s)
 
 nlocalnodes(s::Shape) = length(localnodes(s))
-nquadpoints(s::Shape) = length(quadpoints(s))
 
 get_dimension(::Shape{dim}) where {dim} = dim
-
-struct QuadratureRule{dim, T, P <: AbstractVector{Vec{dim, T}}, W <: AbstractVector{<: T}}
-    points::P
-    weights::W
-end
-
-quadrature_rule(s::Shape) = QuadratureRule(quadpoints(s), quadweights(s))
 
 ########
 # Line #
@@ -56,15 +46,6 @@ function value(::Line2, X::Vec{1, T}) where {T}
     )
 end
 
-function quadpoints(::Type{T}, ::Line2) where {T}
-    SVector{1, Vec{1, T}}((
-        (0,),
-    ))
-end
-function quadweights(::Type{T}, ::Line2) where {T}
-    SVector{1, T}((2,))
-end
-
 """
     Line3()
 
@@ -97,17 +78,6 @@ function value(::Line3, X::Vec{1, T}) where {T}
          0.5 * ξ*(1+ξ),
         1 - ξ^2,
     )
-end
-
-function quadpoints(::Type{T}, ::Line3) where {T}
-    ξ = √3 / 3
-    SVector{2, Vec{1, T}}((
-        (-ξ,),
-        ( ξ,),
-    ))
-end
-function quadweights(::Type{T}, ::Line3) where {T}
-    SVector{2, T}((1, 1))
 end
 
 """
@@ -144,18 +114,6 @@ function value(::Line4, X::Vec{1, T}) where {T}
          1.6875 * (ξ+1)*(ξ-1/3)*(ξ-1),
         -1.6875 * (ξ+1)*(ξ+1/3)*(ξ-1),
     )
-end
-
-function quadpoints(::Type{T}, ::Line4) where {T}
-    ξ = √(3/5)
-    SVector{3, Vec{1, T}}((
-        (-ξ,),
-        ( 0,),
-        ( ξ,),
-    ))
-end
-function quadweights(::Type{T}, ::Line4) where {T}
-    SVector{3, T}((5/9, 8/9, 5/9))
 end
 
 ########
@@ -208,19 +166,6 @@ function value(::Quad4, X::Vec{2, T}) where {T}
     )
 end
 
-function quadpoints(::Type{T}, ::Quad4) where {T}
-    ξ = η = √3 / 3
-    SVector{4, Vec{2, T}}((
-        (-ξ, -η),
-        ( ξ, -η),
-        ( ξ,  η),
-        (-ξ,  η),
-    ))
-end
-function quadweights(::Type{T}, ::Quad4) where {T}
-    SVector{4, T}((1, 1, 1, 1))
-end
-
 """
     Quad8()
 
@@ -271,34 +216,6 @@ function value(::Quad8, X::Vec{2, T}) where {T}
         0.5  * (1-ξ^2) * (1+η),
         0.5  * (1-ξ) * (1-η^2),
     )
-end
-
-function quadpoints(::Type{T}, ::Quad8) where {T}
-    ξ = η = √(3/5)
-    SVector{9, Vec{2, T}}((
-        (-ξ, -η),
-        ( 0, -η),
-        ( ξ, -η),
-        (-ξ,  0),
-        ( 0,  0),
-        ( ξ,  0),
-        (-ξ,  η),
-        ( 0,  η),
-        ( ξ,  η),
-    ))
-end
-function quadweights(::Type{T}, ::Quad8) where {T}
-    SVector{9, T}((
-        5/9 * 5/9,
-        8/9 * 5/9,
-        5/9 * 5/9,
-        5/9 * 8/9,
-        8/9 * 8/9,
-        5/9 * 8/9,
-        5/9 * 5/9,
-        8/9 * 5/9,
-        5/9 * 5/9,
-    ))
 end
 
 """
@@ -354,9 +271,6 @@ function value(::Quad9, X::Vec{2, T}) where {T}
          (1-ξ^2) * (1-η^2),
     )
 end
-
-quadpoints(::Type{T}, ::Quad9) where {T} = quadpoints(T, Quad8())
-quadweights(::Type{T}, ::Quad9) where {T} = quadweights(T, Quad8())
 
 #######
 # Hex #
@@ -416,23 +330,6 @@ function value(::Hex8, X::Vec{3, T}) where {T}
         0.125 * (1+ξ) * (1+η) * (1+ζ),
         0.125 * (1-ξ) * (1+η) * (1+ζ),
     )
-end
-
-function quadpoints(::Type{T}, ::Hex8) where {T}
-    ξ = η = ζ = √3 / 3
-    SVector{8, Vec{3, T}}((
-        (-ξ, -η, -ζ),
-        ( ξ, -η, -ζ),
-        ( ξ,  η, -ζ),
-        (-ξ,  η, -ζ),
-        (-ξ, -η,  ζ),
-        ( ξ, -η,  ζ),
-        ( ξ,  η,  ζ),
-        (-ξ,  η,  ζ),
-    ))
-end
-function quadweights(::Type{T}, ::Hex8) where {T}
-    SVector{8, T}((1, 1, 1, 1, 1, 1, 1, 1))
 end
 
 @doc raw"""
@@ -512,70 +409,6 @@ function value(::Hex20, X::Vec{3, T}) where {T}
         0.25 * (1-η) * (1+η) * (1+ξ) * (1+ζ),
         0.25 * (1-ξ) * (1+ξ) * (1+η) * (1+ζ),
     )
-end
-
-function quadpoints(::Type{T}, ::Hex20) where {T}
-    ξ = η = ζ = √(3/5)
-    SVector{27, Vec{3, T}}((
-        (-ξ, -η, -ζ),
-        ( 0, -η, -ζ),
-        ( ξ, -η, -ζ),
-        (-ξ,  0, -ζ),
-        ( 0,  0, -ζ),
-        ( ξ,  0, -ζ),
-        (-ξ,  η, -ζ),
-        ( 0,  η, -ζ),
-        ( ξ,  η, -ζ),
-        (-ξ, -η,  0),
-        ( 0, -η,  0),
-        ( ξ, -η,  0),
-        (-ξ,  0,  0),
-        ( 0,  0,  0),
-        ( ξ,  0,  0),
-        (-ξ,  η,  0),
-        ( 0,  η,  0),
-        ( ξ,  η,  0),
-        (-ξ, -η,  η),
-        ( 0, -η,  η),
-        ( ξ, -η,  η),
-        (-ξ,  0,  η),
-        ( 0,  0,  η),
-        ( ξ,  0,  η),
-        (-ξ,  η,  η),
-        ( 0,  η,  η),
-        ( ξ,  η,  η),
-    ))
-end
-function quadweights(::Type{T}, ::Hex20) where {T}
-    SVector{27, T}((
-        5/9 * 5/9 * 5/9,
-        8/9 * 5/9 * 5/9,
-        5/9 * 5/9 * 5/9,
-        5/9 * 8/9 * 5/9,
-        8/9 * 8/9 * 5/9,
-        5/9 * 8/9 * 5/9,
-        5/9 * 5/9 * 5/9,
-        8/9 * 5/9 * 5/9,
-        5/9 * 5/9 * 5/9,
-        5/9 * 5/9 * 8/9,
-        8/9 * 5/9 * 8/9,
-        5/9 * 5/9 * 8/9,
-        5/9 * 8/9 * 8/9,
-        8/9 * 8/9 * 8/9,
-        5/9 * 8/9 * 8/9,
-        5/9 * 5/9 * 8/9,
-        8/9 * 5/9 * 8/9,
-        5/9 * 5/9 * 8/9,
-        5/9 * 5/9 * 5/9,
-        8/9 * 5/9 * 5/9,
-        5/9 * 5/9 * 5/9,
-        5/9 * 8/9 * 5/9,
-        8/9 * 8/9 * 5/9,
-        5/9 * 8/9 * 5/9,
-        5/9 * 5/9 * 5/9,
-        8/9 * 5/9 * 5/9,
-        5/9 * 5/9 * 5/9,
-    ))
 end
 
 @doc raw"""
@@ -671,9 +504,6 @@ function value(::Hex27, X::Vec{3, T}) where {T}
     )
 end
 
-quadpoints(::Type{T}, ::Hex27) where {T} = quadpoints(T, Hex20())
-quadweights(::Type{T}, ::Hex27) where {T} = quadweights(T, Hex20())
-
 #######
 # Tri #
 #######
@@ -716,15 +546,6 @@ end
 function value(::Tri3, X::Vec{2, T}) where {T}
     ξ, η = X
     SVector{3, T}(1-ξ-η, ξ, η)
-end
-
-function quadpoints(::Type{T}, ::Tri3) where {T}
-    SVector{1, Vec{2, T}}((
-        (1/3, 1/3),
-    ))
-end
-function quadweights(::Type{T}, ::Tri3) where {T}
-    SVector{1, T}((0.5,))
 end
 
 @doc raw"""
@@ -774,17 +595,6 @@ function value(::Tri6, X::Vec{2, T}) where {T}
         4ζ * η,
         4ξ * η,
     )
-end
-
-function quadpoints(::Type{T}, ::Tri6) where {T}
-    SVector{3, Vec{2, T}}((
-        (1/6, 1/6),
-        (2/3, 1/6),
-        (1/6, 2/3),
-    ))
-end
-function quadweights(::Type{T}, ::Tri6) where {T}
-    SVector{3, T}((1/6, 1/6, 1/6))
 end
 
 #######
@@ -839,15 +649,6 @@ function value(::Tet4, X::Vec{3, T}) where {T}
     ξ, η, ζ = X
     χ = 1 - ξ - η - ζ
     SVector{4, T}(χ, ξ, η, ζ)
-end
-
-function quadpoints(::Type{T}, ::Tet4) where {T}
-    SVector{1, Vec{3, T}}((
-        (1/4, 1/4, 1/4),
-    ))
-end
-function quadweights(::Type{T}, ::Tet4) where {T}
-    SVector{1, T}((1/6,))
 end
 
 @doc raw"""
@@ -913,16 +714,4 @@ function value(::Tet10, X::Vec{3, T}) where {T}
         4η * ζ,
         4ξ * ζ,
     )
-end
-
-function quadpoints(::Type{T}, ::Tet10) where {T}
-    SVector{4, Vec{3, T}}((
-        (1/4 -  √5/20, 1/4 -  √5/20, 1/4 -  √5/20),
-        (1/4 + 3√5/20, 1/4 -  √5/20, 1/4 -  √5/20),
-        (1/4 -  √5/20, 1/4 + 3√5/20, 1/4 -  √5/20),
-        (1/4 -  √5/20, 1/4 -  √5/20, 1/4 + 3√5/20),
-    ))
-end
-function quadweights(::Type{T}, ::Tet10) where {T}
-    SVector{4, T}((1/24, 1/24, 1/24, 1/24))
 end

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -16,7 +16,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
     mesh = IGAMesh(cmesh; degree=Quadratic())
     meshcells = collect(cells(mesh))
     basis = @inferred Tesserae.igabasis(mesh)
-    qrule = Tesserae.quadrature_rule(basis)
+    qrule = generate_quadrature_rule(basis)
     patch = Tesserae.patches(mesh, 1)
     span = first(meshcells).span
     ξ = Tesserae.span_point(patch, span, first(qrule.points))
@@ -127,22 +127,18 @@ const nurbs_cubic = Tesserae.NURBS.cubic
 
     @testset "Quadrature" begin
         # For degree p, IGA uses p+1 Gauss points per parametric direction.
-        @test length(Tesserae.quadrature_rule(IGABasis((Linear(), Linear()))).points) == 4
+        @test length(generate_quadrature_rule(IGABasis((Constant(),))).points) == 1
         @test length(qrule.points) == 9
-        @test length(Tesserae.quadrature_rule(IGABasis((Cubic(), Cubic()))).points) == 16
-        @test length(Tesserae.quadrature_rule(IGABasis((Tesserae.Quartic(), Tesserae.Quartic()))).points) == 25
-        @test length(Tesserae.quadrature_rule(IGABasis((Tesserae.Quintic(), Tesserae.Quintic()))).points) == 36
         @test sum(qrule.weights) ≈ 4
-
-        for (degree, n) in ((Linear(), 2), (Quadratic(), 3), (Cubic(), 4), (Tesserae.Quartic(), 5), (Tesserae.Quintic(), 6))
-            qpts, qwts = @inferred Tesserae.gauss_legendre_rule(Float64, degree)
-            @test length(qpts) == n
-            @test sum(qwts) ≈ 2
-            for k in 0:(2n-1)
-                exact = iseven(k) ? 2 / (k + 1) : 0
-                @test isapprox(sum(qwts .* qpts .^ k), exact; atol=1e-14, rtol=1e-14)
-            end
-        end
+        high_order_rule = @inferred generate_quadrature_rule(Float32, IGABasis((Tesserae.Degree(6), Quadratic())))
+        @test length(high_order_rule.points) == 21
+        @test eltype(high_order_rule.weights) === Float32
+        @test sum(high_order_rule.weights) ≈ 4
+        @test_throws ArgumentError generate_quadrature_rule(BigFloat, basis)
+        anisotropic_rule = @inferred generate_quadrature_rule(IGABasis((Linear(), Quadratic())))
+        @test length(anisotropic_rule.points) == 6
+        @test sum(anisotropic_rule.weights) ≈ 4
+        @test length(generate_quadrature_rule(IGABasis((Tesserae.Quintic(),))).points) == 6
 
         # Parent Gauss points are mapped from [-1,1]^dim to each knot span.
         α = √(3/5)
@@ -279,7 +275,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         boundary_patch = IGAPatch((Quadratic(),), (copy(iga_test_knot_vectors(patch)[1]),), Array(patch.controlpoint_ids[:,1]))
         boundary_mesh = IGAMesh([boundary_patch], mesh.controlpoints)
         @test supportnodes(boundary_mesh) == collect(patch.controlpoint_ids[:,1])
-        boundary_rule = Tesserae.quadrature_rule(Tesserae.igabasis(boundary_mesh))
+        boundary_rule = generate_quadrature_rule(Tesserae.igabasis(boundary_mesh))
         boundary_weights = generate_basis_weights(boundary_mesh, length(boundary_rule.points), Tesserae.ncells(boundary_mesh); name=Val(:N))
         measure = zeros(Float64, size(boundary_weights))
         normal = zeros(Vec{2, Float64}, size(boundary_weights))

--- a/test/shapes.jl
+++ b/test/shapes.jl
@@ -39,7 +39,57 @@
                 @test sum(values) ≈ 1
                 @test all(j -> j == i || values[j] ≈ 0, eachindex(values))
             end
-            @test sum(Tesserae.quadweights(shape)) ≈ reference_measure(shape)
+            rule = generate_quadrature_rule(shape)
+            @test sum(rule.weights) ≈ reference_measure(shape)
+        end
+    end
+
+    @testset "quadrature exactness" begin
+        integrate(rule, powers) = sum(w * prod(xᵢ^p for (xᵢ, p) in zip(x, powers)) for (x, w) in zip(rule.points, rule.weights))
+
+        for T in (Float16, Float32, Float64)
+            typed_rule = generate_quadrature_rule(T, Tesserae.Quad, 4)
+            @test eltype(first(typed_rule.points)) === T
+            @test eltype(typed_rule.weights) === T
+        end
+        @test eltype(generate_quadrature_rule(Float32, Tesserae.Quad9()).weights) === Float32
+        @test eltype(generate_quadrature_rule(Tesserae.Quad, 4).weights) === Float64
+        @test_throws ArgumentError generate_quadrature_rule(BigFloat, Tesserae.Quad, 4)
+
+        @test isapprox(integrate(generate_quadrature_rule(Tesserae.Line, 11), (10,)), 2/11; atol=1e-14)
+        @test isapprox(integrate(generate_quadrature_rule(Tesserae.Line, 12), (12,)), 2/13; atol=1e-14)
+        @test isapprox(integrate(generate_quadrature_rule(Tesserae.Quad, 4), (4, 4)), (2/5)^2; atol=1e-14)
+        @test isapprox(integrate(generate_quadrature_rule(Tesserae.Hex, 4), (4, 4, 4)), (2/5)^3; atol=1e-14)
+        @test isapprox(integrate(generate_quadrature_rule(Tesserae.Tri, 4), (2, 2)), 1/180; atol=1e-14)
+        @test isapprox(integrate(generate_quadrature_rule(Tesserae.Tri, 6), (3, 3)), 1/1120; atol=1e-14)
+        @test isapprox(integrate(generate_quadrature_rule(Tesserae.Tet, 5), (3, 1, 1)), 1/6720; atol=1e-14)
+        @test isapprox(integrate(generate_quadrature_rule(Tesserae.Tet, 7), (3, 2, 2)), 1/151200; atol=1e-14)
+
+        @test_throws ArgumentError generate_quadrature_rule(Tesserae.Line, -1)
+        @test_throws ArgumentError generate_quadrature_rule(Tesserae.Tri, 7)
+        @test_throws ArgumentError generate_quadrature_rule(Tesserae.Tet, 8)
+    end
+
+    @testset "shape quadrature" begin
+        standard_rules = (
+            (Tesserae.Line2(), 2), (Tesserae.Line3(), 3), (Tesserae.Line4(), 4),
+            (Tesserae.Quad4(), 4), (Tesserae.Quad8(), 9), (Tesserae.Quad9(), 9),
+            (Tesserae.Hex8(), 8), (Tesserae.Hex20(), 27), (Tesserae.Hex27(), 27),
+            (Tesserae.Tri3(), 3), (Tesserae.Tri6(), 6),
+            (Tesserae.Tet4(), 4), (Tesserae.Tet10(), 14),
+        )
+
+        for (shape, npoints) in standard_rules
+            rule = generate_quadrature_rule(shape)
+            @test length(rule.points) == npoints
+
+            n = Tesserae.nlocalnodes(shape)
+            mass = zeros(n, n)
+            for (point, weight) in zip(rule.points, rule.weights)
+                values = Tesserae.value(shape, point)
+                mass .+= weight .* (values * values')
+            end
+            @test rank(mass) == n
         end
     end
 end


### PR DESCRIPTION
Centralizes FEM and IGA quadrature rules behind `generate_quadrature_rule`.

Adds selectable floating-point output types, generated higher-order tensor-product rules, and degree-six triangle and degree-seven tetrahedron rules.