### PR TITLE
Add threaded IGA matrix assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Tesserae.jl will be documented in this file.
 
+## v0.7.1
+
+### Added
+
+- Added threaded CPU transfers and matrix assembly for `IGAMesh` through
+  `ThreadPartition(mesh)`.
+
 ## v0.7.0
 
 v0.7.0 focuses on larger and more inspectable MPM workflows: sparse-grid GPU

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tesserae"
 uuid = "fd374396-9d9c-4d88-9aa5-37a7f6105aca"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
 
 [deps]

--- a/docs/src/iga.md
+++ b/docs/src/iga.md
@@ -293,15 +293,11 @@ As in the FEM example, the global matrix is assembled with
 
 ```@example iga_annulus
 K = create_sparse_matrix(mesh; ndofs=1)
-partition = ThreadPartition(mesh)
 
-@threaded @P2G_Matrix grid=>(i,j) gauss_points=>p weights=>(ip,jp) partition begin
+@P2G_Matrix grid=>(i,j) gauss_points=>p weights=>(ip,jp) begin
     K[i,j] = @∑ ∇N[ip] ⋅ ∇N[jp] * V[p]
 end
 ```
-
-The IGA partition is determined entirely by the fixed knot-span connectivity,
-so it can be constructed once and reused for subsequent assemblies.
 
 ### Boundary Conditions
 

--- a/docs/src/iga.md
+++ b/docs/src/iga.md
@@ -293,11 +293,15 @@ As in the FEM example, the global matrix is assembled with
 
 ```@example iga_annulus
 K = create_sparse_matrix(mesh; ndofs=1)
+partition = ThreadPartition(mesh)
 
-@P2G_Matrix grid=>(i,j) gauss_points=>p weights=>(ip,jp) begin
+@threaded @P2G_Matrix grid=>(i,j) gauss_points=>p weights=>(ip,jp) partition begin
     K[i,j] = @∑ ∇N[ip] ⋅ ∇N[jp] * V[p]
 end
 ```
+
+The IGA partition is determined entirely by the fixed knot-span connectivity,
+so it can be constructed once and reused for subsequent assemblies.
 
 ### Boundary Conditions
 

