### PR TITLE
Add QuadraturePoints cell views

### DIFF
--- a/src/particles.jl
+++ b/src/particles.jl
@@ -149,6 +149,7 @@ end
 A matrix of point-property records associated with a reference-cell
 [`QuadratureRule`](@ref). `parent(points)` returns the underlying `StructArray`,
 and [`quadrature_rule(points)`](@ref) returns the stored rule.
+`view(points, :, cells)` shares the storage and rule when `cells` is `:` or an `AbstractVector`.
 """
 struct QuadraturePoints{T, P <: StructArray{T, 2}, R <: QuadratureRule} <: AbstractMatrix{T}
     particles::P
@@ -175,7 +176,10 @@ Base.IndexStyle(::Type{<: QuadraturePoints{T, P}}) where {T, P} = IndexStyle(P)
 Base.propertynames(points::QuadraturePoints, private::Bool=false) = propertynames(parent(points), private)
 @inline Base.getproperty(points::QuadraturePoints, name::Symbol) = getproperty(parent(points), name)
 @inline Base.getindex(points::QuadraturePoints, i::Int) = getindex(parent(points), i)
+@inline Base.getindex(points::QuadraturePoints, i::Int, j::Int) = getindex(parent(points), i, j)
 @inline Base.setindex!(points::QuadraturePoints, value, i::Int) = setindex!(parent(points), value, i)
+@inline Base.setindex!(points::QuadraturePoints, value, i::Int, j::Int) = setindex!(parent(points), value, i, j)
+@inline Base.view(points::QuadraturePoints, ::Colon, cells::Union{Colon, AbstractVector}) = QuadraturePoints(view(parent(points), :, cells), quadrature_rule(points))
 Base.copy(points::QuadraturePoints) = QuadraturePoints(copy(parent(points)), quadrature_rule(points))
 StructArrays.components(points::QuadraturePoints) = StructArrays.components(parent(points))
 

--- a/test/fem.jl
+++ b/test/fem.jl
@@ -21,6 +21,14 @@
         @test_throws ArgumentError generate_particles(@NamedTuple{x::Vec{2,Float64}}, geometry, generate_quadrature_rule(Tesserae.Tri6()))
         @test quadrature_rule(points) === rule
         @test points[1,1] == parent(points)[1,1]
+        points_view = @inferred view(points, :, [1])
+        @test quadrature_rule(points_view) === rule
+        original_point = parent(points)[1,1]
+        parent(points)[1,1] = merge(original_point, (; V=1))
+        @test points_view[1,1].V == 1
+        points_view[1,1] = original_point
+        @test parent(points)[1,1] == original_point
+        @test collect(points_view) == collect(parent(points_view))
         adapted_points = Tesserae.Adapt.adapt(Array, points)
         @test adapted_points isa QuadraturePoints
         @test parent(adapted_points) isa Tesserae.StructArray


### PR DESCRIPTION
Allow cell-axis views of `QuadraturePoints` to preserve shared `StructArray` storage and the associated quadrature rule. Forward Cartesian indexing so vector cell selectors remain fully usable.