### PR TITLE
Add geometry-derived FEM field meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ macros.
 
 ### Added
 
+- Added `FEMesh(shape, geometry)` for compact field meshes that share geometry
+  coordinates.
 - Added GPU support for `SpArray` sparsity updates and sparse-grid transfers.
   (#112)
 - Added `@explain` and `ExplainedCode` for inspecting transfer macro structure.

--- a/src/femesh.jl
+++ b/src/femesh.jl
@@ -1,5 +1,6 @@
 """
     FEMesh(shape, nodes, cellsupports)
+    FEMesh(shape, geometry::FEMesh)
     FEMesh(cartesian_mesh)
     FEMesh(shape, cartesian_mesh)
 
@@ -9,6 +10,12 @@ Create a finite-element mesh.
 `cellsupports` stores the node indices of each cell. `cells(mesh)` iterates over
 cell indices, while `supportnodes(mesh, cell)` returns the nodes used by one
 cell.
+
+`FEMesh(shape, geometry)` selects the geometry nodes that coincide with the
+reference nodes of `shape`, renumbers them contiguously, and stores their
+coordinates as a view of `geometry.nodes`. Every reference node of `shape`
+must exist in the geometry cell. Coordinate changes through either mesh are
+shared; connectivity changes made later are not.
 
 The Cartesian constructors are convenience constructors for structured test
 meshes and examples. `FEMesh(cartesian_mesh)` uses the default first-order cell
@@ -21,15 +28,31 @@ from the Cartesian grid.
 [`generate_basis_weights`](@ref) to create element-local basis storage, and
 `update!` to fill the element-local basis data.
 """
-struct FEMesh{S <: Shape, dim, T, L} <: AbstractMesh{dim, T, 1}
+struct FEMesh{S <: Shape, dim, T, L, V <: AbstractVector{Vec{dim, T}}} <: AbstractMesh{dim, T, 1}
     shape::S
-    nodes::Vector{Vec{dim, T}}
+    nodes::V
     cellsupports::Vector{SVector{L, Int}}
     usednodes::Vector{Int}
 end
 
-function FEMesh(shape::S, nodes::Vector{Vec{dim, T}}, cellsupports::Vector{SVector{L, Int}}) where {S <: Shape, dim, T, L}
-    FEMesh{S, dim, T, L}(shape, nodes, cellsupports, _collect_supportnodes(cellsupports))
+function FEMesh(shape::S, nodes::V, cellsupports::Vector{SVector{L, Int}}) where {S <: Shape, dim, T, L, V <: AbstractVector{Vec{dim, T}}}
+    FEMesh{S, dim, T, L, V}(shape, nodes, cellsupports, _collect_supportnodes(cellsupports))
+end
+
+function FEMesh(shape::Shape, geometry::FEMesh)
+    _reference_cell_family(shape) === _reference_cell_family(cellshape(geometry)) || throw(ArgumentError("field and geometry must use the same reference-cell family"))
+    geometry_localnodes = localnodes(cellshape(geometry))
+    localindices = map(localnodes(shape)) do node
+        index = findfirst(==(node), geometry_localnodes)
+        isnothing(index) && throw(ArgumentError("each field node must also be a node of the geometry cell"))
+        index
+    end
+    supports_in_geometry = map(indices -> indices[localindices], geometry.cellsupports)
+    nodeindices = _collect_supportnodes(supports_in_geometry)
+    nodemap = zeros(Int, length(geometry))
+    nodemap[nodeindices] .= eachindex(nodeindices)
+    field_supports = map(indices -> map(i -> nodemap[i], indices), supports_in_geometry)
+    FEMesh(shape, view(geometry.nodes, nodeindices), field_supports)
 end
 
 function _collect_supportnodes(cellsupports)
@@ -164,6 +187,7 @@ function extract_face(mesh::FEMesh, nodeindices::AbstractVector{Int})
 end
 
 function Base.merge!(dest::FEMesh{S}, src::FEMesh{S}) where {S}
+    dest.nodes isa Vector || throw(ArgumentError("merge! requires a resizable Vector of nodes"))
     isapproxzero(x) = dot(x,x) < eps(eltype(x))
 
     nodemap = Vector{Int}(undef, length(src))

--- a/test/fem.jl
+++ b/test/fem.jl
@@ -68,7 +68,7 @@
             [Vec(0.0, 0.0), Vec(1.0, 0.0), Vec(0.0, 1.0), Vec(0.5, 0.0), Vec(0.0, 0.5), Vec(0.5, 0.5 + α / 4)],
             [Tesserae.SVector(1, 2, 3, 4, 5, 6)],
         )
-        field = FEMesh(Tesserae.Tri3(), [Vec(-1.0, -1.0), geometry.nodes[1:3]...], [Tesserae.SVector(2, 3, 4)])
+        field = FEMesh(Tesserae.Tri3(), geometry)
         rule = generate_quadrature_rule(Tesserae.Tri6())
         points = generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, geometry, rule)
         weights = generate_basis_weights(field, size(points); name=Val(:N))
