### PR TITLE
Require explicit FEM and IGA quadrature rules

### DIFF
--- a/docs/literate/tutorials/heat.jl
+++ b/docs/literate/tutorials/heat.jl
@@ -28,7 +28,8 @@ function main()
     grid = generate_grid(GridProp, mesh)
 
     ## Integration points
-    points = generate_particles(PointProp, mesh)
+    rule = generate_quadrature_rule(basis(mesh))
+    points = generate_particles(PointProp, mesh, rule)
 
     ## Basis weights
     weights = generate_basis_weights(mesh, size(points); name=Val(:N))

--- a/docs/src/fem.md
+++ b/docs/src/fem.md
@@ -166,10 +166,8 @@ plot_gmsh_groups(domain, outer_boundary, hole_boundary)
 Use the `domain` physical group as the finite-element mesh. From the transfer
 macros, the objects have the same roles as in MPM: `grid` stores nodal fields,
 `gauss_points` is the point array, and `weights` connects each point to the
-grid nodes. The meaning of the point array is different, though. For a
-`FEMesh`, `generate_particles` uses the cell quadrature rule by default and
-returns an `nq × ncells(domain)` array. Each column contains the Gauss points
-for one cell, ordered by the quadrature rule of the cell shape.
+grid nodes. `gauss_points` has one row per quadrature point and one column per
+cell.
 
 ```@example fem_plate
 GridProp = @NamedTuple begin
@@ -184,7 +182,8 @@ GaussProp = @NamedTuple begin
 end
 
 grid = generate_grid(GridProp, domain)
-gauss_points = generate_particles(GaussProp, domain)
+rule = generate_quadrature_rule(basis(domain))
+gauss_points = generate_particles(GaussProp, domain, rule)
 weights = generate_basis_weights(domain, size(gauss_points); name=Val(:N))
 
 update!(weights, gauss_points, domain; measure=gauss_points.V)
@@ -240,7 +239,8 @@ BoundaryGaussProp = @NamedTuple begin
     n :: Vec{2, Float64}
 end
 
-hole_gauss_points = generate_particles(BoundaryGaussProp, hole_boundary)
+boundary_rule = generate_quadrature_rule(basis(hole_boundary))
+hole_gauss_points = generate_particles(BoundaryGaussProp, hole_boundary, boundary_rule)
 hole_weights = generate_basis_weights(hole_boundary, size(hole_gauss_points); name=Val(:N))
 
 update!(

--- a/docs/src/iga.md
+++ b/docs/src/iga.md
@@ -249,9 +249,7 @@ plot_patch(surface)
 
 From the transfer macros, the objects have the same roles as in MPM and FEM:
 `grid` stores the control-point fields, `gauss_points` is the point array, and
-`weights` connects each Gauss point to the active control points. For an
-[`IGAMesh`](@ref), `generate_particles` uses the tensor-product Gauss rule for
-the patch degree and returns an `nq × ncells(mesh)` array.
+`weights` connects each Gauss point to the active control points.
 
 ```@example iga_annulus
 GridProp = @NamedTuple begin
@@ -267,7 +265,8 @@ GaussProp = @NamedTuple begin
 end
 
 grid = generate_grid(GridProp, mesh)
-gauss_points = generate_particles(GaussProp, mesh)
+rule = generate_quadrature_rule(basis(mesh))
+gauss_points = generate_particles(GaussProp, mesh, rule)
 weights = generate_basis_weights(mesh, size(gauss_points); name=Val(:N))
 
 update!(weights, gauss_points, mesh; measure=gauss_points.V)

--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -154,7 +154,7 @@ BasisWeight(::Type{T}, basis::Basis, mesh::CartesianMesh; kwargs...) where {T} =
 BasisWeight(basis::Basis, mesh::CartesianMesh; kwargs...) = _basis_weight(Float64, basis, mesh; kwargs...)
 
 # FEMesh
-BasisWeight(::Type{T}, mesh::FEMesh; kwargs...) where {T} = _basis_weight(T, cellshape(mesh), mesh; kwargs...)
+BasisWeight(::Type{T}, mesh::FEMesh; kwargs...) where {T} = _basis_weight(T, basis(mesh), mesh; kwargs...)
 BasisWeight(mesh::FEMesh; kwargs...) = BasisWeight(Float64, mesh; kwargs...)
 
 Base.propertynames(bw::BasisWeight) = propertynames(getfield(bw, :vals))
