### PR TITLE
Support mixed IGA sparse matrices

### DIFF
--- a/src/fem.jl
+++ b/src/fem.jl
@@ -68,7 +68,7 @@ function update!(
     mode = pdim == dim ? Val(:domain) : Val(:boundary)
     rule = _check_quadrature_inputs(is_domain, weights, points, geometry, measure, normal)
     fieldmesh === geometry && return _update_iga!(mode, weights, rule, fieldmesh, measure, normal)
-    _check_iga_cell_partition(fieldmesh, geometry)
+    check_matching_cell_partitions(fieldmesh, geometry)
 
     field_supports = cellsupports(getfield(weights, :indices))
     for (field_cell, geometry_cell) in zip(cells(fieldmesh), cells(geometry))
@@ -116,23 +116,6 @@ function _update_iga!(mode, weights, rule, mesh, measure, normal)
         end
     end
     weights
-end
-
-function _check_iga_cell_partition(fieldmesh, geometry)
-    length(patches(fieldmesh)) == length(patches(geometry)) || throw(DimensionMismatch("field and geometry must have the same number of patches"))
-    for (field_patch, geometry_patch) in zip(patches(fieldmesh), patches(geometry))
-        for d in eachindex(degrees(field_patch))
-            field_knots = field_patch.knot_vectors[d]
-            geometry_knots = geometry_patch.knot_vectors[d]
-            field_spans = Iterators.filter(i -> _has_positive_span(field_knots, i), _active_span_range(field_knots, degrees(field_patch, d)))
-            geometry_spans = Iterators.filter(i -> _has_positive_span(geometry_knots, i), _active_span_range(geometry_knots, degrees(geometry_patch, d)))
-            _span_count(field_knots, degrees(field_patch, d)) == _span_count(geometry_knots, degrees(geometry_patch, d)) || throw(DimensionMismatch("field and geometry must have the same number of nonzero knot spans"))
-            for (field_span, geometry_span) in zip(field_spans, geometry_spans)
-                field_knots[field_span] == geometry_knots[geometry_span] && field_knots[field_span+1] == geometry_knots[geometry_span+1] || throw(ArgumentError("field and geometry must have the same nonzero knot spans"))
-            end
-        end
-    end
-    nothing
 end
 
 function _check_quadrature_inputs(is_domain, weights, points, geometry, measure, normal)

--- a/src/igamesh.jl
+++ b/src/igamesh.jl
@@ -277,6 +277,24 @@ function cells(mesh::IGAMesh)
 end
 _patch_cells(p, patch) = ((p, span) for span in _span_indices(patch))
 
+# Check that both meshes enumerate the same nonzero knot-span cells in the same order.
+function check_matching_cell_partitions(mesh1::IGAMesh, mesh2::IGAMesh)
+    length(patches(mesh1)) == length(patches(mesh2)) || throw(DimensionMismatch("IGA meshes must have the same number of patches"))
+    for (patch1, patch2) in zip(patches(mesh1), patches(mesh2))
+        for d in eachindex(degrees(patch1))
+            knots1 = patch1.knot_vectors[d]
+            knots2 = patch2.knot_vectors[d]
+            spans1 = Iterators.filter(i -> _has_positive_span(knots1, i), _active_span_range(knots1, degrees(patch1, d)))
+            spans2 = Iterators.filter(i -> _has_positive_span(knots2, i), _active_span_range(knots2, degrees(patch2, d)))
+            _span_count(knots1, degrees(patch1, d)) == _span_count(knots2, degrees(patch2, d)) || throw(DimensionMismatch("IGA meshes must have the same number of nonzero knot spans"))
+            for (span1, span2) in zip(spans1, spans2)
+                knots1[span1] == knots2[span2] && knots1[span1+1] == knots2[span2+1] || throw(ArgumentError("IGA meshes must have the same nonzero knot spans"))
+            end
+        end
+    end
+    nothing
+end
+
 """
     supportnodes(mesh::IGAMesh)
     supportnodes(mesh::IGAMesh, cell::IGACell)

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -71,12 +71,16 @@ function (dofmap::DofMap)(A::AbstractArray{T}) where {T <: Real}
 end
 
 """
+    create_sparse_matrix(mesh; ndofs)
+    create_sparse_matrix((rowmesh, colmesh); ndofs=(row_ndofs, col_ndofs))
     create_sparse_matrix(basis, mesh; ndofs)
 
 Create a sparse matrix.
 Since the created matrix accounts for all nodes in the mesh,
 it needs to be extracted for active nodes using the `DofMap`.
 `ndofs` specifies the number of DoFs for a field and must be provided explicitly.
+For a mesh pair, the first mesh defines the rows and the second defines the
+columns.
 
 ```jldoctest
 julia> mesh = CartesianMesh(1, (0,10), (0,10));
@@ -202,6 +206,20 @@ _create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Int) where {T} = _create_
 _create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
 create_sparse_matrix(::Type{T}, mesh::IGAMesh{dim}; ndofs) where {T, dim} = _create_sparse_matrix(T, mesh, ndofs)
 create_sparse_matrix(mesh::IGAMesh{dim}; ndofs) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
+
+function create_sparse_matrix(::Type{T}, (rowmesh,colmesh)::Tuple{IGAMesh{dim,pdim}, IGAMesh{dim,pdim}}; ndofs::Tuple{Int, Int}) where {T, dim, pdim}
+    rowmesh === colmesh && return _create_cell_support_sparse_matrix(T, rowmesh, ndofs)
+    check_matching_cell_partitions(rowmesh, colmesh)
+
+    row_dofs = LinearIndices((ndofs[1], length(rowmesh)))
+    col_dofs = LinearIndices((ndofs[2], length(colmesh)))
+    I, J = Int[], Int[]
+    for (rowcell, colcell) in zip(cells(rowmesh), cells(colmesh))
+        append_dofs!(I, J, row_dofs[:, supportnodes(rowmesh, rowcell)], col_dofs[:, supportnodes(colmesh, colcell)])
+    end
+    sparse(I, J, zeros(T, length(I)), length(row_dofs), length(col_dofs))
+end
+create_sparse_matrix(meshes::Tuple{IGAMesh{dim,pdim}, IGAMesh{dim,pdim}}; ndofs::Tuple{Int, Int}) where {dim, pdim} = create_sparse_matrix(Float64, meshes; ndofs)
 
 function create_sparse_matrix(::Type{T}, (mesh1,mesh2)::Tuple{FEMesh, FEMesh}; ndofs::Tuple{Int, Int}) where {T}
     mesh1 === mesh2 && return _create_cell_support_sparse_matrix(T, mesh1, ndofs)

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -367,6 +367,38 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         @test size(C) == (2 * length(mesh), length(mesh))
         @test eltype(C) === Float32
         @test stored_pattern(C) == mixed_pattern
+
+        # Distinct row and column spaces use their own support nodes in each corresponding span.
+        linear_mesh = IGAMesh(cmesh; degree=Linear())
+        linear_patch = Tesserae.patches(linear_mesh, 1)
+        reversed_patch = IGAPatch(iga_test_degrees(linear_patch), map(copy, iga_test_knot_vectors(linear_patch)), reverse(linear_patch.controlpoint_ids))
+        column_mesh = IGAMesh([reversed_patch], linear_mesh.controlpoints)
+        rectangular_pattern = Set{Tuple{Int,Int}}()
+        column_dofs = LinearIndices((1, length(column_mesh)))
+        for (rowcell, colcell) in zip(cells(mesh), cells(column_mesh))
+            rownodes = supportnodes(mesh, rowcell)
+            colnodes = supportnodes(column_mesh, colcell)
+            for j in colnodes, i in rownodes, col in column_dofs[:,j], row in row_dofs[:,i]
+                push!(rectangular_pattern, (row, col))
+            end
+        end
+
+        D = @inferred create_sparse_matrix((mesh, column_mesh); ndofs=(2, 1))
+        D32 = @inferred create_sparse_matrix(Float32, (mesh, column_mesh); ndofs=(2, 1))
+        @test size(D) == (2 * length(mesh), length(column_mesh))
+        @test eltype(D32) === Float32
+        @test stored_pattern(D) == rectangular_pattern
+        @test stored_pattern(D32) == rectangular_pattern
+
+        # Equal cell counts are insufficient when the span endpoints differ.
+        mismatched_knots = map(copy, iga_test_knot_vectors(patch))
+        mismatched_knots[1][4] = 0.2
+        mismatched_patch = IGAPatch(iga_test_degrees(patch), mismatched_knots, copy(patch.controlpoint_ids))
+        mismatched_mesh = IGAMesh([mismatched_patch], mesh.controlpoints)
+        @test_throws ArgumentError create_sparse_matrix((mesh, mismatched_mesh); ndofs=(2, 1))
+
+        coarse_mesh = IGAMesh(CartesianMesh(0.5, (0,1), (0,1)); degree=Linear())
+        @test_throws DimensionMismatch create_sparse_matrix((mesh, coarse_mesh); ndofs=(2, 1))
     end
 
     @testset "Heat problem" begin


### PR DESCRIPTION
Add sparse matrix construction for independent row and column IGA meshes.

Corresponding meshes are checked against their nonzero knot-span cell partitions before their support-node patterns are combined.