--- a/docs/src/multithreading.md
+++ b/docs/src/multithreading.md
@@ -28,13 +28,15 @@ For scattering operations, prefix `@P2G` with `@threaded` and use [`ThreadPartit
 
 ```julia
 partition = ThreadPartition(mesh)
-update!(partition, particles.x)
+update!(partition, particles.x) # CartesianMesh only
 @threaded @P2G grid=>i particles=>p weights=>ip partition begin
     # your code here
 end
 ```
 
-Same applies to `@G2P2G` and `@P2G_Matrix`.
+For [`FEMesh`](@ref) and [`IGAMesh`](@ref), the partition is built from the
+fixed cell connectivity, so it does not need an `update!` call. The same
+partitioning applies to `@G2P2G` and `@P2G_Matrix`.
 
 ### Updating basis weights
 

--- a/src/thread_partition.jl
+++ b/src/thread_partition.jl
@@ -474,28 +474,28 @@ end
 
 threadsafe_groups(cs::CellStrategy) = cs.threadsafe_groups
 
-function CellStrategy(mesh::FEMesh)
+function CellStrategy(mesh::Union{FEMesh, IGAMesh})
     g = _cell_conflict_graph(mesh)
 
     coloring = Graphs.degree_greedy_color(g)
 
     groups = [Int[] for _ in 1:coloring.num_colors]
-    @inbounds for cell in cells(mesh)
-        push!(groups[coloring.colors[cell]], cell)
+    @inbounds for (cellid, cell) in enumerate(cells(mesh))
+        push!(groups[coloring.colors[cellid]], cellid)
     end
 
     CellStrategy(groups)
 end
 
-function _cell_conflict_graph(mesh::FEMesh)
+function _cell_conflict_graph(mesh::Union{FEMesh, IGAMesh})
     nc = ncells(mesh)
     nn = length(mesh)
     graph = SimpleGraph(nc)
 
     node2cells = [Int[] for _ in 1:nn]
-    @inbounds for cell in cells(mesh)
+    @inbounds for (cellid, cell) in enumerate(cells(mesh))
         for i in supportnodes(mesh, cell)
-            push!(node2cells[i], cell)
+            push!(node2cells[i], cellid)
         end
     end
 
@@ -515,6 +515,7 @@ end
 """
     ThreadPartition(::CartesianMesh)
     ThreadPartition(::FEMesh)
+    ThreadPartition(::IGAMesh)
 
 `ThreadPartition` stores partitioning information used by the [`@P2G`](@ref), [`@G2P2G`](@ref) and [`@P2G_Matrix`](@ref) macros
 to avoid write conflicts during threaded particle-to-grid transfers.
@@ -528,7 +529,7 @@ to avoid write conflicts during threaded particle-to-grid transfers.
 partition = ThreadPartition(mesh)
 
 # Update partition using current particle positions
-update!(partition, particles.x) # Required for `CartesianMesh`; not needed for `FEMesh` (FEM).
+update!(partition, particles.x) # Required only for `CartesianMesh`.
 
 # P2G transfer
 @threaded @P2G grid=>i particles=>p weights=>ip partition begin
@@ -550,7 +551,7 @@ particle_indices(partition::ThreadPartition{<: CellStrategy}, particles, cell) =
     (CartesianIndex(p, cell) for p in 1:size(particles, 1))
 
 ThreadPartition(mesh::CartesianMesh) = ThreadPartition(BlockStrategy(mesh))
-ThreadPartition(mesh::FEMesh) = ThreadPartition(CellStrategy(mesh))
+ThreadPartition(mesh::Union{FEMesh, IGAMesh}) = ThreadPartition(CellStrategy(mesh))
 update!(partition::ThreadPartition, args...) = update!(strategy(partition), args...)
 
 reorder_particles!(particles::StructVector, partition::ThreadPartition{<: BlockStrategy}; kwargs...) =

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -401,6 +401,23 @@ const nurbs_cubic = Tesserae.NURBS.cubic
 
         coarse_mesh = IGAMesh(CartesianMesh(0.5, (0,1), (0,1)); degree=Linear())
         @test_throws DimensionMismatch create_sparse_matrix((mesh, coarse_mesh); ndofs=(2, 1))
+
+        # IGA cells with disjoint control-point supports can assemble directly
+        # into the same CSC matrix from different threads.
+        grid = generate_grid(@NamedTuple{x::Vec{2,Float64}}, mesh)
+        points = generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, mesh, qrule)
+        weights = generate_basis_weights(mesh, size(points); name=Val(:N))
+        update!(weights, points, mesh; measure=points.V)
+        K_sequential = create_sparse_matrix(mesh; ndofs=1)
+        K_threaded = create_sparse_matrix(mesh; ndofs=1)
+        @P2G_Matrix grid=>(i,j) points=>p weights=>(ip,jp) begin
+            K_sequential[i,j] = @∑ ∇N[ip] ⋅ ∇N[jp] * V[p]
+        end
+        partition = ThreadPartition(mesh)
+        @threaded @P2G_Matrix grid=>(i,j) points=>p weights=>(ip,jp) partition begin
+            K_threaded[i,j] = @∑ ∇N[ip] ⋅ ∇N[jp] * V[p]
+        end
+        @test K_threaded ≈ K_sequential
     end
 
     @testset "Heat problem" begin

--- a/test/thread_partition.jl
+++ b/test/thread_partition.jl
@@ -123,6 +123,24 @@
         @test sort(allcells) == collect(1:Tesserae.ncells(mesh))
         @test collect(Tesserae.particle_indices(partition, zeros(3, Tesserae.ncells(mesh)), first(first(groups)))) ==
               [CartesianIndex(p, first(first(groups))) for p in 1:3]
+
+        iga_mesh = IGAMesh(CartesianMesh(0.25, (0,2), (0,2)); degree=Quadratic())
+        iga_partition = @inferred ThreadPartition(iga_mesh)
+        iga_groups = Tesserae.threadsafe_groups(iga_partition)
+        iga_cells = collect(cells(iga_mesh))
+        @test all(!isempty, iga_groups)
+        for group in iga_groups
+            for i in 1:length(group)-1, j in i+1:length(group)
+                nodes1 = supportnodes(iga_mesh, iga_cells[group[i]])
+                nodes2 = supportnodes(iga_mesh, iga_cells[group[j]])
+                @test isempty(intersect(Set(nodes1), Set(nodes2)))
+            end
+        end
+        iga_allcells = reduce(vcat, iga_groups)
+        @test length(iga_allcells) == Tesserae.ncells(iga_mesh)
+        @test sort(iga_allcells) == collect(1:Tesserae.ncells(iga_mesh))
+        @test collect(Tesserae.particle_indices(iga_partition, zeros(3, Tesserae.ncells(iga_mesh)), first(first(iga_groups)))) ==
+              [CartesianIndex(p, first(first(iga_groups))) for p in 1:3]
     end
     @testset "Utilities" begin
         @test Tesserae.nodeindices_in_block(CartesianIndex(1,1), (20,20); block_size_log2=Val(2)) === CartesianIndices((1:5,1:5))


### PR DESCRIPTION
## Summary

- enable `ThreadPartition` for `IGAMesh` with conflict-free cell coloring
- support threaded IGA transfers and sparse matrix assembly
- document reusable IGA partitions and bump the package version to 0.7.1