@@ -178,10 +178,13 @@ end
 @inline scalartype(bw::BasisWeight) = eltype(nodal_basis_values(bw, Order(0)))
 
 """
+    basis(mesh::FEMesh)
+    basis(mesh::IGAMesh)
     basis(weight)
 
-Return the basis object used by a [`BasisWeight`](@ref) or [`BasisWeightArray`](@ref).
+Return the basis associated with a mesh or basis-weight storage.
 """
+@inline basis(mesh::FEMesh) = cellshape(mesh)
 @inline basis(bw::BasisWeight) = getfield(bw, :basis)
 
 """
@@ -341,8 +344,8 @@ generate_basis_weights(::Type{T}, basis::Basis, mesh::CartesianMesh, dims...; kw
 generate_basis_weights(basis::Basis, mesh::CartesianMesh, dims...; kwargs...) = _generate_basis_weights(Float64, basis, mesh, _todims(dims...); kwargs...)
 
 # FEMesh
-generate_basis_weights(::Type{T}, mesh::FEMesh, dims...; kwargs...) where {T} = _generate_basis_weights(T, cellshape(mesh), mesh, _todims(dims...); kwargs...)
-generate_basis_weights(mesh::FEMesh, dims...; kwargs...) = _generate_basis_weights(Float64, cellshape(mesh), mesh, _todims(dims...); kwargs...)
+generate_basis_weights(::Type{T}, mesh::FEMesh, dims...; kwargs...) where {T} = _generate_basis_weights(T, basis(mesh), mesh, _todims(dims...); kwargs...)
+generate_basis_weights(mesh::FEMesh, dims...; kwargs...) = _generate_basis_weights(Float64, basis(mesh), mesh, _todims(dims...); kwargs...)
 
 Base.size(x::BasisWeightArray) = size(getfield(x, :indices))
 

--- a/src/Basis/iga.jl
+++ b/src/Basis/iga.jl
@@ -8,7 +8,7 @@ struct IGABasis{dim, Degrees <: NTuple{dim, Degree}} <: Basis
 end
 
 degrees(basis::IGABasis) = basis.degrees
-igabasis(mesh::IGAMesh) = IGABasis(degrees(first(patches(mesh))))
+basis(mesh::IGAMesh) = IGABasis(degrees(first(patches(mesh))))
 nsupportnodes(basis::IGABasis) = prod(degree -> _degree(degree) + 1, degrees(basis))
 
 initial_supportnodes(basis::IGABasis, mesh::IGAMesh) = zero(SVector{nsupportnodes(basis), Int})
@@ -21,7 +21,7 @@ function allocate_static_basis_values(::Type{Vec{dim, T}}, basis::IGABasis; kwar
     _allocate_basis_values(A, Vec{dim, T}; kwargs...)
 end
 
-generate_basis_weights(::Type{T}, mesh::IGAMesh, dims...; kwargs...) where {T} = _generate_basis_weights(T, igabasis(mesh), mesh, _todims(dims...); kwargs...)
+generate_basis_weights(::Type{T}, mesh::IGAMesh, dims...; kwargs...) where {T} = _generate_basis_weights(T, basis(mesh), mesh, _todims(dims...); kwargs...)
 generate_basis_weights(mesh::IGAMesh, dims...; kwargs...) = generate_basis_weights(Float64, mesh, dims...; kwargs...)
 
 """

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -122,24 +122,24 @@ function generate_particles(mesh::CartesianMesh{dim, T}; alg::SamplingAlgorithm=
 end
 
 """
-    generate_particles(ParticleProp, mesh::FEMesh, rule=generate_quadrature_rule(cellshape(mesh)))
+    generate_particles(ParticleProp, mesh::FEMesh, rule::QuadratureRule)
 
 Generate one point-property record for each point of `rule` in every finite
 element cell. The result is a [`QuadraturePoints`](@ref) matrix whose rows are
 rule points and whose columns are cells.
 """
-function generate_particles(::Type{ParticleProp}, mesh::FEMesh, rule::QuadratureRule=generate_quadrature_rule(cellshape(mesh))) where {ParticleProp}
+function generate_particles(::Type{ParticleProp}, mesh::FEMesh, rule::QuadratureRule) where {ParticleProp}
     QuadraturePoints(_generate_particles(ParticleProp, generate_points(rule, mesh)), rule)
 end
 
 """
-    generate_particles(ParticleProp, mesh::IGAMesh, rule=generate_quadrature_rule(igabasis(mesh)))
+    generate_particles(ParticleProp, mesh::IGAMesh, rule::QuadratureRule)
 
 Generate one point-property record for each point of `rule` in every nonzero
 knot span. The result is a [`QuadraturePoints`](@ref) matrix whose rows are rule
 points and whose columns are cells.
 """
-function generate_particles(::Type{ParticleProp}, mesh::IGAMesh, rule::QuadratureRule=generate_quadrature_rule(igabasis(mesh))) where {ParticleProp}
+function generate_particles(::Type{ParticleProp}, mesh::IGAMesh, rule::QuadratureRule) where {ParticleProp}
     QuadraturePoints(_generate_particles(ParticleProp, generate_points(rule, mesh)), rule)
 end
 

--- a/test/fem.jl
+++ b/test/fem.jl
@@ -18,6 +18,8 @@
         points = @inferred generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, geometry, rule)
         weights = @inferred generate_basis_weights(field, size(points); name=Val(:N))
 
