### PR TITLE
Separate FEM field and geometry updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,9 @@ macros.
 - `CPDI` on `SpGrid` is now rejected explicitly; use a dense grid for CPDI.
   (#130)
 - `feupdate!` has been removed. Use
-  `update!(weights, points, geometry; measure=nothing, normal=nothing)` instead;
-  `points` carries the quadrature rule.
+  `update!(weights, points, fieldmesh; geometry=fieldmesh, measure=nothing,
+  normal=nothing)` instead; `points` carries the quadrature rule. For mixed
+  interpolation, pass the geometry mesh with the `geometry` keyword.
 - The finite-element mesh type has been renamed from `UnstructuredMesh` to
   `FEMesh`; the old name is no longer available. (#156)
 

--- a/docs/src/fem.md
+++ b/docs/src/fem.md
@@ -352,6 +352,6 @@ plot_solution(domain, grid.u, outer_boundary, hole_boundary)
 FEMesh
 generate_field_meshes
 supportnodes(::FEMesh)
-update!(::BasisWeightArray{S}, ::QuadraturePoints, ::FEMesh{<:Tesserae.Shape{pdim},dim}) where {pdim,dim,S<:Tesserae.Shape{pdim}}
+update!(::BasisWeightArray{S}, ::QuadraturePoints, ::FEMesh{S,dim}) where {pdim,dim,S<:Tesserae.Shape{pdim}}
 readmsh
 ```

--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -292,7 +292,31 @@ end
 _generate_supportnodes(basis, mesh::CartesianMesh, dims) = map(_ -> initial_supportnodes(basis, mesh), CartesianIndices(dims))
 
 # FEMesh
-_generate_supportnodes(::Shape, mesh::FEMesh, dims::Dims{2}) = _generate_cell_supportnodes(mesh, dims)
+mutable struct CellSupportMatrix{T, V <: AbstractVector{T}} <: AbstractMatrix{T}
+    const dims::Dims{2}
+    cellsupports::V
+end
+
+function CellSupportMatrix(supports::V, nq::Int, ncells::Int) where {T, V <: AbstractVector{T}}
+    ncells == length(supports) || throw(DimensionMismatch("the second basis-weight dimension must equal the number of cells"))
+    CellSupportMatrix{T, V}((nq, ncells), supports)
+end
+
+Base.size(A::CellSupportMatrix) = A.dims
+Base.IndexStyle(::Type{<: CellSupportMatrix}) = IndexCartesian()
+cellsupports(A::CellSupportMatrix) = getfield(A, :cellsupports)
+@inline function Base.getindex(A::CellSupportMatrix, q::Int, cell::Int)
+    @boundscheck checkbounds(A, q, cell)
+    @inbounds cellsupports(A)[cell]
+end
+
+function set_cellsupports!(A::CellSupportMatrix{T, V}, supports::V) where {T, V}
+    length(supports) == size(A, 2) || throw(DimensionMismatch("the number of cells must match the second basis-weight dimension"))
+    setfield!(A, :cellsupports, supports)
+    A
+end
+
+_generate_supportnodes(::Shape, mesh::FEMesh, dims::Dims{2}) = CellSupportMatrix(cellsupports(mesh), dims...)
 _generate_supportnodes(::Shape, ::FEMesh, ::Dims) = throw(DimensionMismatch("FEM basis weights must have dimensions (quadrature points, cells)"))
 
 function _generate_cell_supportnodes(mesh, dims::Dims{2})

--- a/src/fem.jl
+++ b/src/fem.jl
@@ -7,13 +7,12 @@ end
 end
 
 """
-    update!(weights::BasisWeightArray{<:Shape}, points::QuadraturePoints, geometry::FEMesh; measure=nothing, normal=nothing)
+    update!(weights::BasisWeightArray{<:Shape}, points::QuadraturePoints, fieldmesh::FEMesh; geometry=fieldmesh, measure=nothing, normal=nothing)
 
-Evaluate the FEM field basis stored by `weights` at the reference points in
-`quadrature_rule(points)`. `geometry` supplies the mapping to physical space.
-The field and geometry may use different shapes from the same reference-cell
-family, provided that they describe the same cells in the same order and
-orientation.
+Evaluate the basis of `fieldmesh` using the quadrature rule stored in `points`,
+with `geometry` defining the physical mapping. `geometry` defaults to
+`fieldmesh`. If they differ, the meshes must describe the same cells in the
+same order and orientation.
 
 For full-dimensional cells, `weights` stores basis values and physical
 gradients. For boundary cells, it stores basis values. `measure` receives the
@@ -21,16 +20,20 @@ physical quadrature measure, and `normal` receives boundary unit normals.
 """
 function update!(
         weights::BasisWeightArray{S}, points::QuadraturePoints,
-        geometry::FEMesh{<: Shape{pdim}, dim};
+        fieldmesh::FEMesh{S, dim};
+        geometry::FEMesh=fieldmesh,
         measure::Union{Nothing, AbstractArray}=nothing,
         normal::Union{Nothing, AbstractArray}=nothing,
     ) where {pdim, dim, S <: Shape{pdim}}
+    length(eltype(geometry)) == dim || throw(DimensionMismatch("field and geometry physical dimensions must match"))
     _reference_cell_family(basis(weights)) === _reference_cell_family(cellshape(geometry)) || throw(ArgumentError("field and geometry must use the same reference-cell family"))
+    ncells(fieldmesh) == ncells(geometry) || throw(DimensionMismatch("field and geometry must have the same number of cells"))
+    set_cellsupports!(getfield(weights, :indices), cellsupports(fieldmesh))
     is_domain = pdim == dim
     mode = pdim == dim ? Val(:domain) : Val(:boundary)
     rule = _check_quadrature_inputs(is_domain, weights, points, geometry, measure, normal)
 
-    field_shape = basis(weights)
+    field_shape = cellshape(fieldmesh)
     geometry_shape = cellshape(geometry)
     field_qdata = jet.(Ref(Order(1)), Ref(field_shape), rule.points)
     geometry_qdata = field_shape === geometry_shape ? field_qdata : jet.(Ref(Order(1)), Ref(geometry_shape), rule.points)

--- a/src/femesh.jl
+++ b/src/femesh.jl
@@ -45,8 +45,9 @@ end
 end
 
 cellshape(mesh::FEMesh) = mesh.shape
-ncells(mesh::FEMesh) = length(mesh.cellsupports)
-cells(mesh::FEMesh) = eachindex(mesh.cellsupports)
+cellsupports(mesh::FEMesh) = getfield(mesh, :cellsupports)
+ncells(mesh::FEMesh) = length(cellsupports(mesh))
+cells(mesh::FEMesh) = eachindex(cellsupports(mesh))
 
 """
     supportnodes(mesh::FEMesh)
@@ -55,8 +56,8 @@ cells(mesh::FEMesh) = eachindex(mesh.cellsupports)
 Return the sorted node indices used by `mesh`, or the local support node
 indices of `cell`.
 """
-@inline supportnodes(mesh::FEMesh) = mesh.usednodes
-@inline supportnodes(mesh::FEMesh, cell::Int) = (@_propagate_inbounds_meta; mesh.cellsupports[cell])
+@inline supportnodes(mesh::FEMesh) = getfield(mesh, :usednodes)
+@inline supportnodes(mesh::FEMesh, cell::Int) = (@_propagate_inbounds_meta; cellsupports(mesh)[cell])
 
 FEMesh(mesh::CartesianMesh) = FEMesh(default_cellshape(mesh), mesh)
 default_cellshape(::CartesianMesh{1}) = Line2()
@@ -163,12 +164,12 @@ function Base.merge!(dest::FEMesh{S}, src::FEMesh{S}) where {S}
         end
     end
 
-    sortedinds_src = map(inds -> sort(nodemap[inds]), src.cellsupports)
-    sortedinds_dst = map(sort, dest.cellsupports)
+    sortedinds_src = map(inds -> sort(nodemap[inds]), cellsupports(src))
+    sortedinds_dst = map(sort, cellsupports(dest))
     for cell in cells(src)
         inds_src = sortedinds_src[cell]
         if all(inds_dest -> inds_src !== inds_dest, sortedinds_dst)
-            push!(dest.cellsupports, nodemap[supportnodes(src, cell)])
+            push!(cellsupports(dest), nodemap[supportnodes(src, cell)])
         end
     end
     _refresh_supportnodes!(dest)
@@ -177,7 +178,7 @@ function Base.merge!(dest::FEMesh{S}, src1::FEMesh{S}, src2::FEMesh{S}, others::
     merge!(merge!(dest, src1), src2, others...)
 end
 function Base.merge(x::FEMesh{S}, y::FEMesh{S}, z::FEMesh{S}...) where {S}
-    dest = FEMesh(cellshape(x), copy(x.nodes), copy(x.cellsupports))
+    dest = FEMesh(cellshape(x), copy(x.nodes), copy(cellsupports(x)))
     merge!(dest, y, z...)
 end
 
@@ -305,7 +306,7 @@ function _collect_supportnodes(cellsupports)
 end
 
 function _refresh_supportnodes!(mesh::FEMesh)
-    empty!(mesh.usednodes)
-    append!(mesh.usednodes, _collect_supportnodes(mesh.cellsupports))
+    empty!(supportnodes(mesh))
+    append!(supportnodes(mesh), _collect_supportnodes(cellsupports(mesh)))
     mesh
 end

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -68,8 +68,8 @@ end
 # FEMesh
 function KernelAbstractions.get_backend(mesh::FEMesh)
     backend = get_backend(mesh.nodes)
-    @assert get_backend(mesh.cellsupports) == backend
-    @assert get_backend(mesh.usednodes) == backend
+    @assert get_backend(cellsupports(mesh)) == backend
+    @assert get_backend(supportnodes(mesh)) == backend
     backend
 end
 
@@ -81,6 +81,9 @@ Adapt.adapt_structure(to, points::QuadraturePoints) = QuadraturePoints(adapt(to,
 KernelAbstractions.get_backend(points::QuadraturePoints) = get_backend(parent(points))
 
 # BasisWeightArray
+Adapt.adapt_structure(to, A::CellSupportMatrix) = CellSupportMatrix(adapt(to, cellsupports(A)), size(A)...)
+KernelAbstractions.get_backend(A::CellSupportMatrix) = get_backend(cellsupports(A))
+
 function Adapt.adapt_structure(to, weights::BasisWeightArray)
     b = basis(weights)
     vals = map(a -> adapt(to, a), getfield(weights, :vals))

--- a/test/fem.jl
+++ b/test/fem.jl
@@ -20,6 +20,7 @@
 
         @test_throws ArgumentError generate_particles(@NamedTuple{x::Vec{2,Float64}}, geometry, generate_quadrature_rule(Tesserae.Tri6()))
         @test quadrature_rule(points) === rule
+        @test Tesserae.cellsupports(getfield(weights, :indices)) === Tesserae.cellsupports(field)
         @test points[1,1] == parent(points)[1,1]
         points_view = @inferred view(points, :, [1])
         @test quadrature_rule(points_view) === rule
@@ -34,7 +35,7 @@
         @test parent(adapted_points) isa Tesserae.StructArray
         @test quadrature_rule(adapted_points) === rule
         @test supportnodes(weights[1,1]) == Tesserae.SVector(2, 3, 4, 5)
-        @test (@inferred update!(weights, points, geometry; measure=points.V)) === weights
+        @test (@inferred update!(weights, points, field; geometry, measure=points.V)) === weights
         for (q, (point, weight)) in enumerate(zip(rule.points, rule.weights))
             ξ, η = point
             N, dNdξ = Tesserae.jet(Order(1), Tesserae.Quad4(), point)
@@ -46,6 +47,11 @@
             @test points.V[q,1] ≈ weight * det(J)
         end
         @test sum(points.V) ≈ 1 + 2α / 3
+
+        other_field = FEMesh(Tesserae.Quad4(), field.nodes, [Tesserae.SVector(1, 2, 3, 4)])
+        update!(weights, points, other_field; geometry)
+        @test Tesserae.cellsupports(getfield(weights, :indices)) === Tesserae.cellsupports(other_field)
+        @test supportnodes(weights[1,1]) == Tesserae.SVector(1, 2, 3, 4)
     end
 
     @testset "Higher-order field" begin
@@ -62,8 +68,8 @@
 
         @test supportnodes(weights[1,1]) == Tesserae.SVector(2, 3, 4, 5, 6, 7, 8, 9, 10)
         value_weights = generate_basis_weights(field, size(points); derivative=Order(0))
-        @test_throws ArgumentError update!(value_weights, points, geometry)
-        @test update!(weights, points, geometry; measure=points.V) === weights
+        @test_throws ArgumentError update!(value_weights, points, field; geometry)
+        @test update!(weights, points, field; geometry, measure=points.V) === weights
         @test all(q -> weights[q,1].N ≈ Tesserae.value(Tesserae.Quad9(), rule.points[q]), eachindex(rule.points))
         @test all(q -> weights[q,1].∇N ≈ last(Tesserae.jet(Order(1), Tesserae.Quad9(), rule.points[q])) .⊡ Ref(inv(J)), eachindex(rule.points))
         @test points.V[:,1] ≈ rule.weights / 4
@@ -81,7 +87,7 @@
         points = generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, geometry, rule)
         weights = generate_basis_weights(field, size(points); name=Val(:N))
 
-        update!(weights, points, geometry; measure=points.V)
+        update!(weights, points, field; geometry, measure=points.V)
         for (q, (point, weight)) in enumerate(zip(rule.points, rule.weights))
             @test weights[q,1].N ≈ Tesserae.value(Tesserae.Tri3(), point)
             @test supportnodes(weights[q,1]) == Tesserae.SVector(1, 2, 3)
@@ -98,7 +104,7 @@
         points = generate_particles(@NamedTuple{x::Vec{2,Float64}, dS::Float64, n::Vec{2,Float64}}, geometry, rule)
         weights = generate_basis_weights(field, size(points); name=Val(:N))
 
-        update!(weights, points, geometry; measure=points.dS, normal=points.n)
+        update!(weights, points, field; geometry, measure=points.dS, normal=points.n)
         for (q, (point, weight)) in enumerate(zip(rule.points, rule.weights))
             tangent = Vec(0.5, -2h * point[1])
             scale = norm(tangent)

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -322,8 +322,8 @@ end
     points = generate_particles(PointProp, geometry)
     velocity_weights = generate_basis_weights(quad9, size(points); name=Val(:N))
     pressure_weights = generate_basis_weights(quad4, size(points); name=Val(:N))
-    update!(velocity_weights, points, geometry; measure=points.V)
-    update!(pressure_weights, points, geometry)
+    update!(velocity_weights, points, quad9; geometry, measure=points.V)
+    update!(pressure_weights, points, quad4; geometry)
 
     @P2G_Matrix (velocity_grid,pressure_grid)=>(i,j) points=>p (velocity_weights,pressure_weights)=>(ip,jp) begin
         A[i,j] = @∑ ∇N[ip] * N[jp] * V[p]

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -76,8 +76,8 @@ end
     @test length(mesh) == 35
     @test Tesserae.ncells(mesh) == 24
     @test collect(cells(mesh)) == collect(1:Tesserae.ncells(mesh))
-    @test supportnodes(mesh, 1) === mesh.cellsupports[1]
-    @test supportnodes(mesh) === mesh.usednodes
+    @test supportnodes(mesh, 1) === Tesserae.cellsupports(mesh)[1]
+    @test supportnodes(mesh) === getfield(mesh, :usednodes)
     @test supportnodes(mesh) == collect(eachindex(mesh))
     @test mesh == vec(cmesh)
     cmesh′ = CartesianMesh(0.5, (1,3), (1,4))


### PR DESCRIPTION
Allow FEM basis updates to take the field mesh explicitly while using an optional geometry mesh for the physical mapping.

- Rebind basis-weight cell connectivity to the field mesh without copying it on every update.
- Keep isoparametric updates concise with `geometry=fieldmesh` as the default.
- Separate mesh-wide support nodes from the internal per-cell connectivity accessor.
