### PR TITLE
Support mixed finite element fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@ macros.
   was removed. Pass a `ThreadPartition` instead. (#137)
 - `CPDI` on `SpGrid` is now rejected explicitly; use a dense grid for CPDI.
   (#130)
-- `feupdate!` now uses a single `measure` output keyword for domain and boundary
-  integration. The old `volume` and `area` output keywords were removed. (#147)
+- `feupdate!` has been removed. Use
+  `update!(weights, points, geometry; measure=nothing, normal=nothing)` instead;
+  `points` carries the quadrature rule.
 - The finite-element mesh type has been renamed from `UnstructuredMesh` to
   `FEMesh`; the old name is no longer available. (#156)
 

--- a/docs/literate/tutorials/heat.jl
+++ b/docs/literate/tutorials/heat.jl
@@ -32,7 +32,7 @@ function main()
 
     ## Basis weights
     weights = generate_basis_weights(mesh, size(points); name=Val(:N))
-    feupdate!(weights, mesh; measure=points.V) # Use `feupdate!` instead of `update!`
+    update!(weights, points, mesh; measure=points.V)
 
     ## Global matrix
     ndofs = 1 # Degrees of freedom per node

--- a/docs/src/fem.md
+++ b/docs/src/fem.md
@@ -2,7 +2,7 @@
 
 This page solves a scalar Poisson problem. The key convention is that
 finite-element quadrature points are stored in the particle array:
-after [`feupdate!`](@ref) fills the quadrature weights and basis data, the same
+after `update!` fills the physical quadrature measures and basis data, the same
 [`@P2G`](@ref) and [`@P2G_Matrix`](@ref) macros used for MPM assemble
 finite-element vectors and matrices.
 
@@ -11,7 +11,7 @@ For quadrature point `q` in cell `c`, define a particle `p` by
 ```math
 \bm{x}_p = \bm{x}_c(\bm{\xi}_q),
 \qquad
-V_p = \omega_q \det \bm{J}_c(\bm{\xi}_q).
+V_p = \omega_q \left|\det \bm{J}_c(\bm{\xi}_q)\right|.
 ```
 
 Then a particle sum is the usual FEM quadrature rule:
@@ -21,7 +21,7 @@ Then a particle sum is the usual FEM quadrature rule:
 =
 \sum_c \sum_q
 f(\bm{x}_c(\bm{\xi}_q))
-\omega_q \det \bm{J}_c(\bm{\xi}_q).
+\omega_q \left|\det \bm{J}_c(\bm{\xi}_q)\right|.
 ```
 
 The particle arrays in this page store fixed Gauss points, not moving MPM
@@ -187,11 +187,11 @@ grid = generate_grid(GridProp, domain)
 gauss_points = generate_particles(GaussProp, domain)
 weights = generate_basis_weights(domain, size(gauss_points); name=Val(:N))
 
-feupdate!(weights, domain; measure=gauss_points.V)
+update!(weights, gauss_points, domain; measure=gauss_points.V)
 ```
 
 The basis-weight array has the same `nq × ncells` shape as `gauss_points`.
-After [`feupdate!`](@ref), each entry stores the element-local basis data for
+After `update!`, each entry stores the element-local basis data for
 one Gauss point: `N[ip]` and `∇N[ip]` are the value and physical gradient of
 the basis function associated with local support index `ip`, and `V[p]` is the
 quadrature weight multiplied by the Jacobian measure. This is the same
@@ -243,8 +243,9 @@ end
 hole_gauss_points = generate_particles(BoundaryGaussProp, hole_boundary)
 hole_weights = generate_basis_weights(hole_boundary, size(hole_gauss_points); name=Val(:N))
 
-feupdate!(
+update!(
     hole_weights,
+    hole_gauss_points,
     hole_boundary;
     measure=hole_gauss_points.dS,
     normal=hole_gauss_points.n,
@@ -350,6 +351,6 @@ plot_solution(domain, grid.u, outer_boundary, hole_boundary)
 ```@docs
 FEMesh
 supportnodes(::FEMesh)
-feupdate!
+update!(::BasisWeightArray{S}, ::QuadraturePoints, ::FEMesh{<:Tesserae.Shape{pdim},dim}) where {pdim,dim,S<:Tesserae.Shape{pdim}}
 readmsh
 ```

--- a/docs/src/generation.md
+++ b/docs/src/generation.md
@@ -9,7 +9,7 @@ The first field is reserved for position: grid positions are backed by the mesh 
 
 ```@docs
 generate_grid
-generate_particles
+generate_particles(::Type, ::CartesianMesh)
 GridSampling
 PoissonDiskSampling
 ```

--- a/docs/src/iga.md
+++ b/docs/src/iga.md
@@ -5,8 +5,8 @@
 
 This page solves a scalar heat-conduction problem on a NURBS patch. The
 assembly flow is the same as in [Finite element calculations](fem.md):
-quadrature points are stored in the particle array, [`feupdate!`](@ref) fills
-the basis values and quadrature weights, and [`@P2G_Matrix`](@ref) assembles
+quadrature points are stored in the particle array, `update!` fills the basis
+values and physical quadrature measures, and [`@P2G_Matrix`](@ref) assembles
 the global matrix.
 
 The difference is the geometric and discrete basis. An [`IGAMesh`](@ref) uses
@@ -270,10 +270,10 @@ grid = generate_grid(GridProp, mesh)
 gauss_points = generate_particles(GaussProp, mesh)
 weights = generate_basis_weights(mesh, size(gauss_points); name=Val(:N))
 
-feupdate!(weights, mesh; measure=gauss_points.V)
+update!(weights, gauss_points, mesh; measure=gauss_points.V)
 ```
 
-After [`feupdate!`](@ref), `N[ip]` and `∇N[ip]` are the rational basis value
+After `update!`, `N[ip]` and `∇N[ip]` are the rational basis value
 and physical gradient associated with local support index `ip`. The value
 `V[p]` is the quadrature weight multiplied by the physical Jacobian measure.
 
@@ -403,6 +403,7 @@ IGAPatch
 IGAMesh
 IGABasis
 boundaries
+update!(::BasisWeightArray{B}, ::QuadraturePoints, ::IGAMesh{dim,pdim}) where {dim,pdim,B<:IGABasis{pdim}}
 ```
 
 ### NURBS

--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -280,12 +280,25 @@ function BasisWeightArray(basis::B, vals::Vals, indices::Indices) where {B, Vals
 end
 
 # AbstractMesh
-function _generate_basis_weights(::Type{T}, basis, mesh::AbstractMesh{dim}, dims::Dims{N}; kwargs...) where {T, dim, N}
+function _generate_basis_weights(::Type{T}, basis, mesh::AbstractMesh{dim}, dims::Dims; kwargs...) where {T, dim}
     vals = map(allocate_basis_values(Vec{dim, T}, basis; kwargs...)) do vals
         fill(zero(eltype(vals)), size(vals)..., dims...)
     end
-    indices = map(p->initial_supportnodes(basis, mesh), CartesianIndices(dims))
+    indices = _generate_supportnodes(basis, mesh, dims)
     BasisWeightArray(basis, vals, indices)
+end
+
+# CartesianMesh
+_generate_supportnodes(basis, mesh::CartesianMesh, dims) = map(_ -> initial_supportnodes(basis, mesh), CartesianIndices(dims))
+
+# FEMesh
+_generate_supportnodes(::Shape, mesh::FEMesh, dims::Dims{2}) = _generate_cell_supportnodes(mesh, dims)
+_generate_supportnodes(::Shape, ::FEMesh, ::Dims) = throw(DimensionMismatch("FEM basis weights must have dimensions (quadrature points, cells)"))
+
+function _generate_cell_supportnodes(mesh, dims::Dims{2})
+    dims[2] == ncells(mesh) || throw(DimensionMismatch("the second basis-weight dimension must equal the number of cells"))
+    cell_supports = map(cell -> supportnodes(mesh, cell), cells(mesh))
+    map(I -> cell_supports[I[2]], CartesianIndices(dims))
 end
 
 _todims(x::Tuple{Vararg{Int}}) = x

--- a/src/Basis/iga.jl
+++ b/src/Basis/iga.jl
@@ -13,6 +13,9 @@ nsupportnodes(basis::IGABasis) = prod(degree -> _degree(degree) + 1, degrees(bas
 
 initial_supportnodes(basis::IGABasis, mesh::IGAMesh) = zero(SVector{nsupportnodes(basis), Int})
 
+_generate_supportnodes(::IGABasis, mesh::IGAMesh, dims::Dims{2}) = _generate_cell_supportnodes(mesh, dims)
+_generate_supportnodes(::IGABasis, ::IGAMesh, ::Dims) = throw(DimensionMismatch("IGA basis weights must have dimensions (quadrature points, cells)"))
+
 function allocate_static_basis_values(::Type{Vec{dim, T}}, basis::IGABasis; kwargs...) where {dim, T}
     A = MArray{Tuple{nsupportnodes(basis)}}
     _allocate_basis_values(A, Vec{dim, T}; kwargs...)
@@ -33,7 +36,7 @@ generate_quadrature_rule(basis::IGABasis) = generate_quadrature_rule(Float64, ba
 function generate_quadrature_rule(::Type{T}, basis::IGABasis{dim}) where {T, dim}
     _check_quadrature_float(T)
     rules = map(degree -> _gauss_legendre_rule(T, degree), degrees(basis))
-    _tensor_product_quadrature_rule(rules)
+    _tensor_product_quadrature_rule(_tensor_product_family(Val(dim)), rules)
 end
 
 # Map parent Gauss points from [-1, 1]^dim to the selected knot span.

--- a/src/Tesserae.jl
+++ b/src/Tesserae.jl
@@ -65,8 +65,10 @@ export
     spacing,
 # Quadrature
     generate_quadrature_rule,
+    quadrature_rule,
 # Particles
     generate_particles,
+    QuadraturePoints,
     reorder_particles!,
     GridSampling,
     PoissonDiskSampling,
@@ -95,7 +97,6 @@ export
     BasisWeight,
     BasisWeightArray,
     InterpolationWeight,
-    feupdate!,
 # transfer
     @P2G,
     @G2P,

--- a/src/fem.jl
+++ b/src/fem.jl
@@ -7,149 +7,116 @@ end
 end
 
 """
-    feupdate!(weights, mesh[, nodes]; measure=nothing, quadrature_rule=generate_quadrature_rule(cellshape(mesh)))
-    feupdate!(weights, boundary_mesh[, nodes]; measure=nothing, normal=nothing, quadrature_rule=generate_quadrature_rule(cellshape(boundary_mesh)))
+    update!(weights::BasisWeightArray{<:Shape}, points::QuadraturePoints, geometry::FEMesh; measure=nothing, normal=nothing)
 
-Fill finite-element basis data at quadrature points.
+Evaluate the FEM field basis stored by `weights` at the reference points in
+`quadrature_rule(points)`. `geometry` supplies the mapping to physical space.
+The field and geometry may use different shapes from the same reference-cell
+family, provided that they describe the same cells in the same order and
+orientation.
 
-`weights` is usually created by [`generate_basis_weights`](@ref) with dimensions
-matching the number of quadrature points per cell and the number of cells in
-`mesh`. For a domain mesh, `feupdate!` stores the basis values and physical
-gradients in each [`BasisWeight`](@ref). If `measure` is provided, it is filled
-with the quadrature weight multiplied by the Jacobian measure, such as `dV` in
-3D or `dA` in 2D.
-
-For a lower-dimensional boundary mesh, `feupdate!` stores basis values for
-boundary integration. If `normal` is provided, it is filled with unit normals
-computed from the boundary Jacobian. Normals are available for 2D curves and 3D
-surfaces; a 3D line has no unique normal and throws an `ArgumentError`.
-
-Pass `nodes` to evaluate the geometry on coordinates different from `mesh`
-itself, for example when assembling on a deformed configuration.
-
-# Example
-```julia
-mesh = FEMesh(CartesianMesh(0.1, (-1, 1), (-1, 1)))
-points = generate_particles(@NamedTuple{x::Vec{2, Float64}, V::Float64}, mesh)
-weights = generate_basis_weights(mesh, size(points); name=Val(:N))
-
-feupdate!(weights, mesh; measure=points.V)
-```
-
-After the update, `N[ip]` and `∇N[ip]` can be used inside transfer macros such
-as [`@P2G`](@ref) and [`@P2G_Matrix`](@ref) to assemble FEM vectors and
-matrices.
+For full-dimensional cells, `weights` stores basis values and physical
+gradients. For boundary cells, it stores basis values. `measure` receives the
+physical quadrature measure, and `normal` receives boundary unit normals.
 """
-function feupdate!(
-        weights::AbstractArray{<: BasisWeight{S}}, mesh::FEMesh{S, dim},
-        nodes::AbstractArray{<: Vec{dim}} = mesh;
-        measure::Union{Nothing, AbstractArray} = nothing,
-        quadrature_rule::QuadratureRule = generate_quadrature_rule(cellshape(mesh)),
-    ) where {dim, S <: Shape{dim}}
-    qpts, qwts = quadrature_rule.points, quadrature_rule.weights
-    qdata = jet.(Ref(Order(1)), Ref(cellshape(mesh)), qpts)
-    _feupdate!(Val(:domain), weights, mesh, nodes, measure, nothing, qdata, qwts)
-end
+function update!(
+        weights::BasisWeightArray{S}, points::QuadraturePoints,
+        geometry::FEMesh{<: Shape{pdim}, dim};
+        measure::Union{Nothing, AbstractArray}=nothing,
+        normal::Union{Nothing, AbstractArray}=nothing,
+    ) where {pdim, dim, S <: Shape{pdim}}
+    _reference_cell_family(basis(weights)) === _reference_cell_family(cellshape(geometry)) || throw(ArgumentError("field and geometry must use the same reference-cell family"))
+    is_domain = pdim == dim
+    mode = pdim == dim ? Val(:domain) : Val(:boundary)
+    rule = _check_quadrature_inputs(is_domain, weights, points, geometry, measure, normal)
 
-function feupdate!(
-        weights::AbstractArray{<: BasisWeight{<: IGABasis}}, mesh::IGAMesh{dim, dim, T},
-        nodes::AbstractArray{<: Vec{dim}} = mesh;
-        measure::Union{Nothing, AbstractArray} = nothing,
-        quadrature_rule::QuadratureRule = generate_quadrature_rule(igabasis(mesh)),
-    ) where {dim, T}
-    qpts, qwts = quadrature_rule.points, quadrature_rule.weights
-    _feupdate!(Val(:domain), weights, mesh, nodes, measure, nothing, qpts, qwts)
-end
-
-@inline _basis_values_and_gradients(mesh::FEMesh, qdata, cell, indices, p) = qdata[p]
-@inline _quadrature_weight(mesh::FEMesh, qdata, qwts, cell, p) = qwts[p]
-@inline function _basis_values_and_gradients(mesh::IGAMesh, qdata, cell, indices, p)
-    patch = patches(mesh, cell.patch)
-    ξ = span_point(patch, cell.span, qdata[p])
-    N, dN = iga_basis_values_and_gradients(patch, cell.span, ξ)
-    _rationalize_basis(N, dN, mesh.weights, indices)
-end
-@inline _rationalize_basis(N, dN, ::Nothing, indices) = N, dN
-@inline _rationalize_basis(N, dN, weights::AbstractVector, indices) = rational_basis_values_and_gradients(N, dN, weights[indices])
-@inline function _quadrature_weight(mesh::IGAMesh, qdata, qwts, cell, p)
-    patch = patches(mesh, cell.patch)
-    span_weight(patch, cell.span, qwts[p])
-end
-
-function _feupdate!(mode, weights, mesh::AbstractMesh, nodes, measure, normal, qdata, qwts)
-    @assert length(qdata) == length(qwts)
-    @assert size(mesh) == size(nodes)
-    @assert size(weights) == (length(qdata), ncells(mesh))
-    _check_feupdate_outputs(mode, weights, measure, normal)
-    for cell in cells(mesh)
-        indices = supportnodes(mesh, cell)
-        x = nodes[indices]
-        for p in eachindex(qdata, qwts)
-            N, dNdξ = _basis_values_and_gradients(mesh, qdata, cell, indices, p)
-            J = sum(x .⊗ dNdξ)
-            qwt = _quadrature_weight(mesh, qdata, qwts, cell, p)
-            bw = weights[p,cell]
-            _set_feupdate_values!(mode, bw, N, dNdξ, J)
-            supportnodes_storage(bw)[] = indices
-            _set_feupdate_outputs!(mode, measure, normal, p, cell, qwt, J)
+    field_shape = basis(weights)
+    geometry_shape = cellshape(geometry)
+    field_qdata = jet.(Ref(Order(1)), Ref(field_shape), rule.points)
+    geometry_qdata = field_shape === geometry_shape ? field_qdata : jet.(Ref(Order(1)), Ref(geometry_shape), rule.points)
+    for cell in cells(geometry)
+        geometry_indices = supportnodes(geometry, cell)
+        x = geometry[geometry_indices]
+        for q in eachindex(field_qdata, rule.weights)
+            N, dNdξ = field_qdata[q]
+            J = sum(x .⊗ last(geometry_qdata[q]))
+            _set_quadrature_data!(mode, weights[q,cell], measure, normal, q, cell, N, dNdξ, J, rule.weights[q])
         end
+    end
+    weights
+end
+
+"""
+    update!(weights::BasisWeightArray{<:IGABasis}, points::QuadraturePoints, geometry::IGAMesh; measure=nothing, normal=nothing)
+
+Evaluate the IGA basis of `geometry` at the reference points in
+`quadrature_rule(points)` and store the result in `weights`. `measure` and
+`normal` have the same roles as in the FEM method.
+"""
+function update!(
+        weights::BasisWeightArray{B}, points::QuadraturePoints,
+        geometry::IGAMesh{dim, pdim};
+        measure::Union{Nothing, AbstractArray}=nothing,
+        normal::Union{Nothing, AbstractArray}=nothing,
+    ) where {dim, pdim, B <: IGABasis{pdim}}
+    degrees(basis(weights)) == degrees(igabasis(geometry)) || throw(ArgumentError("IGA field and geometry degrees must match"))
+    is_domain = pdim == dim
+    mode = pdim == dim ? Val(:domain) : Val(:boundary)
+    rule = _check_quadrature_inputs(is_domain, weights, points, geometry, measure, normal)
+
+    for cell in cells(geometry)
+        indices = supportnodes(geometry, cell)
+        supportnodes(weights[1,cell]) == indices || throw(ArgumentError("IGA basis weights and geometry must use the same cell connectivity"))
+        x = geometry[indices]
+        patch = patches(geometry, cell.patch)
+        for q in eachindex(rule.points, rule.weights)
+            ξ = span_point(patch, cell.span, rule.points[q])
+            N, dNdξ = iga_basis_values_and_gradients(patch, cell.span, ξ)
+            if geometry.weights !== nothing
+                N, dNdξ = rational_basis_values_and_gradients(N, dNdξ, geometry.weights[indices])
+            end
+            J = sum(x .⊗ dNdξ)
+            weight = span_weight(patch, cell.span, rule.weights[q])
+            _set_quadrature_data!(mode, weights[q,cell], measure, normal, q, cell, N, dNdξ, J, weight)
+        end
+    end
+    weights
+end
+
+function _check_quadrature_inputs(is_domain, weights, points, geometry, measure, normal)
+    rule = quadrature_rule(points)
+    _check_quadrature_rule(rule, geometry)
+    size(weights) == size(points) || throw(DimensionMismatch("basis weights and quadrature points must have the same dimensions"))
+    size(points) == (length(rule.points), ncells(geometry)) || throw(DimensionMismatch("quadrature points must have dimensions (rule points, geometry cells)"))
+    isnothing(measure) || size(weights) == size(measure) || throw(DimensionMismatch("measure and basis weights must have the same dimensions"))
+    is_domain && !isnothing(normal) && throw(ArgumentError("normal is only valid for boundary integration"))
+    isnothing(normal) || size(weights) == size(normal) || throw(DimensionMismatch("normal and basis weights must have the same dimensions"))
+    if is_domain && !isempty(weights)
+        bw = first(weights)
+        derivative_order(bw) isa Order{0} && throw(ArgumentError("domain basis weights must store first derivatives"))
+        length(eltype(nodal_basis_values(bw, Order(1)))) == length(eltype(geometry)) || throw(DimensionMismatch("basis-gradient and geometry dimensions must match"))
+    end
+    rule
+end
+
+@inline function _set_quadrature_data!(::Val{:domain}, bw, measure, normal, q, cell, N, dNdξ, J, weight)
+    set_values!(bw, (N, dNdξ .⊡ Ref(inv(J))))
+    if measure !== nothing
+        measure[q,cell] = weight * sqrt(det(J'J))
     end
 end
 
-function _check_feupdate_outputs(::Val{:domain}, weights, measure, normal)
-    @assert isnothing(measure) || size(weights) == size(measure)
-    @assert isnothing(normal)
+@inline function _set_quadrature_data!(::Val{:boundary}, bw, measure, normal, q, cell, N, dNdξ, J, weight)
+    set_values!(bw, (N,))
+    if measure !== nothing
+        measure[q,cell] = weight * sqrt(det(J'J))
+    end
+    if normal !== nothing
+        n = _get_normal(J)
+        normal[q,cell] = n / norm(n)
+    end
 end
-function _check_feupdate_outputs(::Val{:boundary}, weights, measure, normal)
-    @assert isnothing(measure) || size(weights) == size(measure)
-    @assert isnothing(normal) || size(weights) == size(normal)
-end
-
-# This is dL, dA, or dV depending on the parametric dimension of the element.
-@inline _jacobian_measure(qwt, J) = qwt * sqrt(det(J'J))
-
-# Domain cells have a square Jacobian, so gradients can be mapped to physical coordinates.
-@inline _set_feupdate_values!(::Val{:domain}, bw, N, dNdξ, J) = set_values!(bw, (N, dNdξ .⊡ Ref(inv(J))))
-# Boundary cells only need basis values for line/surface integration.
-@inline _set_feupdate_values!(::Val{:boundary}, bw, N, dNdξ, J) = set_values!(bw, (N,))
 
 _get_normal(J::Mat{3,2}) = J[:,1] × J[:,2]
 _get_normal(J::Mat{2,1}) = Vec(J[2,1], -J[1,1])
 _get_normal(J::Mat{3,1}) = throw(ArgumentError("normal is not defined for a 3D line element"))
-
-@inline function _set_feupdate_outputs!(::Val{:domain}, measure, normal, p, cell, qwt, J)
-    if measure !== nothing
-        measure[p,cell] = _jacobian_measure(qwt, J)
-    end
-end
-@inline function _set_feupdate_outputs!(::Val{:boundary}, measure, normal, p, cell, qwt, J)
-    if measure !== nothing
-        measure[p,cell] = _jacobian_measure(qwt, J)
-    end
-    if normal !== nothing
-        n = _get_normal(J)
-        n_norm = norm(n)
-        normal[p,cell] = n / n_norm
-    end
-end
-
-function feupdate!(
-        weights::AbstractArray{<: BasisWeight{S}}, mesh::FEMesh{S, dim},
-        nodes::AbstractArray{<: Vec{dim}} = mesh;
-        measure::Union{Nothing, AbstractArray} = nothing, normal::Union{Nothing, AbstractArray} = nothing,
-        quadrature_rule::QuadratureRule = generate_quadrature_rule(cellshape(mesh)),
-    ) where {S <: Shape, dim}
-    qpts, qwts = quadrature_rule.points, quadrature_rule.weights
-    qdata = jet.(Ref(Order(1)), Ref(cellshape(mesh)), qpts)
-    _feupdate!(Val(:boundary), weights, mesh, nodes, measure, normal, qdata, qwts)
-end
-
-function feupdate!(
-        weights::AbstractArray{<: BasisWeight{<: IGABasis}}, mesh::IGAMesh{dim, pdim, T},
-        nodes::AbstractArray{<: Vec{dim}} = mesh;
-        measure::Union{Nothing, AbstractArray} = nothing, normal::Union{Nothing, AbstractArray} = nothing,
-        quadrature_rule::QuadratureRule = generate_quadrature_rule(igabasis(mesh)),
-    ) where {dim, T, pdim}
-    qpts, qwts = quadrature_rule.points, quadrature_rule.weights
-    _feupdate!(Val(:boundary), weights, mesh, nodes, measure, normal, qpts, qwts)
-end

--- a/src/femesh.jl
+++ b/src/femesh.jl
@@ -17,9 +17,9 @@ shape for the dimension: `Line2`, `Quad4`, or `Hex8`. Passing an explicit
 from the Cartesian grid.
 
 `FEMesh` is used by the finite-element workflow. Use
-[`generate_particles`](@ref) to create quadrature points,
+`generate_particles` to create quadrature points,
 [`generate_basis_weights`](@ref) to create element-local basis storage, and
-[`feupdate!`](@ref) to fill the quadrature weights and basis values.
+`update!` to fill the element-local basis data.
 """
 struct FEMesh{S <: Shape, dim, T, L} <: AbstractMesh{dim, T, 1}
     shape::S

--- a/src/foreach.jl
+++ b/src/foreach.jl
@@ -197,6 +197,7 @@ end
 
 function foreach_loop(f, device::GPUDevice, ::Val{scheduler}, collection) where {scheduler}
     scheduler == :nothing || @warn "Multi-threading is disabled for GPU" maxlog=1
+    collection = collection isa QuadraturePoints ? parent(collection) : collection
     backend = get_backend(device)
     if collection isa SpGrid
         spinds = get_spinds(collection)
@@ -213,6 +214,7 @@ end
 
 function foreach_loop(f, device::GPUDevice, ::Val{scheduler}, collection, slice::ForeachSlice) where {scheduler}
     scheduler == :nothing || @warn "Multi-threading is disabled for GPU" maxlog=1
+    collection = collection isa QuadraturePoints ? parent(collection) : collection
     foreach_check_slice(collection, slice)
     ndrange = foreach_slice_ndrange(slice)
     backend = get_backend(device)

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -73,7 +73,12 @@ function KernelAbstractions.get_backend(mesh::FEMesh)
     backend
 end
 
+# IGAMesh
 KernelAbstractions.get_backend(mesh::IGAMesh) = get_backend(mesh.controlpoints)
+
+# QuadraturePoints
+Adapt.adapt_structure(to, points::QuadraturePoints) = QuadraturePoints(adapt(to, parent(points)), quadrature_rule(points))
+KernelAbstractions.get_backend(points::QuadraturePoints) = get_backend(parent(points))
 
 # BasisWeightArray
 function Adapt.adapt_structure(to, weights::BasisWeightArray)

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -17,46 +17,6 @@ function generate_points(alg::GridSampling, mesh::CartesianMesh{dim, T}) where {
     vec(CartesianMesh(axis.(domain)...))
 end
 
-struct CellSampling{V <: Union{AbstractVector{<: Vec}, Tuple{Vararg{Vec}}}} <: SamplingAlgorithm
-    qpts::V
-end
-
-cell_sampling(mesh::FEMesh) = CellSampling(generate_quadrature_rule(cellshape(mesh)).points)
-cell_sampling(mesh::IGAMesh) = CellSampling(generate_quadrature_rule(igabasis(mesh)).points)
-
-function generate_points(alg::CellSampling, mesh::Union{FEMesh, IGAMesh})
-    qpts = alg.qpts
-    points = Matrix{eltype(mesh)}(undef, length(qpts), ncells(mesh))
-    for cell in cells(mesh)
-        for (i, qpt) in enumerate(qpts)
-            points[i,cell] = cell_point(mesh, cell, qpt)
-        end
-    end
-    points
-end
-
-function cell_point(mesh::FEMesh, cell, qpt)
-    indices = supportnodes(mesh, cell)
-    N = value(cellshape(mesh), qpt)
-    sum(N .* mesh[indices])
-end
-
-function cell_point(mesh::IGAMesh, cell, qpt)
-    patch = patches(mesh, cell.patch)
-    ξ = span_point(patch, cell.span, qpt)
-    N, _ = iga_basis_values_and_gradients(patch, cell.span, ξ)
-    indices = supportnodes(mesh, cell)
-    R = geometry_basis_values(N, mesh.weights, indices)
-    sum(R .* mesh[indices])
-end
-
-geometry_basis_values(N, ::Nothing, indices) = N
-function geometry_basis_values(N, weights::AbstractVector, indices)
-    w = weights[indices]
-    W = sum(N .* w)
-    map((Nᵢ, wᵢ) -> Nᵢ*wᵢ/W, N, w)
-end
-
 """
     PoissonDiskSampling(spacing = 1/2, rng = Random.default_rng())
 
@@ -96,7 +56,7 @@ function _generate_particles(::Type{ParticleProp}, points::AbstractArray{<: Vec}
 end
 
 """
-    generate_particles([ParticleProp], mesh; alg=PoissonDiskSampling())
+    generate_particles(ParticleProp, mesh::CartesianMesh; alg=PoissonDiskSampling())
 
 Generate particles across the entire `mesh` domain based on the selected `alg` algorithm.
 See also [`GridSampling`](@ref) and [`PoissonDiskSampling`](@ref).
@@ -157,14 +117,108 @@ function generate_particles(
     particles
 end
 
-function generate_particles(
-        ::Type{ParticleProp}, mesh::Union{FEMesh, IGAMesh};
-        alg::SamplingAlgorithm=cell_sampling(mesh)) where {ParticleProp}
-    points = generate_points(alg, mesh)
-    particles = _generate_particles(ParticleProp, points)
-    particles
-end
-
 function generate_particles(mesh::CartesianMesh{dim, T}; alg::SamplingAlgorithm=PoissonDiskSampling()) where {dim, T}
     generate_particles(@NamedTuple{x::Vec{dim, T}}, mesh; alg).x
+end
+
+"""
+    generate_particles(ParticleProp, mesh::FEMesh, rule=generate_quadrature_rule(cellshape(mesh)))
+
+Generate one point-property record for each point of `rule` in every finite
+element cell. The result is a [`QuadraturePoints`](@ref) matrix whose rows are
+rule points and whose columns are cells.
+"""
+function generate_particles(::Type{ParticleProp}, mesh::FEMesh, rule::QuadratureRule=generate_quadrature_rule(cellshape(mesh))) where {ParticleProp}
+    QuadraturePoints(_generate_particles(ParticleProp, generate_points(rule, mesh)), rule)
+end
+
+"""
+    generate_particles(ParticleProp, mesh::IGAMesh, rule=generate_quadrature_rule(igabasis(mesh)))
+
+Generate one point-property record for each point of `rule` in every nonzero
+knot span. The result is a [`QuadraturePoints`](@ref) matrix whose rows are rule
+points and whose columns are cells.
+"""
+function generate_particles(::Type{ParticleProp}, mesh::IGAMesh, rule::QuadratureRule=generate_quadrature_rule(igabasis(mesh))) where {ParticleProp}
+    QuadraturePoints(_generate_particles(ParticleProp, generate_points(rule, mesh)), rule)
+end
+
+"""
+    QuadraturePoints(particles, rule)
+
+A matrix of point-property records associated with a reference-cell
+[`QuadratureRule`](@ref). `parent(points)` returns the underlying `StructArray`,
+and [`quadrature_rule(points)`](@ref) returns the stored rule.
+"""
+struct QuadraturePoints{T, P <: StructArray{T, 2}, R <: QuadratureRule} <: AbstractMatrix{T}
+    particles::P
+    rule::R
+    function QuadraturePoints{T, P, R}(particles::P, rule::R) where {T, P <: StructArray{T, 2}, R <: QuadratureRule}
+        length(rule.points) == length(rule.weights) || throw(DimensionMismatch("quadrature points and weights must have the same length"))
+        size(particles, 1) == length(rule.points) || throw(DimensionMismatch("the first particle dimension must equal the number of quadrature points"))
+        new{T, P, R}(particles, rule)
+    end
+end
+
+QuadraturePoints(particles::P, rule::R) where {T, P <: StructArray{T, 2}, R <: QuadratureRule} = QuadraturePoints{T, P, R}(particles, rule)
+
+Base.parent(points::QuadraturePoints) = getfield(points, :particles)
+
+"""
+    quadrature_rule(points::QuadraturePoints)
+
+Return the reference-cell quadrature rule stored by `points`.
+"""
+quadrature_rule(points::QuadraturePoints) = getfield(points, :rule)
+Base.size(points::QuadraturePoints) = size(parent(points))
+Base.IndexStyle(::Type{<: QuadraturePoints{T, P}}) where {T, P} = IndexStyle(P)
+Base.propertynames(points::QuadraturePoints, private::Bool=false) = propertynames(parent(points), private)
+@inline Base.getproperty(points::QuadraturePoints, name::Symbol) = getproperty(parent(points), name)
+@inline Base.getindex(points::QuadraturePoints, i::Int) = getindex(parent(points), i)
+@inline Base.setindex!(points::QuadraturePoints, value, i::Int) = setindex!(parent(points), value, i)
+Base.copy(points::QuadraturePoints) = QuadraturePoints(copy(parent(points)), quadrature_rule(points))
+StructArrays.components(points::QuadraturePoints) = StructArrays.components(parent(points))
+
+function _check_quadrature_rule(::QuadratureRule{F, qdim}, mesh::FEMesh) where {F, qdim}
+    F === _reference_cell_family(cellshape(mesh)) || throw(ArgumentError("quadrature rule and FEM mesh must use the same reference-cell family"))
+    qdim == get_dimension(cellshape(mesh)) || throw(DimensionMismatch("quadrature-rule and FEM reference dimensions must match"))
+end
+
+function _check_quadrature_rule(::QuadratureRule{F, qdim}, ::IGAMesh{dim, pdim}) where {F, qdim, dim, pdim}
+    F === _tensor_product_family(Val(pdim)) || throw(ArgumentError("quadrature rule and IGA mesh must use the same reference-cell family"))
+    qdim == pdim || throw(DimensionMismatch("quadrature-rule and IGA parametric dimensions must match"))
+end
+
+function generate_points(rule::QuadratureRule, mesh::Union{FEMesh, IGAMesh})
+    _check_quadrature_rule(rule, mesh)
+    qpts = rule.points
+    points = Matrix{eltype(mesh)}(undef, length(qpts), ncells(mesh))
+    for cell in cells(mesh)
+        for (i, qpt) in enumerate(qpts)
+            points[i,cell] = cell_point(mesh, cell, qpt)
+        end
+    end
+    points
+end
+
+function cell_point(mesh::FEMesh, cell, qpt)
+    indices = supportnodes(mesh, cell)
+    N = value(cellshape(mesh), qpt)
+    sum(N .* mesh[indices])
+end
+
+function cell_point(mesh::IGAMesh, cell, qpt)
+    patch = patches(mesh, cell.patch)
+    ξ = span_point(patch, cell.span, qpt)
+    N, _ = iga_basis_values_and_gradients(patch, cell.span, ξ)
+    indices = supportnodes(mesh, cell)
+    R = geometry_basis_values(N, mesh.weights, indices)
+    sum(R .* mesh[indices])
+end
+
+geometry_basis_values(N, ::Nothing, indices) = N
+function geometry_basis_values(N, weights::AbstractVector, indices)
+    w = weights[indices]
+    W = sum(N .* w)
+    map((Nᵢ, wᵢ) -> Nᵢ*wᵢ/W, N, w)
 end

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -1,11 +1,16 @@
 """
-    QuadratureRule(points, weights)
+    QuadratureRule(family, points, weights)
 
-Points and weights for integration on a reference cell.
+Points and weights for integration on a reference cell of `family`.
 """
-struct QuadratureRule{dim, T, P <: AbstractVector{Vec{dim, T}}, W <: AbstractVector{<: T}}
+struct QuadratureRule{F <: Shape, dim, T, P <: AbstractVector{Vec{dim, T}}, W <: AbstractVector{<: T}}
     points::P
     weights::W
+end
+
+function QuadratureRule(::Type{F}, points::P, weights::W) where {F <: Shape, dim, T, P <: AbstractVector{Vec{dim, T}}, W <: AbstractVector{<: T}}
+    length(points) == length(weights) || throw(DimensionMismatch("quadrature points and weights must have the same length"))
+    QuadratureRule{F, dim, T, P, W}(points, weights)
 end
 
 _reference_cell_family(::S) where {S <: Shape} = S
@@ -14,6 +19,7 @@ _reference_cell_family(::Quad) = Quad
 _reference_cell_family(::Hex) = Hex
 _reference_cell_family(::Tri) = Tri
 _reference_cell_family(::Tet) = Tet
+_reference_cell_family(::QuadratureRule{F}) where {F} = F
 
 _order_value(::Order{p}) where {p} = p
 
@@ -24,8 +30,8 @@ _order_value(::Order{p}) where {p} = p
 Generate the standard [`QuadratureRule`](@ref) for `shape`. For interpolation
 order `p`, the rule integrates degree `2p` in each reference coordinate for
 tensor-product shapes and total degree `2p` for simplex shapes. `T` may be
-`Float16`, `Float32`, or `Float64` and defaults to `Float64`. The selection
-depends only on the interpolation order of `shape`.
+`Float16`, `Float32`, or `Float64` and defaults to `Float64`. The reference-cell
+family and interpolation order of `shape` determine the selected rule.
 """
 generate_quadrature_rule(shape::Shape) = generate_quadrature_rule(Float64, shape)
 function generate_quadrature_rule(::Type{T}, shape::Shape) where {T}
@@ -65,26 +71,30 @@ end
 function _generate_tensor_quadrature_rule(::Type{T}, family, exactness::Int, ::Val{dim}) where {T, dim}
     exactness ≥ 0 || throw(ArgumentError("$family quadrature exactness must be nonnegative; got $exactness"))
     rule1d = _gauss_legendre_rule(T, Val(fld(exactness, 2) + 1))
-    _tensor_product_quadrature_rule(ntuple(_ -> rule1d, Val(dim)))
+    _tensor_product_quadrature_rule(family, ntuple(_ -> rule1d, Val(dim)))
 end
 
-function _tensor_product_quadrature_rule(rules::Tuple{Vararg{Tuple{<: StaticVector, <: StaticVector}, dim}}) where {dim}
+_tensor_product_family(::Val{1}) = Line
+_tensor_product_family(::Val{2}) = Quad
+_tensor_product_family(::Val{3}) = Hex
+
+function _tensor_product_quadrature_rule(family, rules::Tuple{Vararg{Tuple{<: StaticVector, <: StaticVector}, dim}}) where {dim}
     qpts1d = map(first, rules)
     qwts1d = map(last, rules)
     indices = CartesianIndices(map(length, qpts1d))
     npoints = length(indices)
     qpts = SVector{npoints}(map(I -> Vec(map(getindex, qpts1d, Tuple(I))), indices))
     qwts = SVector{npoints}(map(I -> prod(map(getindex, qwts1d, Tuple(I))), indices))
-    QuadratureRule(qpts, qwts)
+    QuadratureRule(family, qpts, qwts)
 end
 
-function _tensor_product_quadrature_rule(rules::Tuple{Vararg{Any, dim}}) where {dim}
+function _tensor_product_quadrature_rule(family, rules::Tuple{Vararg{Any, dim}}) where {dim}
     qpts1d = map(first, rules)
     qwts1d = map(last, rules)
     indices = CartesianIndices(map(length, qpts1d))
     qpts = vec(map(I -> Vec(map(getindex, qpts1d, Tuple(I))), indices))
     qwts = vec(map(I -> prod(map(getindex, qwts1d, Tuple(I))), indices))
-    QuadratureRule(qpts, qwts)
+    QuadratureRule(family, qpts, qwts)
 end
 
 _gauss_legendre_rule(::Type{T}, ::Degree{p}) where {T, p} = _gauss_legendre_rule(T, Val(p + 1))
@@ -150,14 +160,14 @@ end
 function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{1}) where {T}
     a = T(0.33333333333333333333)
     w = T(0.50000000000000000000)
-    QuadratureRule(SVector{1, Vec{2, T}}(((a, a),)), SVector{1, T}((w,)))
+    QuadratureRule(Tri, SVector{1, Vec{2, T}}(((a, a),)), SVector{1, T}((w,)))
 end
 
 function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{2}) where {T}
     a = T(0.16666666666666666667)
     b = T(0.66666666666666666667)
     w = T(0.16666666666666666667)
-    QuadratureRule(_triangle_orbit3(a, b), SVector{3, T}((w, w, w)))
+    QuadratureRule(Tri, _triangle_orbit3(a, b), SVector{3, T}((w, w, w)))
 end
 
 function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{4}) where {T}
@@ -168,7 +178,7 @@ function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{4}) where {T}
     b2 = T(0.81684757298045851308)
     w2 = T(0.05497587182766093382)
     points = SVector{6, Vec{2, T}}((_triangle_orbit3(a1, b1)..., _triangle_orbit3(a2, b2)...))
-    QuadratureRule(points, SVector{6, T}((w1, w1, w1, w2, w2, w2)))
+    QuadratureRule(Tri, points, SVector{6, T}((w1, w1, w1, w2, w2, w2)))
 end
 
 function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{6}) where {T}
@@ -184,7 +194,7 @@ function _simplex_quadrature_rule(::Type{T}, ::Type{Tri}, ::Val{6}) where {T}
     w3 = T(0.04142553780918678541)
     points = SVector{12, Vec{2, T}}((_triangle_orbit3(a1, b1)..., _triangle_orbit3(a2, b2)..., _triangle_orbit6(a3, b3, c3)...))
     weights = SVector{12, T}((w1, w1, w1, w2, w2, w2, w3, w3, w3, w3, w3, w3))
-    QuadratureRule(points, weights)
+    QuadratureRule(Tri, points, weights)
 end
 
 @inline _tetrahedron_orbit4(a::T, b::T) where {T} = SVector{4, Vec{3, T}}(((a, b, b), (b, a, b), (b, b, a), (b, b, b)))
@@ -194,14 +204,14 @@ end
 function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{1}) where {T}
     a = T(0.25000000000000000000)
     w = T(0.16666666666666666667)
-    QuadratureRule(SVector{1, Vec{3, T}}(((a, a, a),)), SVector{1, T}((w,)))
+    QuadratureRule(Tet, SVector{1, Vec{3, T}}(((a, a, a),)), SVector{1, T}((w,)))
 end
 
 function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{2}) where {T}
     a = T(0.58541019662496845446)
     b = T(0.13819660112501051518)
     w = T(0.04166666666666666667)
-    QuadratureRule(_tetrahedron_orbit4(a, b), SVector{4, T}((w, w, w, w)))
+    QuadratureRule(Tet, _tetrahedron_orbit4(a, b), SVector{4, T}((w, w, w, w)))
 end
 
 function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{5}) where {T}
@@ -216,7 +226,7 @@ function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{5}) where {T}
     w3 = T(0.00709100346284691107)
     points = SVector{14, Vec{3, T}}((_tetrahedron_orbit4(b1, a1)..., _tetrahedron_orbit4(b2, a2)..., _tetrahedron_orbit6(a3, b3)...))
     weights = SVector{14, T}((w1, w1, w1, w1, w2, w2, w2, w2, w3, w3, w3, w3, w3, w3))
-    QuadratureRule(points, weights)
+    QuadratureRule(Tet, points, weights)
 end
 
 function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{7}) where {T}
@@ -238,5 +248,5 @@ function _simplex_quadrature_rule(::Type{T}, ::Type{Tet}, ::Val{7}) where {T}
     w4 = T(0.00135179513831722360)
     points = SVector{35, Vec{3, T}}(((q, q, q), _tetrahedron_orbit4(b1, a1)..., _tetrahedron_orbit6(a2, b2)..., _tetrahedron_orbit12(a3, b3, c3)..., _tetrahedron_orbit12(a4, b4, c4)...))
     weights = SVector{35, T}((w0, w1, w1, w1, w1, w2, w2, w2, w2, w2, w2, w3, w3, w3, w3, w3, w3, w3, w3, w3, w3, w3, w3, w4, w4, w4, w4, w4, w4, w4, w4, w4, w4, w4, w4))
-    QuadratureRule(points, weights)
+    QuadratureRule(Tet, points, weights)
 end

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -358,6 +358,7 @@ end
 end
 function P2G(f, device::GPUDevice, ::Val{scheduler}, grid, particles, weights, ::Nothing) where {scheduler}
     scheduler == :nothing || @warn "Multi-threading is disabled for GPU" maxlog=1
+    particles = particles isa QuadraturePoints ? parent(particles) : particles
     backend = get_backend(device)
     kernel = gpukernel_P2G(backend)
     kernel(f, hybrid(grid), particles, weights; ndrange=length(particles))
@@ -565,6 +566,7 @@ end
 end
 function G2P(f, device::GPUDevice, ::Val{scheduler}, grid, particles, weights) where {scheduler}
     scheduler == :nothing || @warn "Multi-threading is disabled for GPU" maxlog=1
+    particles = particles isa QuadraturePoints ? parent(particles) : particles
     backend = get_backend(device)
     kernel = gpukernel_G2P(backend)
     kernel(f, grid, particles, weights; ndrange=length(particles))

--- a/test/fem.jl
+++ b/test/fem.jl
@@ -1,0 +1,110 @@
+@testset "FEM field and geometry" begin
+    @testset "Quadrilateral domain" begin
+        α = 0.2
+        geometry = FEMesh(
+            Tesserae.Quad9(),
+            [
+                Vec(0.0, 0.0), Vec(1.0, 0.0), Vec(1.0, 1.0), Vec(0.0, 1.0),
+                Vec(0.5, 0.0), Vec(1.0, 0.5), Vec(0.5, 1 + α), Vec(0.0, 0.5), Vec(0.5, (1 + α) / 2),
+            ],
+            [Tesserae.SVector(1, 2, 3, 4, 5, 6, 7, 8, 9)],
+        )
+        field = FEMesh(
+            Tesserae.Quad4(),
+            [Vec(-1.0, -1.0), geometry.nodes[1:4]...],
+            [Tesserae.SVector(2, 3, 4, 5)],
+        )
+        rule = generate_quadrature_rule(Tesserae.Quad9())
+        points = @inferred generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, geometry, rule)
+        weights = @inferred generate_basis_weights(field, size(points); name=Val(:N))
+
+        @test_throws ArgumentError generate_particles(@NamedTuple{x::Vec{2,Float64}}, geometry, generate_quadrature_rule(Tesserae.Tri6()))
+        @test quadrature_rule(points) === rule
+        @test points[1,1] == parent(points)[1,1]
+        adapted_points = Tesserae.Adapt.adapt(Array, points)
+        @test adapted_points isa QuadraturePoints
+        @test parent(adapted_points) isa Tesserae.StructArray
+        @test quadrature_rule(adapted_points) === rule
+        @test supportnodes(weights[1,1]) == Tesserae.SVector(2, 3, 4, 5)
+        @test (@inferred update!(weights, points, geometry; measure=points.V)) === weights
+        for (q, (point, weight)) in enumerate(zip(rule.points, rule.weights))
+            ξ, η = point
+            N, dNdξ = Tesserae.jet(Order(1), Tesserae.Quad4(), point)
+            J = Mat{2,2}(0.5, -α * ξ * (1 + η), 0, (1 + α * (1 - ξ^2)) / 2)
+            @test points.x[q,1] ≈ Vec((1 + ξ) / 2, (1 + η) * (1 + α * (1 - ξ^2)) / 2)
+            @test weights[q,1].N ≈ N
+            @test weights[q,1].∇N ≈ dNdξ .⊡ Ref(inv(J))
+            @test supportnodes(weights[q,1]) == Tesserae.SVector(2, 3, 4, 5)
+            @test points.V[q,1] ≈ weight * det(J)
+        end
+        @test sum(points.V) ≈ 1 + 2α / 3
+    end
+
+    @testset "Higher-order field" begin
+        geometry = FEMesh(Tesserae.Quad4(), [Vec(0.0, 0.0), Vec(1.0, 0.0), Vec(1.0, 1.0), Vec(0.0, 1.0)], [Tesserae.SVector(1, 2, 3, 4)])
+        field = FEMesh(
+            Tesserae.Quad9(),
+            [Vec(-1.0, -1.0), Vec(0.0, 0.0), Vec(1.0, 0.0), Vec(1.0, 1.0), Vec(0.0, 1.0), Vec(0.5, 0.0), Vec(1.0, 0.5), Vec(0.5, 1.0), Vec(0.0, 0.5), Vec(0.5, 0.5)],
+            [Tesserae.SVector(2, 3, 4, 5, 6, 7, 8, 9, 10)],
+        )
+        rule = generate_quadrature_rule(Tesserae.Quad9())
+        points = generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, geometry, rule)
+        weights = generate_basis_weights(field, size(points); name=Val(:N))
+        J = Mat{2,2}(0.5, 0, 0, 0.5)
+
+        @test supportnodes(weights[1,1]) == Tesserae.SVector(2, 3, 4, 5, 6, 7, 8, 9, 10)
+        value_weights = generate_basis_weights(field, size(points); derivative=Order(0))
+        @test_throws ArgumentError update!(value_weights, points, geometry)
+        @test update!(weights, points, geometry; measure=points.V) === weights
+        @test all(q -> weights[q,1].N ≈ Tesserae.value(Tesserae.Quad9(), rule.points[q]), eachindex(rule.points))
+        @test all(q -> weights[q,1].∇N ≈ last(Tesserae.jet(Order(1), Tesserae.Quad9(), rule.points[q])) .⊡ Ref(inv(J)), eachindex(rule.points))
+        @test points.V[:,1] ≈ rule.weights / 4
+    end
+
+    @testset "Triangular domain" begin
+        α = 0.3
+        geometry = FEMesh(
+            Tesserae.Tri6(),
+            [Vec(0.0, 0.0), Vec(1.0, 0.0), Vec(0.0, 1.0), Vec(0.5, 0.0), Vec(0.0, 0.5), Vec(0.5, 0.5 + α / 4)],
+            [Tesserae.SVector(1, 2, 3, 4, 5, 6)],
+        )
+        field = FEMesh(Tesserae.Tri3(), [Vec(-1.0, -1.0), geometry.nodes[1:3]...], [Tesserae.SVector(2, 3, 4)])
+        rule = generate_quadrature_rule(Tesserae.Tri6())
+        points = generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, geometry, rule)
+        weights = generate_basis_weights(field, size(points); name=Val(:N))
+
+        update!(weights, points, geometry; measure=points.V)
+        for (q, (point, weight)) in enumerate(zip(rule.points, rule.weights))
+            @test weights[q,1].N ≈ Tesserae.value(Tesserae.Tri3(), point)
+            @test supportnodes(weights[q,1]) == Tesserae.SVector(2, 3, 4)
+            @test points.V[q,1] ≈ weight * (1 + α * point[1])
+        end
+        @test sum(points.V) ≈ 1/2 + α/6
+    end
+
+    @testset "Curved boundary" begin
+        h = 0.25
+        geometry = FEMesh(Tesserae.Line3(), [Vec(0.0, 0.0), Vec(1.0, 0.0), Vec(0.5, h)], [Tesserae.SVector(1, 2, 3)])
+        field = FEMesh(Tesserae.Line2(), [Vec(-1.0, -1.0), geometry.nodes[1:2]...], [Tesserae.SVector(2, 3)])
+        rule = generate_quadrature_rule(Tesserae.Line3())
+        points = generate_particles(@NamedTuple{x::Vec{2,Float64}, dS::Float64, n::Vec{2,Float64}}, geometry, rule)
+        weights = generate_basis_weights(field, size(points); name=Val(:N))
+
+        update!(weights, points, geometry; measure=points.dS, normal=points.n)
+        for (q, (point, weight)) in enumerate(zip(rule.points, rule.weights))
+            tangent = Vec(0.5, -2h * point[1])
+            scale = norm(tangent)
+            @test weights[q,1].N ≈ Tesserae.value(Tesserae.Line2(), point)
+            @test supportnodes(weights[q,1]) == Tesserae.SVector(2, 3)
+            @test points.dS[q,1] ≈ weight * scale
+            @test points.n[q,1] ≈ Vec(tangent[2], -tangent[1]) / scale
+        end
+    end
+
+    @testset "Empty domain" begin
+        mesh = FEMesh(Tesserae.Quad4(), Vec{2,Float64}[], Tesserae.SVector{4,Int}[])
+        points = generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, mesh)
+        weights = generate_basis_weights(mesh, size(points))
+        @test update!(weights, points, mesh; measure=points.V) === weights
+    end
+end

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -243,21 +243,28 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         @test rational_points.x[1, rational_cell] ≈ sum(R .* rational_mesh[rational_ids])
     end
 
-    @testset "feupdate!" begin
-        feweights = generate_basis_weights(Float64, mesh, length(qrule.points), Tesserae.ncells(mesh))
+    @testset "Quadrature update" begin
+        points = generate_particles(@NamedTuple{x::Vec{2,Float64}}, mesh, qrule)
+        feweights = generate_basis_weights(Float64, mesh, size(points))
         measure = zeros(Float64, size(feweights))
-        @test (@inferred feupdate!(feweights, mesh; measure)) === nothing
+        @test (@inferred update!(feweights, points, mesh; measure)) === feweights
         @test supportnodes(feweights[1, meshcells[1]]) == supportnodes(mesh, meshcells[1])
         @test sum(feweights[1, meshcells[1]].w) ≈ 1
         @test isapprox(sum(feweights[1, meshcells[1]].∇w), Vec(0.0, 0.0); atol=1e-14)
         @test sum(measure[:, meshcells[1]]) ≈ 1/16
         @test sum(measure) ≈ 1
 
-        # Rational feupdate! should use rational basis values in both N and ∇N.
+        reversed_patch = IGAPatch(iga_test_degrees(patch), map(copy, iga_test_knot_vectors(patch)), reverse(patch.controlpoint_ids))
+        reversed_mesh = IGAMesh([reversed_patch], mesh.controlpoints)
+        reversed_weights = generate_basis_weights(reversed_mesh, size(points))
+        @test_throws ArgumentError update!(reversed_weights, points, mesh)
+
+        # Rational updates should use rational basis values in both N and ∇N.
         rational_mesh = IGAMesh(cmesh; degree=Quadratic(), weights=range(1.0, 2.0; length=length(mesh)))
-        rational_weights = generate_basis_weights(Float64, rational_mesh, length(qrule.points), Tesserae.ncells(rational_mesh))
+        rational_points = generate_particles(@NamedTuple{x::Vec{2,Float64}}, rational_mesh)
+        rational_weights = generate_basis_weights(Float64, rational_mesh, size(rational_points))
         rational_measure = zeros(Float64, size(rational_weights))
-        @test feupdate!(rational_weights, rational_mesh; measure=rational_measure) === nothing
+        @test update!(rational_weights, rational_points, rational_mesh; measure=rational_measure) === rational_weights
 
         rational_cell = first(cells(rational_mesh))
         rational_patch = Tesserae.patches(rational_mesh, rational_cell.patch)
@@ -275,11 +282,11 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         boundary_patch = IGAPatch((Quadratic(),), (copy(iga_test_knot_vectors(patch)[1]),), Array(patch.controlpoint_ids[:,1]))
         boundary_mesh = IGAMesh([boundary_patch], mesh.controlpoints)
         @test supportnodes(boundary_mesh) == collect(patch.controlpoint_ids[:,1])
-        boundary_rule = generate_quadrature_rule(Tesserae.igabasis(boundary_mesh))
-        boundary_weights = generate_basis_weights(boundary_mesh, length(boundary_rule.points), Tesserae.ncells(boundary_mesh); name=Val(:N))
+        boundary_points = generate_particles(@NamedTuple{x::Vec{2,Float64}}, boundary_mesh)
+        boundary_weights = generate_basis_weights(boundary_mesh, size(boundary_points); name=Val(:N))
         measure = zeros(Float64, size(boundary_weights))
         normal = zeros(Vec{2, Float64}, size(boundary_weights))
-        @test (@inferred feupdate!(boundary_weights, boundary_mesh; measure, normal)) === nothing
+        @test (@inferred update!(boundary_weights, boundary_points, boundary_mesh; measure, normal)) === boundary_weights
         @test sum(measure) ≈ 1
         @test all(n -> n ≈ Vec(0.0, -1.0), normal)
     end
@@ -337,7 +344,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
             grid = generate_grid(GridProp, mesh)
             points = generate_particles(PointProp, mesh)
             weights = generate_basis_weights(mesh, size(points); name=Val(:N))
-            feupdate!(weights, mesh; measure=points.V)
+            update!(weights, points, mesh; measure=points.V)
             K = create_sparse_matrix(mesh; ndofs=1)
             dofmask = trues(1, size(grid)...)
             for i in eachindex(mesh)

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -101,10 +101,10 @@ end
             x      :: Vec{dim, Float64}
             detJdV :: Float64
         end
-        particles = generate_particles(ParticleProp, mesh)
-        weights = generate_basis_weights(mesh, size(particles))
-        feupdate!(weights, mesh; measure = particles.detJdV)
-        sum(particles.detJdV)
+        points = generate_particles(ParticleProp, mesh)
+        weights = generate_basis_weights(mesh, size(points))
+        update!(weights, points, mesh; measure=points.detJdV)
+        sum(points.detJdV)
     end
     cmesh = CartesianMesh(1, (0,2))
     @test compute_volume(FEMesh(Tesserae.Line2(), cmesh)) ≈
@@ -131,10 +131,10 @@ end
             detJdA :: Float64
         end
         mesh_face = Tesserae.extract_face(mesh_body, 1:length(mesh_body))
-        particles = generate_particles(ParticleProp, mesh_face)
-        weights = generate_basis_weights(mesh_face, size(particles))
-        feupdate!(weights, mesh_face; normal = particles.n, measure = particles.detJdA)
-        sum(particles.detJdA)
+        points = generate_particles(ParticleProp, mesh_face)
+        weights = generate_basis_weights(mesh_face, size(points))
+        update!(weights, points, mesh_face; normal=points.n, measure=points.detJdA)
+        sum(points.detJdA)
     end
     cmesh = CartesianMesh(1, (0,1), (0,1))
     @test compute_area(FEMesh(Tesserae.Quad4(), cmesh)) ≈
@@ -161,9 +161,9 @@ end
     end
     line_points = generate_particles(LinePointProp, line_mesh)
     line_weights = generate_basis_weights(line_mesh, size(line_points))
-    feupdate!(line_weights, line_mesh; measure=line_points.detJdL)
+    update!(line_weights, line_points, line_mesh; measure=line_points.detJdL)
     @test sum(line_points.detJdL) ≈ 3
-    @test_throws ArgumentError feupdate!(line_weights, line_mesh; normal=line_points.n)
+    @test_throws ArgumentError update!(line_weights, line_points, line_mesh; normal=line_points.n)
 
     cmesh1 = CartesianMesh(1, (0,2), (0,2))
     cmesh2 = CartesianMesh(1, (1,3), (1,3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ include("particles.jl")
 
 include("basis.jl")
 include("shapes.jl")
+include("fem.jl")
 
 include("transfer.jl")
 include("foreach.jl")


### PR DESCRIPTION
Separate FEM field interpolation and connectivity from the geometry mapping used at quadrature points.

Store the selected quadrature rule with generated point sets, and update the FEM/IGA assembly and GPU transfer paths accordingly.