+        @test (@inferred basis(geometry)) === Tesserae.cellshape(geometry)
+        @test_throws MethodError generate_particles(@NamedTuple{x::Vec{2,Float64}}, geometry)
         @test_throws ArgumentError generate_particles(@NamedTuple{x::Vec{2,Float64}}, geometry, generate_quadrature_rule(Tesserae.Tri6()))
         @test quadrature_rule(points) === rule
         @test Tesserae.cellsupports(getfield(weights, :indices)) === Tesserae.cellsupports(field)
@@ -117,7 +119,8 @@
 
     @testset "Empty domain" begin
         mesh = FEMesh(Tesserae.Quad4(), Vec{2,Float64}[], Tesserae.SVector{4,Int}[])
-        points = generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, mesh)
+        rule = generate_quadrature_rule(basis(mesh))
+        points = generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, mesh, rule)
         weights = generate_basis_weights(mesh, size(points))
         @test update!(weights, points, mesh; measure=points.V) === weights
     end

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -15,8 +15,8 @@ const nurbs_cubic = Tesserae.NURBS.cubic
     cmesh = CartesianMesh(0.25, (0,1), (0,1))
     mesh = IGAMesh(cmesh; degree=Quadratic())
     meshcells = collect(cells(mesh))
-    basis = @inferred Tesserae.igabasis(mesh)
-    qrule = generate_quadrature_rule(basis)
+    mesh_basis = @inferred basis(mesh)
+    qrule = generate_quadrature_rule(mesh_basis)
     patch = Tesserae.patches(mesh, 1)
     span = first(meshcells).span
     ξ = Tesserae.span_point(patch, span, first(qrule.points))
@@ -30,9 +30,9 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         @test meshcells[1] == IGACell(1, 1, CartesianIndex(3,3))
         @test meshcells[end] == IGACell(16, 1, CartesianIndex(6,6))
         @test iga_test_degrees(patch) == (Quadratic(), Quadratic())
-        @test typeof(basis) === IGABasis{2, Tuple{Quadratic, Quadratic}}
-        @test iga_test_degrees(basis) == (Quadratic(), Quadratic())
-        @test (@inferred Tesserae.nsupportnodes(basis)) === 9
+        @test typeof(mesh_basis) === IGABasis{2, Tuple{Quadratic, Quadratic}}
+        @test iga_test_degrees(mesh_basis) == (Quadratic(), Quadratic())
+        @test (@inferred Tesserae.nsupportnodes(mesh_basis)) === 9
         @test supportnodes(mesh) === mesh.used_controlpoint_ids
         @test supportnodes(mesh) == collect(eachindex(mesh))
         @test (@inferred supportnodes(mesh, meshcells[1])) === Tesserae.SVector(1, 2, 3, 7, 8, 9, 13, 14, 15)
