### PR TITLE
Linearize mixed FEM sparsity construction

### DIFF
--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -205,30 +205,23 @@ create_sparse_matrix(mesh::IGAMesh{dim}; ndofs) where {dim} = create_sparse_matr
 
 function create_sparse_matrix(::Type{T}, (mesh1,mesh2)::Tuple{FEMesh, FEMesh}; ndofs::Tuple{Int, Int}) where {T}
     mesh1 === mesh2 && return _create_cell_support_sparse_matrix(T, mesh1, ndofs)
+    _reference_cell_family(cellshape(mesh1)) === _reference_cell_family(cellshape(mesh2)) || throw(ArgumentError("FEM meshes must use the same reference-cell family"))
+    ncells(mesh1) == ncells(mesh2) || throw(DimensionMismatch("FEM meshes must have the same number of cells"))
 
     gdofs1 = LinearIndices((ndofs[1], length(mesh1)))
     gdofs2 = LinearIndices((ndofs[2], length(mesh2)))
-
-    nrow = length(gdofs1)
-    ncol = length(gdofs2)
+    primarynodes1 = primarynodes_indices(cellshape(mesh1))
+    primarynodes2 = primarynodes_indices(cellshape(mesh2))
 
     I, J = Int[], Int[]
-    for cell1 in cells(mesh1)
+    for (cell1, cell2) in zip(cells(mesh1), cells(mesh2))
         cellnodes1 = supportnodes(mesh1, cell1)
-        primary_cellnodes1 = cellnodes1[primarynodes_indices(cellshape(mesh1))]
-        celldofs1 = gdofs1[:, cellnodes1]
-
-        for cell2 in cells(mesh2)
-            cellnodes2 = supportnodes(mesh2, cell2)
-            primary_cellnodes2 = cellnodes2[primarynodes_indices(cellshape(mesh2))]
-            if mesh1[primary_cellnodes1] ≈ mesh2[primary_cellnodes2]
-                celldofs2 = gdofs2[:, cellnodes2]
-                append_dofs!(I, J, celldofs1, celldofs2)
-            end
-        end
+        cellnodes2 = supportnodes(mesh2, cell2)
+        mesh1[cellnodes1[primarynodes1]] ≈ mesh2[cellnodes2[primarynodes2]] || throw(ArgumentError("FEM meshes must describe the same cells in the same order and orientation; cell $cell1 does not match"))
+        append_dofs!(I, J, gdofs1[:, cellnodes1], gdofs2[:, cellnodes2])
     end
 
-    sparse(I, J, zeros(T, length(I)), nrow, ncol)
+    sparse(I, J, zeros(T, length(I)), length(gdofs1), length(gdofs2))
 end
 create_sparse_matrix(meshes::Tuple{FEMesh, FEMesh}; ndofs::Tuple{Int, Int}) = create_sparse_matrix(Float64, meshes; ndofs)
 create_sparse_matrix(::Type{T}, mesh::FEMesh{<: Any, dim}; ndofs::Int) where {T, dim} = create_sparse_matrix(T, (mesh,mesh); ndofs=(ndofs,ndofs))

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -303,7 +303,7 @@ end
 end
 
 @testset "FEM sparse matrix pattern" begin
-    cmesh = CartesianMesh(1, (0,1), (0,1))
+    cmesh = CartesianMesh(1, (0,2), (0,1))
     geometry = FEMesh(Tesserae.Quad9(), cmesh)
     quad4 = only(generate_field_meshes((geometry,), Order(1)))
     quad9 = only(generate_field_meshes((geometry,)))
@@ -311,11 +311,32 @@ end
     @test_throws UndefKeywordError create_sparse_matrix(quad4)
 
     A = create_sparse_matrix((quad9, quad4); ndofs=(2, 1))
-    @test size(A) == (18, 4)
-    @test Tesserae.SparseArrays.nnz(A) == prod(size(A))
+    @test size(A) == (30, 6)
+    @test Tesserae.SparseArrays.nnz(A) == 132
 
-    shifted = FEMesh(Tesserae.Quad4(), CartesianMesh(1, (2,3), (2,3)))
-    B = create_sparse_matrix((quad9, shifted); ndofs=(2, 1))
-    @test size(B) == (2length(quad9), length(shifted))
-    @test iszero(Tesserae.SparseArrays.nnz(B))
+    GridPropU = @NamedTuple{x::Vec{2,Float64}, u::Vec{2,Float64}}
+    GridPropP = @NamedTuple{x::Vec{2,Float64}, p::Float64}
+    PointProp = @NamedTuple{x::Vec{2,Float64}, V::Float64}
+    velocity_grid = generate_grid(GridPropU, quad9)
+    pressure_grid = generate_grid(GridPropP, quad4)
+    points = generate_particles(PointProp, geometry)
+    velocity_weights = generate_basis_weights(quad9, size(points); name=Val(:N))
+    pressure_weights = generate_basis_weights(quad4, size(points); name=Val(:N))
+    update!(velocity_weights, points, geometry; measure=points.V)
+    update!(pressure_weights, points, geometry)
+
+    @P2G_Matrix (velocity_grid,pressure_grid)=>(i,j) points=>p (velocity_weights,pressure_weights)=>(ip,jp) begin
+        A[i,j] = @∑ ∇N[ip] * N[jp] * V[p]
+    end
+    @test any(!iszero, Tesserae.SparseArrays.nonzeros(A))
+
+    shifted = FEMesh(Tesserae.Quad4(), CartesianMesh(1, (2,4), (0,1)))
+    @test_throws ArgumentError create_sparse_matrix((quad9, shifted); ndofs=(2, 1))
+
+    reversed_supports = supportnodes.(Ref(quad4), reverse(collect(cells(quad4))))
+    reversed = FEMesh(Tesserae.Quad4(), collect(quad4), reversed_supports)
+    @test_throws ArgumentError create_sparse_matrix((quad9, reversed); ndofs=(2, 1))
+
+    partial = FEMesh(Tesserae.Quad4(), collect(quad4[supportnodes(quad4, 1)]), [Tesserae.SVector(1, 2, 3, 4)])
+    @test_throws DimensionMismatch create_sparse_matrix((quad9, partial); ndofs=(2, 1))
 end


### PR DESCRIPTION
Replace the all-pairs FEM cell search with a linear traversal of corresponding field cells.

Validate that the row and column meshes use the same reference-cell family, cell count, ordering, and orientation. Add a multi-cell Q2/Q1 regression that assembles a coupling block with distinct grids and basis weights.