@@ -76,7 +76,7 @@
         update!(weights, points, geometry; measure=points.V)
         for (q, (point, weight)) in enumerate(zip(rule.points, rule.weights))
             @test weights[q,1].N ≈ Tesserae.value(Tesserae.Tri3(), point)
-            @test supportnodes(weights[q,1]) == Tesserae.SVector(2, 3, 4)
+            @test supportnodes(weights[q,1]) == Tesserae.SVector(1, 2, 3)
             @test points.V[q,1] ≈ weight * (1 + α * point[1])
         end
         @test sum(points.V) ≈ 1/2 + α/6

--- a/test/grid.jl
+++ b/test/grid.jl
@@ -50,6 +50,14 @@
     @test all(iszero, (grid.m)::Array{Float32,3})
     @test all(iszero, (grid.x)::Array{Vec{3,Float32},3})
 
+    geometry = FEMesh(Tesserae.Quad9(), CartesianMesh(1, (0,2), (0,1)))
+    field = FEMesh(Tesserae.Quad4(), geometry)
+    field_grid = @inferred generate_grid(@NamedTuple{x::Vec{2,Float64}, p::Float64}, field)
+    @test field_grid.x === field
+    @test length(field_grid) == 6
+    geometry[1] = Vec(-1.0, -1.0)
+    @test field_grid.x[1] == geometry[1]
+
     # broadcast for SpArray
     grid = generate_grid(SpArray, @NamedTuple{x::Vec{2,Float64}, m::Float64, v::Vec{2,Float64}}, mesh)
     spinds = Tesserae.get_spinds(grid)

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -304,13 +304,14 @@ end
 
 @testset "FEM sparse matrix pattern" begin
     cmesh = CartesianMesh(1, (0,1), (0,1))
-    quad4 = FEMesh(Tesserae.Quad4(), cmesh)
-    quad9 = FEMesh(Tesserae.Quad9(), cmesh)
+    geometry = FEMesh(Tesserae.Quad9(), cmesh)
+    quad4 = FEMesh(Tesserae.Quad4(), geometry)
+    quad9 = FEMesh(Tesserae.Quad9(), geometry)
 
     @test_throws UndefKeywordError create_sparse_matrix(quad4)
 
     A = create_sparse_matrix((quad9, quad4); ndofs=(2, 1))
-    @test size(A) == (2length(quad9), length(quad4))
+    @test size(A) == (18, 4)
     @test Tesserae.SparseArrays.nnz(A) == prod(size(A))
 
     shifted = FEMesh(Tesserae.Quad4(), CartesianMesh(1, (2,3), (2,3)))

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -94,6 +94,25 @@ end
     )
     @test length(mesh_with_unused_node) == 3
     @test supportnodes(mesh_with_unused_node) == [1, 3]
+    compact_mesh = FEMesh(Tesserae.Line2(), mesh_with_unused_node)
+    @test length(compact_mesh) == 2
+    @test compact_mesh.cellsupports == [Tesserae.SVector(1, 2)]
+
+    geometry = FEMesh(Tesserae.Quad9(), CartesianMesh(1, (0,2), (0,1)))
+    velocity = @inferred FEMesh(Tesserae.Quad9(), geometry)
+    pressure = @inferred FEMesh(Tesserae.Quad4(), geometry)
+    @test length(geometry) == length(velocity) == 15
+    @test length(pressure) == 6
+    @test parent(velocity.nodes) === parent(pressure.nodes) === geometry.nodes
+    @test pressure.cellsupports == [Tesserae.SVector(1, 2, 5, 4), Tesserae.SVector(2, 3, 6, 5)]
+    @test supportnodes(pressure) == collect(eachindex(pressure))
+    geometry[1] = Vec(-1.0, -1.0)
+    @test velocity[1] == pressure[1] == geometry[1]
+    pressure[1] = Vec(-2.0, -2.0)
+    @test velocity[1] == geometry[1] == pressure[1]
+    @test_throws ArgumentError merge!(pressure, FEMesh(Tesserae.Quad4(), geometry))
+    @test_throws ArgumentError FEMesh(Tesserae.Tri3(), geometry)
+    @test_throws ArgumentError FEMesh(Tesserae.Line3(), FEMesh(Tesserae.Line4(), [Vec(0.0), Vec(1.0), Vec(1 / 3), Vec(2 / 3)], [Tesserae.SVector(1, 2, 3, 4)]))
 
     function compute_volume(mesh)
         dim = Tesserae.get_dimension(Tesserae.cellshape(mesh))


### PR DESCRIPTION
Add `FEMesh(shape, geometry)` for deriving a field mesh from geometry nodes.

The constructor validates the reference-node relation, compacts field connectivity, and stores coordinates as a view of `geometry.nodes`, keeping field grids and sparse matrices compact while sharing coordinate updates.