@@ -134,7 +134,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         @test length(high_order_rule.points) == 21
         @test eltype(high_order_rule.weights) === Float32
         @test sum(high_order_rule.weights) ≈ 4
-        @test_throws ArgumentError generate_quadrature_rule(BigFloat, basis)
+        @test_throws ArgumentError generate_quadrature_rule(BigFloat, mesh_basis)
         anisotropic_rule = @inferred generate_quadrature_rule(IGABasis((Linear(), Quadratic())))
         @test length(anisotropic_rule.points) == 6
         @test sum(anisotropic_rule.weights) ≈ 4
@@ -208,7 +208,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         # direct mesh support queries.
         igaweights = @inferred generate_basis_weights(Float64, mesh, 2, Tesserae.ncells(mesh))
         @test size(igaweights) == (2, Tesserae.ncells(mesh))
-        @test typeof(Tesserae.basis(igaweights)) === typeof(basis)
+        @test typeof(Tesserae.basis(igaweights)) === typeof(mesh_basis)
         @test size(igaweights[1, meshcells[end]].w) == (9,)
         @test size(igaweights[1, meshcells[end]].∇w) == (9,)
         @test length(supportnodes(igaweights[1, meshcells[end]])) == 9
@@ -224,7 +224,8 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         PointProp = @NamedTuple{x::Vec{2,Float64}, V::Float64}
 
         # IGA particles are the physical images of the basis quadrature points.
-        points = @inferred generate_particles(PointProp, mesh)
+        @test_throws MethodError generate_particles(PointProp, mesh)
+        points = @inferred generate_particles(PointProp, mesh, qrule)
         indices = supportnodes(mesh, first(meshcells))
         N, _ = Tesserae.iga_basis_values_and_gradients(patch, span, ξ)
         @test size(points) == (length(qrule.points), Tesserae.ncells(mesh))
@@ -233,7 +234,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
 
         # Rational geometry uses rational basis values for the same mapping.
         rational_mesh = IGAMesh(cmesh; degree=Quadratic(), weights=range(1.0, 2.0; length=length(mesh)))
-        rational_points = @inferred generate_particles(PointProp, rational_mesh)
+        rational_points = @inferred generate_particles(PointProp, rational_mesh, qrule)
         rational_cell = first(cells(rational_mesh))
         rational_patch = Tesserae.patches(rational_mesh, rational_cell.patch)
         rational_ξ = Tesserae.span_point(rational_patch, rational_cell.span, first(qrule.points))
@@ -296,7 +297,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
 
         # Rational updates should use rational basis values in both N and ∇N.
         rational_mesh = IGAMesh(cmesh; degree=Quadratic(), weights=range(1.0, 2.0; length=length(mesh)))
-        rational_points = generate_particles(@NamedTuple{x::Vec{2,Float64}}, rational_mesh)
+        rational_points = generate_particles(@NamedTuple{x::Vec{2,Float64}}, rational_mesh, qrule)
         rational_weights = generate_basis_weights(Float64, rational_mesh, size(rational_points))
         rational_measure = zeros(Float64, size(rational_weights))
         @test update!(rational_weights, rational_points, rational_mesh; measure=rational_measure) === rational_weights
@@ -317,7 +318,8 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         boundary_patch = IGAPatch((Quadratic(),), (copy(iga_test_knot_vectors(patch)[1]),), Array(patch.controlpoint_ids[:,1]))
         boundary_mesh = IGAMesh([boundary_patch], mesh.controlpoints)
         @test supportnodes(boundary_mesh) == collect(patch.controlpoint_ids[:,1])
-        boundary_points = generate_particles(@NamedTuple{x::Vec{2,Float64}}, boundary_mesh)
+        boundary_rule = generate_quadrature_rule(basis(boundary_mesh))
+        boundary_points = generate_particles(@NamedTuple{x::Vec{2,Float64}}, boundary_mesh, boundary_rule)
         boundary_weights = generate_basis_weights(boundary_mesh, size(boundary_points); name=Val(:N))
         measure = zeros(Float64, size(boundary_weights))
         normal = zeros(Vec{2, Float64}, size(boundary_weights))
@@ -333,7 +335,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         end
 
         @test_throws UndefKeywordError create_sparse_matrix(mesh)
