### PR TITLE
Separate IGA field and geometry meshes

### DIFF
--- a/docs/src/iga.md
+++ b/docs/src/iga.md
@@ -403,7 +403,7 @@ IGAPatch
 IGAMesh
 IGABasis
 boundaries
-update!(::BasisWeightArray{B}, ::QuadraturePoints, ::IGAMesh{dim,pdim}) where {dim,pdim,B<:IGABasis{pdim}}
+update!(::BasisWeightArray{B}, ::QuadraturePoints, ::IGAMesh{dim,pdim,T,Degrees}) where {dim,pdim,T,Degrees,B<:IGABasis{pdim,Degrees}}
 ```
 
 ### NURBS

--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -291,7 +291,7 @@ end
 # CartesianMesh
 _generate_supportnodes(basis, mesh::CartesianMesh, dims) = map(_ -> initial_supportnodes(basis, mesh), CartesianIndices(dims))
 
-# FEMesh
+# FEM/IGA
 mutable struct CellSupportMatrix{T, V <: AbstractVector{T}} <: AbstractMatrix{T}
     const dims::Dims{2}
     cellsupports::V
@@ -321,8 +321,7 @@ _generate_supportnodes(::Shape, ::FEMesh, ::Dims) = throw(DimensionMismatch("FEM
 
 function _generate_cell_supportnodes(mesh, dims::Dims{2})
     dims[2] == ncells(mesh) || throw(DimensionMismatch("the second basis-weight dimension must equal the number of cells"))
-    cell_supports = map(cell -> supportnodes(mesh, cell), cells(mesh))
-    map(I -> cell_supports[I[2]], CartesianIndices(dims))
+    CellSupportMatrix(map(cell -> supportnodes(mesh, cell), cells(mesh)), dims...)
 end
 
 _todims(x::Tuple{Vararg{Int}}) = x

--- a/src/fem.jl
+++ b/src/fem.jl
@@ -50,33 +50,65 @@ function update!(
 end
 
 """
-    update!(weights::BasisWeightArray{<:IGABasis}, points::QuadraturePoints, geometry::IGAMesh; measure=nothing, normal=nothing)
+    update!(weights::BasisWeightArray{<:IGABasis}, points::QuadraturePoints, fieldmesh::IGAMesh; geometry=fieldmesh, measure=nothing, normal=nothing)
 
-Evaluate the IGA basis of `geometry` at the reference points in
-`quadrature_rule(points)` and store the result in `weights`. `measure` and
-`normal` have the same roles as in the FEM method.
+Evaluate the basis of `fieldmesh` using `geometry` for the physical mapping.
+The meshes may have different degrees and control-point numbering, but must
+have corresponding patches with the same nonzero knot-span intervals. `measure`
+and `normal` have the same roles as in the FEM method.
 """
 function update!(
         weights::BasisWeightArray{B}, points::QuadraturePoints,
-        geometry::IGAMesh{dim, pdim};
+        fieldmesh::IGAMesh{dim, pdim, T, Degrees};
+        geometry::IGAMesh{dim, pdim}=fieldmesh,
         measure::Union{Nothing, AbstractArray}=nothing,
         normal::Union{Nothing, AbstractArray}=nothing,
-    ) where {dim, pdim, B <: IGABasis{pdim}}
-    degrees(basis(weights)) == degrees(igabasis(geometry)) || throw(ArgumentError("IGA field and geometry degrees must match"))
+    ) where {dim, pdim, T, Degrees, B <: IGABasis{pdim, Degrees}}
     is_domain = pdim == dim
     mode = pdim == dim ? Val(:domain) : Val(:boundary)
     rule = _check_quadrature_inputs(is_domain, weights, points, geometry, measure, normal)
+    fieldmesh === geometry && return _update_iga!(mode, weights, rule, fieldmesh, measure, normal)
+    _check_iga_cell_partition(fieldmesh, geometry)
 
-    for cell in cells(geometry)
-        indices = supportnodes(geometry, cell)
-        supportnodes(weights[1,cell]) == indices || throw(ArgumentError("IGA basis weights and geometry must use the same cell connectivity"))
-        x = geometry[indices]
-        patch = patches(geometry, cell.patch)
+    field_supports = cellsupports(getfield(weights, :indices))
+    for (field_cell, geometry_cell) in zip(cells(fieldmesh), cells(geometry))
+        field_indices = supportnodes(fieldmesh, field_cell)
+        @inbounds field_supports[field_cell] = field_indices
+        geometry_indices = supportnodes(geometry, geometry_cell)
+        field_patch = patches(fieldmesh, field_cell.patch)
+        geometry_patch = patches(geometry, geometry_cell.patch)
+        x = geometry[geometry_indices]
+        for q in eachindex(rule.points, rule.weights)
+            field_ξ = span_point(field_patch, field_cell.span, rule.points[q])
+            N, dNdξ = iga_basis_values_and_gradients(field_patch, field_cell.span, field_ξ)
+            if fieldmesh.weights !== nothing
+                N, dNdξ = rational_basis_values_and_gradients(N, dNdξ, fieldmesh.weights[field_indices])
+            end
+            geometry_ξ = span_point(geometry_patch, geometry_cell.span, rule.points[q])
+            geometry_N, geometry_dNdξ = iga_basis_values_and_gradients(geometry_patch, geometry_cell.span, geometry_ξ)
+            if geometry.weights !== nothing
+                _, geometry_dNdξ = rational_basis_values_and_gradients(geometry_N, geometry_dNdξ, geometry.weights[geometry_indices])
+            end
+            J = sum(x .⊗ geometry_dNdξ)
+            weight = span_weight(geometry_patch, geometry_cell.span, rule.weights[q])
+            _set_quadrature_data!(mode, weights[q,field_cell], measure, normal, q, geometry_cell, N, dNdξ, J, weight)
+        end
+    end
+    weights
+end
+
+function _update_iga!(mode, weights, rule, mesh, measure, normal)
+    field_supports = cellsupports(getfield(weights, :indices))
+    for cell in cells(mesh)
+        indices = supportnodes(mesh, cell)
+        @inbounds field_supports[cell] = indices
+        x = mesh[indices]
+        patch = patches(mesh, cell.patch)
         for q in eachindex(rule.points, rule.weights)
             ξ = span_point(patch, cell.span, rule.points[q])
             N, dNdξ = iga_basis_values_and_gradients(patch, cell.span, ξ)
-            if geometry.weights !== nothing
-                N, dNdξ = rational_basis_values_and_gradients(N, dNdξ, geometry.weights[indices])
+            if mesh.weights !== nothing
+                N, dNdξ = rational_basis_values_and_gradients(N, dNdξ, mesh.weights[indices])
             end
             J = sum(x .⊗ dNdξ)
             weight = span_weight(patch, cell.span, rule.weights[q])
@@ -84,6 +116,23 @@ function update!(
         end
     end
     weights
+end
+
+function _check_iga_cell_partition(fieldmesh, geometry)
+    length(patches(fieldmesh)) == length(patches(geometry)) || throw(DimensionMismatch("field and geometry must have the same number of patches"))
+    for (field_patch, geometry_patch) in zip(patches(fieldmesh), patches(geometry))
+        for d in eachindex(degrees(field_patch))
+            field_knots = field_patch.knot_vectors[d]
+            geometry_knots = geometry_patch.knot_vectors[d]
+            field_spans = Iterators.filter(i -> _has_positive_span(field_knots, i), _active_span_range(field_knots, degrees(field_patch, d)))
+            geometry_spans = Iterators.filter(i -> _has_positive_span(geometry_knots, i), _active_span_range(geometry_knots, degrees(geometry_patch, d)))
+            _span_count(field_knots, degrees(field_patch, d)) == _span_count(geometry_knots, degrees(geometry_patch, d)) || throw(DimensionMismatch("field and geometry must have the same number of nonzero knot spans"))
+            for (field_span, geometry_span) in zip(field_spans, geometry_spans)
+                field_knots[field_span] == geometry_knots[geometry_span] && field_knots[field_span+1] == geometry_knots[geometry_span+1] || throw(ArgumentError("field and geometry must have the same nonzero knot spans"))
+            end
+        end
+    end
+    nothing
 end
 
 function _check_quadrature_inputs(is_domain, weights, points, geometry, measure, normal)

--- a/src/igamesh.jl
+++ b/src/igamesh.jl
@@ -67,14 +67,20 @@ struct IGAMesh{dim, pdim, T, Degrees <: NTuple{pdim, Degree}} <: AbstractMesh{di
     end
 end
 
-function IGAMesh(patches::Vector{IGAPatch{pdim, T, Degrees}}, controlpoints::Vector{Vec{dim, T}}, weights=nothing) where {dim, T, pdim, Degrees <: NTuple{pdim, Degree}}
-    IGAMesh{dim, pdim, T, Degrees}(patches, controlpoints, _controlpoint_weights(T, weights))
+function _check_iga_mesh(patches, controlpoints, weights)
+    isempty(patches) && throw(ArgumentError("patches must not be empty"))
+    _check_controlpoint_weights(weights, controlpoints)
+    for patch in patches
+        ids = patch.controlpoint_ids
+        minimum(ids) < 1 && throw(ArgumentError("controlpoint ids must be positive"))
+        maximum(ids) > length(controlpoints) && throw(ArgumentError("controlpoint ids must not exceed the number of control points"))
+    end
+    nothing
 end
-
-function IGAMesh(mesh::CartesianMesh{dim, T}; degree::Degree, weights=nothing) where {dim, T}
-    patch_degrees = _uniform_degrees(degree, Val(dim))
-    patch, controlpoints = _patch_from_cartesian_mesh(mesh, patch_degrees)
-    IGAMesh([patch], controlpoints, _controlpoint_weights(T, weights))
+_check_controlpoint_weights(::Nothing, controlpoints) = nothing
+function _check_controlpoint_weights(weights::AbstractVector, controlpoints)
+    length(weights) == length(controlpoints) || throw(ArgumentError("weights length must match controlpoints length"))
+    nothing
 end
 
 function _collect_used_controlpoint_ids(patches::AbstractVector{<: IGAPatch})
@@ -83,6 +89,16 @@ function _collect_used_controlpoint_ids(patches::AbstractVector{<: IGAPatch})
         append!(nodes, patch.controlpoint_ids)
     end
     unique!(sort!(nodes))
+end
+
+function IGAMesh(patches::Vector{IGAPatch{pdim, T, Degrees}}, controlpoints::Vector{Vec{dim, T}}, weights=nothing) where {dim, T, pdim, Degrees <: NTuple{pdim, Degree}}
+    IGAMesh{dim, pdim, T, Degrees}(patches, controlpoints, _controlpoint_weights(T, weights))
+end
+
+function IGAMesh(mesh::CartesianMesh{dim, T}; degree::Degree, weights=nothing) where {dim, T}
+    patch_degrees = _uniform_degrees(degree, Val(dim))
+    patch, controlpoints = _patch_from_cartesian_mesh(mesh, patch_degrees)
+    IGAMesh([patch], controlpoints, _controlpoint_weights(T, weights))
 end
 
 """
@@ -107,7 +123,7 @@ function IGAMesh(nets::AbstractVector{<: NURBS.ControlNet{dim, pdim, T}}; merge:
     weights = T[]
     for net in nets
         degrees(net) == patch_degrees || throw(ArgumentError("control net degrees must match"))
-        ids = controlpoint_ids!(controlpoints, weights, net; merge, atol, rtol)
+        ids = register_controlpoints_and_weights!(controlpoints, weights, net; merge, atol, rtol)
         push!(patches, IGAPatch(patch_degrees, knot_vectors(net), ids))
     end
     IGAMesh(patches, controlpoints, weights)
@@ -116,7 +132,7 @@ end
 degrees(net::NURBS.ControlNet) = map(axis -> Degree(axis.degree), net.axes)
 knot_vectors(net::NURBS.ControlNet) = map(axis -> copy(axis.knot_vector), net.axes)
 
-function controlpoint_ids!(controlpoints, weights, net::NURBS.ControlNet; merge::Bool, atol, rtol)
+function register_controlpoints_and_weights!(controlpoints, weights, net::NURBS.ControlNet; merge::Bool, atol, rtol)
     controlpoint_ids = Array{Int}(undef, size(net.points))
     for I in CartesianIndices(net.points)
         id = merge ? matching_controlpoint(controlpoints, weights, net.points[I], net.weights[I], atol, rtol) : 0
@@ -198,22 +214,6 @@ end
 @inline function Base.setindex!(mesh::IGAMesh, x, i::Int)
     @_propagate_inbounds_meta
     mesh.controlpoints[i] = x
-end
-
-function _check_iga_mesh(patches, controlpoints, weights)
-    isempty(patches) && throw(ArgumentError("patches must not be empty"))
-    _check_controlpoint_weights(weights, controlpoints)
-    for patch in patches
-        ids = patch.controlpoint_ids
-        minimum(ids) < 1 && throw(ArgumentError("controlpoint ids must be positive"))
-        maximum(ids) > length(controlpoints) && throw(ArgumentError("controlpoint ids must not exceed the number of control points"))
-    end
-    nothing
-end
-_check_controlpoint_weights(::Nothing, controlpoints) = nothing
-function _check_controlpoint_weights(weights::AbstractVector, controlpoints)
-    length(weights) == length(controlpoints) || throw(ArgumentError("weights length must match controlpoints length"))
-    nothing
 end
 
 """

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -254,10 +254,45 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         @test sum(measure[:, meshcells[1]]) ≈ 1/16
         @test sum(measure) ≈ 1
 
+        field = IGAMesh(cmesh; degree=Linear(), weights=range(1.0, 1.5; length=length(cmesh)))
+        geometry = IGAMesh(cmesh; degree=Quadratic(), weights=range(1.0, 2.0; length=length(mesh)))
+        mixed_points = generate_particles(@NamedTuple{x::Vec{2,Float64}}, geometry, qrule)
+        mixed_weights = generate_basis_weights(field, size(mixed_points); name=Val(:N))
+        mixed_measure = zeros(Float64, size(mixed_weights))
+        @test (@inferred update!(mixed_weights, mixed_points, field; geometry, measure=mixed_measure)) === mixed_weights
+
+        field_cell = first(cells(field))
+        geometry_cell = first(cells(geometry))
+        field_patch = Tesserae.patches(field, field_cell.patch)
+        geometry_patch = Tesserae.patches(geometry, geometry_cell.patch)
+        field_ids = supportnodes(field, field_cell)
+        geometry_ids = supportnodes(geometry, geometry_cell)
+        for q in eachindex(qrule.points, qrule.weights)
+            field_ξ = Tesserae.span_point(field_patch, field_cell.span, qrule.points[q])
+            N, dNdξ = Tesserae.iga_basis_values_and_gradients(field_patch, field_cell.span, field_ξ)
+            N, dNdξ = Tesserae.rational_basis_values_and_gradients(N, dNdξ, field.weights[field_ids])
+            geometry_ξ = Tesserae.span_point(geometry_patch, geometry_cell.span, qrule.points[q])
+            geometry_N, geometry_dNdξ = Tesserae.iga_basis_values_and_gradients(geometry_patch, geometry_cell.span, geometry_ξ)
+            _, geometry_dNdξ = Tesserae.rational_basis_values_and_gradients(geometry_N, geometry_dNdξ, geometry.weights[geometry_ids])
+            J = sum(geometry[geometry_ids] .⊗ geometry_dNdξ)
+            @test mixed_weights[q,field_cell].N ≈ N
+            @test mixed_weights[q,field_cell].∇N ≈ dNdξ .⊡ Ref(inv(J))
+            @test supportnodes(mixed_weights[q,field_cell]) == field_ids
+            @test mixed_measure[q,geometry_cell] ≈ Tesserae.span_weight(geometry_patch, geometry_cell.span, qrule.weights[q]) * sqrt(det(J'J))
+        end
+
         reversed_patch = IGAPatch(iga_test_degrees(patch), map(copy, iga_test_knot_vectors(patch)), reverse(patch.controlpoint_ids))
         reversed_mesh = IGAMesh([reversed_patch], mesh.controlpoints)
-        reversed_weights = generate_basis_weights(reversed_mesh, size(points))
-        @test_throws ArgumentError update!(reversed_weights, points, mesh)
+        reversed_weights = generate_basis_weights(mesh, size(points))
+        @test update!(reversed_weights, points, reversed_mesh; geometry=mesh) === reversed_weights
+        @test supportnodes(reversed_weights[1,first(meshcells)]) == supportnodes(reversed_mesh, first(cells(reversed_mesh)))
+
+        mismatched_knots = map(copy, iga_test_knot_vectors(patch))
+        mismatched_knots[1][4] = 0.2
+        mismatched_patch = IGAPatch(iga_test_degrees(patch), mismatched_knots, copy(patch.controlpoint_ids))
+        mismatched_field = IGAMesh([mismatched_patch], mesh.controlpoints)
+        mismatched_weights = generate_basis_weights(mismatched_field, size(points))
+        @test_throws ArgumentError update!(mismatched_weights, points, mismatched_field; geometry=mesh)
 
         # Rational updates should use rational basis values in both N and ∇N.
         rational_mesh = IGAMesh(cmesh; degree=Quadratic(), weights=range(1.0, 2.0; length=length(mesh)))


### PR DESCRIPTION
Allow IGA field and geometry meshes to use different basis definitions when their nonzero knot-span partitions correspond.

Store IGA support nodes per cell, update them from the field mesh, and retain the optimized same-mesh path.