### PR TITLE
Generate consistently numbered FEM field meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,8 @@ macros.
 
 ### Added
 
-- Added `FEMesh(shape, geometry)` for compact field meshes that share geometry
-  coordinates.
+- Added `generate_field_meshes` for constructing consistently numbered field
+  meshes that share geometry coordinates.
 - Added GPU support for `SpArray` sparsity updates and sparse-grid transfers.
   (#112)
 - Added `@explain` and `ExplainedCode` for inspecting transfer macro structure.

--- a/docs/src/fem.md
+++ b/docs/src/fem.md
@@ -350,6 +350,7 @@ plot_solution(domain, grid.u, outer_boundary, hole_boundary)
 
 ```@docs
 FEMesh
+generate_field_meshes
 supportnodes(::FEMesh)
 update!(::BasisWeightArray{S}, ::QuadraturePoints, ::FEMesh{<:Tesserae.Shape{pdim},dim}) where {pdim,dim,S<:Tesserae.Shape{pdim}}
 readmsh

--- a/src/Tesserae.jl
+++ b/src/Tesserae.jl
@@ -52,6 +52,7 @@ export
     findcell,
     extract,
     FEMesh,
+    generate_field_meshes,
     cells,
     boundaries,
     IGAPatch,

--- a/src/femesh.jl
+++ b/src/femesh.jl
@@ -1,6 +1,5 @@
 """
     FEMesh(shape, nodes, cellsupports)
-    FEMesh(shape, geometry::FEMesh)
     FEMesh(cartesian_mesh)
     FEMesh(shape, cartesian_mesh)
 
@@ -10,12 +9,6 @@ Create a finite-element mesh.
 `cellsupports` stores the node indices of each cell. `cells(mesh)` iterates over
 cell indices, while `supportnodes(mesh, cell)` returns the nodes used by one
 cell.
-
-`FEMesh(shape, geometry)` selects the geometry nodes that coincide with the
-reference nodes of `shape`, renumbers them contiguously, and stores their
-coordinates as a view of `geometry.nodes`. Every reference node of `shape`
-must exist in the geometry cell. Coordinate changes through either mesh are
-shared; connectivity changes made later are not.
 
 The Cartesian constructors are convenience constructors for structured test
 meshes and examples. `FEMesh(cartesian_mesh)` uses the default first-order cell
@@ -37,39 +30,6 @@ end
 
 function FEMesh(shape::S, nodes::V, cellsupports::Vector{SVector{L, Int}}) where {S <: Shape, dim, T, L, V <: AbstractVector{Vec{dim, T}}}
     FEMesh{S, dim, T, L, V}(shape, nodes, cellsupports, _collect_supportnodes(cellsupports))
-end
-
-function FEMesh(shape::Shape, geometry::FEMesh)
-    _reference_cell_family(shape) === _reference_cell_family(cellshape(geometry)) || throw(ArgumentError("field and geometry must use the same reference-cell family"))
-    geometry_localnodes = localnodes(cellshape(geometry))
-    localindices = map(localnodes(shape)) do node
-        index = findfirst(==(node), geometry_localnodes)
-        isnothing(index) && throw(ArgumentError("each field node must also be a node of the geometry cell"))
-        index
-    end
-    supports_in_geometry = map(indices -> indices[localindices], geometry.cellsupports)
-    nodeindices = _collect_supportnodes(supports_in_geometry)
-    nodemap = zeros(Int, length(geometry))
-    nodemap[nodeindices] .= eachindex(nodeindices)
-    field_supports = map(indices -> map(i -> nodemap[i], indices), supports_in_geometry)
-    FEMesh(shape, view(geometry.nodes, nodeindices), field_supports)
-end
-
-function _collect_supportnodes(cellsupports)
-    nodes = Int[]
-    if !isempty(cellsupports)
-        sizehint!(nodes, length(cellsupports) * length(first(cellsupports)))
-    end
-    for indices in cellsupports
-        append!(nodes, indices)
-    end
-    unique!(sort!(nodes))
-end
-
-function _refresh_supportnodes!(mesh::FEMesh)
-    empty!(mesh.usednodes)
-    append!(mesh.usednodes, _collect_supportnodes(mesh.cellsupports))
-    mesh
 end
 
 Base.size(mesh::FEMesh) = size(mesh.nodes)
@@ -219,4 +179,133 @@ end
 function Base.merge(x::FEMesh{S}, y::FEMesh{S}, z::FEMesh{S}...) where {S}
     dest = FEMesh(cellshape(x), copy(x.nodes), copy(x.cellsupports))
     merge!(dest, y, z...)
+end
+
+"""
+    generate_field_meshes(meshes[, order])
+
+Construct consistently numbered field meshes from geometry meshes that share
+one node array. Maximum-dimensional cells define the field nodes;
+lower-dimensional meshes must match their faces or edges.
+
+Omit `order`, or pass the order already used by every shape, to preserve the
+geometry shapes. Pass `Order(1)` to replace them with first-order shapes. The
+returned meshes share a compact view of the geometry nodes. Tuple order and
+dictionary keys are preserved.
+"""
+function generate_field_meshes(meshes::Tuple{Vararg{FEMesh}}, order::Union{Nothing, Order}=nothing)
+    field_nodes, nodemap = _prepare_field_meshes(meshes, order)
+    map(mesh -> _build_field_mesh(mesh, field_nodes, nodemap, order), meshes)
+end
+
+function generate_field_meshes(meshes::AbstractDict{K, <: FEMesh}, order::Union{Nothing, Order}=nothing) where {K}
+    field_nodes, nodemap = _prepare_field_meshes(values(meshes), order)
+    Dict(key => _build_field_mesh(mesh, field_nodes, nodemap, order) for (key, mesh) in meshes)
+end
+
+# Return the requested field shape and the positions of its nodes in the geometry connectivity.
+_field_interpolation(shape::Shape, ::Nothing) = shape, eachindex(localnodes(shape))
+_field_interpolation(shape::Line, ::Order{1}) = Line2(), primarynodes_indices(shape)
+_field_interpolation(shape::Quad, ::Order{1}) = Quad4(), primarynodes_indices(shape)
+_field_interpolation(shape::Hex, ::Order{1}) = Hex8(), primarynodes_indices(shape)
+_field_interpolation(shape::Tri, ::Order{1}) = Tri3(), primarynodes_indices(shape)
+_field_interpolation(shape::Tet, ::Order{1}) = Tet4(), primarynodes_indices(shape)
+function _field_interpolation(shape::Shape, order::Order)
+    typeof(get_order(shape)) === typeof(order) && return shape, eachindex(localnodes(shape))
+    throw(ArgumentError("cannot generate an order-$(_order_value(order)) field from $(typeof(shape)) geometry; omit `order` to preserve the geometry shape or pass `Order(1)` to replace it with its first-order shape"))
+end
+
+# Preserve cell order and local orientation while translating connectivity to the shared field numbering.
+function _build_field_mesh(mesh::FEMesh, field_nodes, nodemap, order)
+    geometry_shape = cellshape(mesh)
+    field_shape, localindices = _field_interpolation(geometry_shape, order)
+
+    field_supports = map(cells(mesh)) do cell
+        indices = supportnodes(mesh, cell)
+        field_indices = nodemap[indices[localindices]]
+        # Zero marks a geometry node excluded from the field by the largest-dimensional cells.
+        any(iszero, field_indices) && throw(ArgumentError("each field node must belong to a maximum-dimensional field cell"))
+        field_indices
+    end
+
+    FEMesh(field_shape, field_nodes, field_supports)
+end
+
+# The largest-dimensional cells define the field. Lower-dimensional meshes may
+# only describe their faces or edges and cannot introduce field nodes.
+function _prepare_field_meshes(meshes, order)
+    isempty(meshes) && throw(ArgumentError("at least one geometry mesh is required"))
+
+    # Connectivity indices are comparable across meshes only when they index the same node array.
+    geometry_nodes = first(meshes).nodes
+    all(mesh -> mesh.nodes === geometry_nodes, meshes) || throw(ArgumentError("all geometry meshes must share the same node array and numbering"))
+    maxdim = maximum(mesh -> get_dimension(cellshape(mesh)), meshes)
+
+    # Pass 1: record every supplied lower-dimensional cell using its complete
+    # geometry connectivity, independently of the requested field order.
+    unmatched = [Set{Pair{Shape, SVector}}() for _ in 1:maxdim]
+    foreach(meshes) do mesh
+        shape = cellshape(mesh)
+        if get_dimension(shape) != maxdim
+            _field_interpolation(shape, order) # reject unsupported shape changes before constructing the numbering
+            for cell in cells(mesh)
+                indices = supportnodes(mesh, cell)
+                push!(unmatched[get_dimension(shape)], shape => sort(indices))
+            end
+        end
+    end
+
+    # Pass 2: largest-dimensional cells select the field nodes; walking their
+    # faces and edges removes the lower-dimensional cells recorded above.
+    active = falses(length(geometry_nodes))
+    foreach(meshes) do mesh
+        geometry_shape = cellshape(mesh)
+        if get_dimension(geometry_shape) == maxdim
+            _, localindices = _field_interpolation(geometry_shape, order)
+            for cell in cells(mesh)
+                geometry_indices = supportnodes(mesh, cell)
+                active[geometry_indices[localindices]] .= true
+                any(!isempty, unmatched) && _match_field_subentities!(unmatched, geometry_shape, geometry_indices)
+            end
+        end
+    end
+    # Anything left was not an actual face or edge of the largest-dimensional geometry.
+    all(isempty, unmatched) || throw(ArgumentError("each lower-dimensional geometry cell must be a subentity of a maximum-dimensional geometry cell"))
+
+    # Dense numbering avoids unused grid entries; the view keeps field coordinates shared with the geometry.
+    nodeindices = findall(active)
+    nodemap = zeros(Int, length(geometry_nodes))
+    nodemap[nodeindices] .= eachindex(nodeindices)
+    view(geometry_nodes, nodeindices), nodemap
+end
+
+# Walk the cell's faces recursively. Match by shape and complete node set while
+# ignoring local orientation.
+function _match_field_subentities!(unmatched, shape::Shape, indices)
+    delete!(unmatched[get_dimension(shape)], shape => sort(indices))
+    get_dimension(shape) == 1 && return
+
+    any(!isempty, @view unmatched[1:get_dimension(shape)-1]) || return
+
+    face_shape = faceshape(shape)
+    for face in faces(shape)
+        _match_field_subentities!(unmatched, face_shape, indices[face])
+    end
+end
+
+function _collect_supportnodes(cellsupports)
+    nodes = Int[]
+    if !isempty(cellsupports)
+        sizehint!(nodes, length(cellsupports) * length(first(cellsupports)))
+    end
+    for indices in cellsupports
+        append!(nodes, indices)
+    end
+    unique!(sort!(nodes))
+end
+
+function _refresh_supportnodes!(mesh::FEMesh)
+    empty!(mesh.usednodes)
+    append!(mesh.usednodes, _collect_supportnodes(mesh.cellsupports))
+    mesh
 end

--- a/test/fem.jl
+++ b/test/fem.jl
@@ -76,7 +76,7 @@
             [Vec(0.0, 0.0), Vec(1.0, 0.0), Vec(0.0, 1.0), Vec(0.5, 0.0), Vec(0.0, 0.5), Vec(0.5, 0.5 + α / 4)],
             [Tesserae.SVector(1, 2, 3, 4, 5, 6)],
         )
-        field = FEMesh(Tesserae.Tri3(), geometry)
+        field = only(generate_field_meshes((geometry,), Order(1)))
         rule = generate_quadrature_rule(Tesserae.Tri6())
         points = generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, geometry, rule)
         weights = generate_basis_weights(field, size(points); name=Val(:N))

--- a/test/gmsh.jl
+++ b/test/gmsh.jl
@@ -29,6 +29,11 @@ nodecoordinates(mesh) = sort([Tuple(mesh[i]) for i in eachindex(mesh)])
         ((0.0, 0.0), (0.0, 1.0)),
         ((1.0, 0.0), (1.0, 1.0)),
     ]
+
+    fields = generate_field_meshes(meshes, Order(1))
+    @test fields["domain"].nodes === fields["boundary"].nodes
+    @test supportnodes(fields["domain"]) == supportnodes(fields["boundary"]) == [1, 2, 3, 4]
+
     reoriented_boundary = readtestmsh("square.msh"; reorient_boundary=true)["boundary"]
     @test sort([cellcoordinates(reoriented_boundary, cell) for cell in cells(reoriented_boundary)]) == [
         ((0.0, 1.0), (0.0, 0.0)),

--- a/test/grid.jl
+++ b/test/grid.jl
@@ -51,7 +51,7 @@
     @test all(iszero, (grid.x)::Array{Vec{3,Float32},3})
 
     geometry = FEMesh(Tesserae.Quad9(), CartesianMesh(1, (0,2), (0,1)))
-    field = FEMesh(Tesserae.Quad4(), geometry)
+    field = only(generate_field_meshes((geometry,), Order(1)))
     field_grid = @inferred generate_grid(@NamedTuple{x::Vec{2,Float64}, p::Float64}, field)
     @test field_grid.x === field
     @test length(field_grid) == 6

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -305,8 +305,8 @@ end
 @testset "FEM sparse matrix pattern" begin
     cmesh = CartesianMesh(1, (0,1), (0,1))
     geometry = FEMesh(Tesserae.Quad9(), cmesh)
-    quad4 = FEMesh(Tesserae.Quad4(), geometry)
-    quad9 = FEMesh(Tesserae.Quad9(), geometry)
+    quad4 = only(generate_field_meshes((geometry,), Order(1)))
+    quad9 = only(generate_field_meshes((geometry,)))
 
     @test_throws UndefKeywordError create_sparse_matrix(quad4)
 

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -87,32 +87,94 @@ end
     @test Tesserae.cellshape(FEMesh(CartesianMesh(1, (0,2), (0,3)))) == Tesserae.Quad4()
     @test Tesserae.cellshape(FEMesh(CartesianMesh(1, (0,2), (0,3), (0,4)))) == Tesserae.Hex8()
 
-    mesh_with_unused_node = Tesserae.FEMesh(
-        Tesserae.Line2(),
-        [Vec(0.0), Vec(1.0), Vec(2.0)],
-        [Tesserae.SVector(1, 3)],
-    )
-    @test length(mesh_with_unused_node) == 3
-    @test supportnodes(mesh_with_unused_node) == [1, 3]
-    compact_mesh = FEMesh(Tesserae.Line2(), mesh_with_unused_node)
-    @test length(compact_mesh) == 2
-    @test compact_mesh.cellsupports == [Tesserae.SVector(1, 2)]
+    @testset "generate_field_meshes" begin
+        geometry = FEMesh(Tesserae.Quad9(), CartesianMesh(1, (0,2), (0,1)))
+        # The unused first node makes compact field numbering observable.
+        geometry_nodes = [Vec(-1.0, -1.0), geometry...]
+        geometry_supports = map(cell -> supportnodes(geometry, cell) .+ 1, cells(geometry))
+        left = FEMesh(Tesserae.Quad9(), geometry_nodes, geometry_supports[1:1])
+        right = FEMesh(Tesserae.Quad9(), geometry_nodes, geometry_supports[2:2])
+        bottom_face = first(Tesserae.faces(Tesserae.Quad9()))
+        left_boundary = geometry_supports[1][bottom_face]
+        right_boundary = geometry_supports[2][bottom_face]
+        # Reverse the second boundary cell to test preservation of its local ordering.
+        boundary = FEMesh(Tesserae.Line3(), geometry_nodes, [left_boundary, Tesserae.SVector(right_boundary[2], right_boundary[1], right_boundary[3])])
+        geometries = (left, right, boundary)
 
-    geometry = FEMesh(Tesserae.Quad9(), CartesianMesh(1, (0,2), (0,1)))
-    velocity = @inferred FEMesh(Tesserae.Quad9(), geometry)
-    pressure = @inferred FEMesh(Tesserae.Quad4(), geometry)
-    @test length(geometry) == length(velocity) == 15
-    @test length(pressure) == 6
-    @test parent(velocity.nodes) === parent(pressure.nodes) === geometry.nodes
-    @test pressure.cellsupports == [Tesserae.SVector(1, 2, 5, 4), Tesserae.SVector(2, 3, 6, 5)]
-    @test supportnodes(pressure) == collect(eachindex(pressure))
-    geometry[1] = Vec(-1.0, -1.0)
-    @test velocity[1] == pressure[1] == geometry[1]
-    pressure[1] = Vec(-2.0, -2.0)
-    @test velocity[1] == geometry[1] == pressure[1]
-    @test_throws ArgumentError merge!(pressure, FEMesh(Tesserae.Quad4(), geometry))
-    @test_throws ArgumentError FEMesh(Tesserae.Tri3(), geometry)
-    @test_throws ArgumentError FEMesh(Tesserae.Line3(), FEMesh(Tesserae.Line4(), [Vec(0.0), Vec(1.0), Vec(1 / 3), Vec(2 / 3)], [Tesserae.SVector(1, 2, 3, 4)]))
+        @testset "construction and numbering" begin
+            velocity = @inferred generate_field_meshes(geometries)
+            @test Tesserae.cellshape.(velocity) == (Tesserae.Quad9(), Tesserae.Quad9(), Tesserae.Line3())
+            @test length.(velocity) == (15, 15, 15)
+            @test velocity[1].nodes === velocity[2].nodes === velocity[3].nodes
+            @test parent(velocity[1].nodes) === geometry_nodes
+            @test supportnodes(velocity[1], 1) == supportnodes(geometry, 1)
+            @test supportnodes(velocity[2], 1) == supportnodes(geometry, 2)
+
+            same_order = @inferred generate_field_meshes(geometries, Order(2))
+            @test Tesserae.cellshape.(same_order) == Tesserae.cellshape.(velocity)
+            @test length.(same_order) == length.(velocity)
+            @test map(mesh -> supportnodes.(Ref(mesh), cells(mesh)), same_order) == map(mesh -> supportnodes.(Ref(mesh), cells(mesh)), velocity)
+
+            pressure = @inferred generate_field_meshes(geometries, Order(1))
+            @test Tesserae.cellshape.(pressure) == (Tesserae.Quad4(), Tesserae.Quad4(), Tesserae.Line2())
+            @test length.(pressure) == (6, 6, 6)
+            @test pressure[1].nodes === pressure[2].nodes === pressure[3].nodes
+            @test supportnodes(pressure[1], 1) == Tesserae.SVector(1, 2, 5, 4)
+            @test supportnodes(pressure[2], 1) == Tesserae.SVector(2, 3, 6, 5)
+            @test supportnodes.(Ref(pressure[3]), cells(pressure[3])) == [Tesserae.SVector(1, 2), Tesserae.SVector(3, 2)]
+            @test supportnodes(pressure[1]) == [1, 2, 4, 5]
+            @test supportnodes(pressure[3]) == [1, 2, 3]
+
+            field_dict = generate_field_meshes(Dict("left" => left, "right" => right, "boundary" => boundary), Order(1))
+            @test Set(keys(field_dict)) == Set(("left", "right", "boundary"))
+            @test supportnodes(field_dict["left"], 1) == supportnodes(pressure[1], 1)
+            @test supportnodes(field_dict["right"], 1) == supportnodes(pressure[2], 1)
+            @test supportnodes.(Ref(field_dict["boundary"]), cells(field_dict["boundary"])) == supportnodes.(Ref(pressure[3]), cells(pressure[3]))
+            @test field_dict["left"].nodes === field_dict["right"].nodes === field_dict["boundary"].nodes
+
+            original_node = geometry_nodes[2]
+            geometry_nodes[2] = Vec(-2.0, -2.0)
+            @test velocity[1][1] == pressure[1][1] == geometry_nodes[2]
+            pressure[1][1] = Vec(-3.0, -3.0)
+            @test velocity[1][1] == geometry_nodes[2] == pressure[1][1]
+            geometry_nodes[2] = original_node
+            @test_throws ArgumentError merge!(pressure[1], pressure[1])
+        end
+
+        @testset "validation" begin
+            diagonal = FEMesh(Tesserae.Line3(), geometry_nodes, [geometry_supports[1][Tesserae.SVector(1, 3, 9)]])
+            @test_throws ArgumentError generate_field_meshes((left, diagonal))
+            wrong_midpoint = FEMesh(Tesserae.Line3(), geometry_nodes, [Tesserae.SVector(left_boundary[1], left_boundary[2], geometry_supports[1][9])])
+            @test_throws ArgumentError generate_field_meshes((left, wrong_midpoint))
+            separate_boundary = FEMesh(Tesserae.Line3(), copy(geometry_nodes), supportnodes.(Ref(boundary), cells(boundary)))
+            @test_throws ArgumentError generate_field_meshes((left, separate_boundary))
+            @test_throws ArgumentError generate_field_meshes(())
+            line4 = FEMesh(Tesserae.Line4(), [Vec(0.0), Vec(1.0), Vec(1 / 3), Vec(2 / 3)], [Tesserae.SVector(1, 2, 3, 4)])
+            @test_throws ArgumentError generate_field_meshes((line4,), Order(2))
+        end
+
+        @testset "shape families and traces" begin
+            for (geometry_shape, field_shape, cmesh) in (
+                    (Tesserae.Line3(), Tesserae.Line2(), CartesianMesh(1, (0,1))),
+                    (Tesserae.Quad9(), Tesserae.Quad4(), CartesianMesh(1, (0,1), (0,1))),
+                    (Tesserae.Hex27(), Tesserae.Hex8(), CartesianMesh(1, (0,1), (0,1), (0,1))),
+                    (Tesserae.Tri6(), Tesserae.Tri3(), CartesianMesh(1, (0,1), (0,1))),
+                    (Tesserae.Tet10(), Tesserae.Tet4(), CartesianMesh(1, (0,1), (0,1), (0,1))),
+                )
+                field = only(generate_field_meshes((FEMesh(geometry_shape, cmesh),), Order(1)))
+                @test Tesserae.cellshape(field) == field_shape
+            end
+
+            volume_geometry = FEMesh(Tesserae.Hex27(), CartesianMesh(1, (0,1), (0,1), (0,1)))
+            surface_support = supportnodes(volume_geometry, only(cells(volume_geometry)))[first(Tesserae.faces(Tesserae.Hex27()))]
+            edge_support = surface_support[first(Tesserae.faces(Tesserae.Quad9()))]
+            surface_geometry = FEMesh(Tesserae.Quad9(), volume_geometry.nodes, [surface_support])
+            edge_geometry = FEMesh(Tesserae.Line3(), volume_geometry.nodes, [edge_support])
+            fields3d = @inferred generate_field_meshes((volume_geometry, surface_geometry, edge_geometry), Order(1))
+            @test Tesserae.cellshape.(fields3d) == (Tesserae.Hex8(), Tesserae.Quad4(), Tesserae.Line2())
+            @test length.(supportnodes.(fields3d)) == (8, 4, 2)
+        end
+    end
 
     function compute_volume(mesh)
         dim = Tesserae.get_dimension(Tesserae.cellshape(mesh))


### PR DESCRIPTION
Add `generate_field_meshes` to construct field mesh collections with one compact global node numbering shared across domain and boundary meshes. This makes mixed nodal FEM fields practical while preserving shared geometry coordinates and validating trace meshes.

Update the FEM call sites, documentation, changelog, and coverage for tuple, dictionary, and Gmsh inputs.