-        @test_throws UndefKeywordError create_sparse_matrix(basis, mesh)
+        @test_throws UndefKeywordError create_sparse_matrix(mesh_basis, mesh)
 
         # The scalar matrix pattern must be exactly the union of each cell's
         # support-node pairings. Values are assembled later by @P2G_Matrix.
@@ -346,7 +348,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         end
 
         A = @inferred create_sparse_matrix(mesh; ndofs=1)
-        B = @inferred create_sparse_matrix(basis, mesh; ndofs=1)
+        B = @inferred create_sparse_matrix(mesh_basis, mesh; ndofs=1)
         @test size(A) == (length(mesh), length(mesh))
         @test stored_pattern(A) == scalar_pattern
         @test stored_pattern(B) == scalar_pattern
@@ -363,7 +365,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
             end
         end
 
-        C = @inferred create_sparse_matrix(Float32, basis, mesh; ndofs=(2, 1))
+        C = @inferred create_sparse_matrix(Float32, mesh_basis, mesh; ndofs=(2, 1))
         @test size(C) == (2 * length(mesh), length(mesh))
         @test eltype(C) === Float32
         @test stored_pattern(C) == mixed_pattern
@@ -409,7 +411,8 @@ const nurbs_cubic = Tesserae.NURBS.cubic
 
         function heat_norm(mesh)
             grid = generate_grid(GridProp, mesh)
-            points = generate_particles(PointProp, mesh)
+            rule = generate_quadrature_rule(basis(mesh))
+            points = generate_particles(PointProp, mesh, rule)
             weights = generate_basis_weights(mesh, size(points); name=Val(:N))
             update!(weights, points, mesh; measure=points.V)
             K = create_sparse_matrix(mesh; ndofs=1)

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -319,7 +319,8 @@ end
     PointProp = @NamedTuple{x::Vec{2,Float64}, V::Float64}
     velocity_grid = generate_grid(GridPropU, quad9)
     pressure_grid = generate_grid(GridPropP, quad4)
-    points = generate_particles(PointProp, geometry)
+    rule = generate_quadrature_rule(basis(geometry))
+    points = generate_particles(PointProp, geometry, rule)
     velocity_weights = generate_basis_weights(quad9, size(points); name=Val(:N))
     pressure_weights = generate_basis_weights(quad4, size(points); name=Val(:N))
     update!(velocity_weights, points, quad9; geometry, measure=points.V)

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -182,7 +182,8 @@ end
             x      :: Vec{dim, Float64}
             detJdV :: Float64
         end
-        points = generate_particles(ParticleProp, mesh)
+        rule = generate_quadrature_rule(basis(mesh))
+        points = generate_particles(ParticleProp, mesh, rule)
         weights = generate_basis_weights(mesh, size(points))
         update!(weights, points, mesh; measure=points.detJdV)
         sum(points.detJdV)
@@ -212,7 +213,8 @@ end
             detJdA :: Float64
         end
         mesh_face = Tesserae.extract_face(mesh_body, 1:length(mesh_body))
-        points = generate_particles(ParticleProp, mesh_face)
+        rule = generate_quadrature_rule(basis(mesh_face))
+        points = generate_particles(ParticleProp, mesh_face, rule)
         weights = generate_basis_weights(mesh_face, size(points))
         update!(weights, points, mesh_face; normal=points.n, measure=points.detJdA)
         sum(points.detJdA)
@@ -240,7 +242,8 @@ end
         n      :: Vec{3, Float64}
         detJdL :: Float64
     end
-    line_points = generate_particles(LinePointProp, line_mesh)
+    line_rule = generate_quadrature_rule(basis(line_mesh))
+    line_points = generate_particles(LinePointProp, line_mesh, line_rule)
     line_weights = generate_basis_weights(line_mesh, size(line_points))
     update!(line_weights, line_points, line_mesh; measure=line_points.detJdL)
     @test sum(line_points.detJdL) ≈ 3


### PR DESCRIPTION
Require FEM and IGA callers to select quadrature rules explicitly before generating quadrature points. Add a common basis(mesh) accessor and update the affected documentation and tests. This avoids silently selecting a mesh-derived rule that may be insufficient for the field or integrand.