### PR TITLE
Optimize P2G matrix assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,29 @@ All notable changes to Tesserae.jl will be documented in this file.
 
 - Added property schemas for `BasisWeight` and `generate_basis_weights`, allowing
   basis-value names, scalar types, and custom fields to be defined with a
-  `NamedTuple` type.
+  `NamedTuple` type. (#178)
+- Added `view` support for `BasisWeightArray`, allowing matching particle and
+  basis-weight subsets to be passed to transfer macros. (#177)
+
+### Performance
+
+- Optimized `@P2G_Matrix` assembly with direct CSC updates for Cartesian
+  matrices, cellwise scatter aggregation for FEM and IGA, and blockwise
+  aggregation for threaded Cartesian transfers. (#176)
 
 ## v0.7.2
 
-### Added
+### Changed
 
-- Added `view` support for `BasisWeightArray`, allowing matching particle and
-  basis-weight subsets to be passed to transfer macros. (#177)
+- Simplified basis-weight update dispatch while preserving the specialized
+  B-spline, WLS, and kernel-correction paths, and made filtered-update support
+  explicit. (#175)
+- Tightened uGIMP and CPDI validation and extension behavior. (#175)
+- Computed ambient tangential gradients for FEM and IGA boundary bases. (#175)
+
+### Dependencies
+
+- Raised the minimum Tensorial version to 0.20.5. (#175)
 
 ## v0.7.1
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tesserae"
 uuid = "fd374396-9d9c-4d88-9aa5-37a7f6105aca"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tesserae"
 uuid = "fd374396-9d9c-4d88-9aa5-37a7f6105aca"
-version = "0.7.3"
+version = "0.7.2"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
 
 [deps]

--- a/src/explain.jl
+++ b/src/explain.jl
@@ -273,8 +273,8 @@ function explain_P2G_Matrix(((grid_i,grid_j),(i,j)), (particles,p), ((weights_i,
     expr_block(matrix_setup_stmts(infos, grid_i, grid_j), partitioned_particle_loop((particles,p), partition, body, threading))
 end
 
-const MATRIX_INFO_NAMES = (:table_i, :table_j, :local_i, :local_j, :local_matrix, :I, :J, :dofs_i, :dofs_j)
-const MATRIX_INFO_SUFFIXES = (:_table_i, :_table_j, :_local_i, :_local_j, :_local, :_i, :_j, :_dofs_i, :_dofs_j)
+const MATRIX_INFO_NAMES = (:table_i, :table_j, :local_matrix, :I, :J, :dofs_i, :dofs_j)
+const MATRIX_INFO_SUFFIXES = (:_table_i, :_table_j, :_local, :_i, :_j, :_dofs_i, :_dofs_j)
 matrix_symbols(gmat) = NamedTuple{MATRIX_INFO_NAMES}(Symbol.(gmat, MATRIX_INFO_SUFFIXES))
 
 function matrix_infos(equations, scope, i, j)
@@ -305,14 +305,13 @@ matrix_table_stmt(info, grid_i, grid_j) = info.lhs_is_row_col ?
     :(($(info.table_i), $(info.table_j)) = Tesserae.matrix_dof_tables($(info.gmat), $grid_i, $grid_j)) :
     :(($(info.table_j), $(info.table_i)) = Tesserae.matrix_dof_tables($(info.gmat), $grid_j, $grid_i))
 
-matrix_local_init(info, nodes_i, nodes_j) = quote
-    $(info.local_i) = Tesserae.local_dof_table($(info.table_i), $nodes_i)
-    $(info.local_j) = Tesserae.local_dof_table($(info.table_j), $nodes_j)
-    $(info.local_matrix) = zeros(eltype($(info.gmat)), (length($(info.local_i)), length($(info.local_j))))
+function matrix_local_init(info, nodes_i, nodes_j)
+    :($(info.local_matrix) = zeros(eltype($(info.gmat)),
+        (size($(info.table_i), 1) * length($nodes_i), size($(info.table_j), 1) * length($nodes_j))))
 end
 
-matrix_idofs(info, ip) = :($(info.I) = Tesserae.local_dofs($(info.local_i), $ip))
-matrix_jdofs(info, jp) = :($(info.J) = Tesserae.local_dofs($(info.local_j), $jp))
+matrix_idofs(info, ip) = :($(info.I) = Tesserae.local_dofs(size($(info.table_i), 1), $ip))
+matrix_jdofs(info, jp) = :($(info.J) = Tesserae.local_dofs(size($(info.table_j), 1), $jp))
 matrix_assign(info) = :($(info.local_matrix)[$(info.I), $(info.J)] .= $(info.rhs))
 matrix_dofs(info, nodes_i, nodes_j) =
     :(($(info.dofs_i), $(info.dofs_j)) = Tesserae.support_dofs($(info.table_i), $nodes_i, $(info.table_j), $nodes_j))
@@ -323,14 +322,16 @@ matrix_add(info) = info.lhs_is_row_col ?
 function matrix_particle_body(infos, (grid_i,grid_j), (weights_i,weights_j), (i,j), (ip,jp), p, (bw_i,bw_j), (nodes_i,nodes_j))
     setup = matrix_particle_setup((grid_i,grid_j), (weights_i,weights_j), p, (bw_i,bw_j), (nodes_i,nodes_j))
     local_inits = map(info -> matrix_local_init(info, nodes_i, nodes_j), infos)
-    local_idofs = map(info -> matrix_idofs(info, ip), infos)
-    local_jdofs = map(info -> matrix_jdofs(info, jp), infos)
+    local_ip = Symbol(:local_, ip)
+    local_jp = Symbol(:local_, jp)
+    local_idofs = map(info -> matrix_idofs(info, local_ip), infos)
+    local_jdofs = map(info -> matrix_jdofs(info, local_jp), infos)
     local_assigns = map(matrix_assign, infos)
     dof_extracts = map(info -> matrix_dofs(info, nodes_i, nodes_j), infos)
     add_stmts = map(matrix_add, infos)
 
-    inner_loop = loop_expr(ip, :(eachindex($nodes_i)), :($i = $nodes_i[$ip]), local_idofs..., local_assigns...)
-    outer_loop = loop_expr(jp, :(eachindex($nodes_j)), :($j = $nodes_j[$jp]), local_jdofs..., inner_loop)
+    inner_loop = loop_expr(:($local_ip, $ip), :(enumerate(eachindex($nodes_i))), :($i = $nodes_i[$ip]), local_idofs..., local_assigns...)
+    outer_loop = loop_expr(:($local_jp, $jp), :(enumerate(eachindex($nodes_j))), :($j = $nodes_j[$jp]), local_jdofs..., inner_loop)
     expr_block(setup, local_inits, outer_loop, dof_extracts, add_stmts)
 end
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -499,8 +499,8 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     lmat_assign = Any[]
     lmat_add = Any[]
     lmat2gmat = Any[]
-    for k in eachindex(equations)
-        (; lhs, rhs, op) = equations[k]
+    for equation in equations
+        (; lhs, rhs, op) = equation
         @capture(lhs, gmat_[gi_,gj_]) || error("@P2G_Matrix: Invalid global matrix expression, got `$lhs`")
         ((gi == i && gj == j) || (gi == j && gj == i)) || error("@P2G_Matrix: Expected expression of the form `$gmat[$i, $j]` or `$gmat[$j, $i]`, got `$lhs`")
         gmat in gmats && error("@P2G_Matrix: each global matrix may appear only once in a block; combine terms for `$gmat` into one `@∑` expression")
@@ -584,16 +584,14 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     end
 
     # cache for local matrices
-    arraydicts = Any[]
-    for gmat in gmats
+    arraydicts = map(gmats) do gmat
         arraydict = Symbol(gmat, :dict)
         Tarraydict = Symbol(:T, arraydict)
-        ex = quote
+        quote
             $Tarraydict = Dict{Tuple{Int,Int}, Matrix{eltype($gmat)}}
             $arraydict = $TaskLocalValue{$Tarraydict}(() -> $Tarraydict())
             $arraydict[] # initialize
         end
-        push!(arraydicts, ex)
     end
 
     body = quote

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -312,23 +312,19 @@ end
 
 # ---- matrix entries ----
 
-# Expand a scalar, vector, or matrix value into one node-pair DoF block.
-@propagate_inbounds matrix_entry_value(value::Number, a, b, row_ndofs, col_ndofs) = value
-@propagate_inbounds matrix_entry_value(value::AbstractVector, a, b, row_ndofs, col_ndofs) = col_ndofs == 1 ? value[a] : value[b]
-@propagate_inbounds matrix_entry_value(value::AbstractMatrix, a, b, row_ndofs, col_ndofs) = value[ifelse(size(value, 1) == 1, 1, a), ifelse(size(value, 2) == 1, 1, b)]
-
 orient_matrix_entry(::typeof(identity), value) = value
 orient_matrix_entry(::typeof(reverse), value) = value'
 
-@noinline check_matrix_entry_size(::Number, row_ndofs, col_ndofs) = nothing
+@noinline function check_matrix_entry_size(::Number, row_ndofs, col_ndofs)
+    (row_ndofs, col_ndofs) == (1, 1) || throw(DimensionMismatch("scalar value requires a scalar matrix entry"))
+end
 @noinline function check_matrix_entry_size(value::AbstractVector, row_ndofs, col_ndofs)
     expected_length = col_ndofs == 1 ? row_ndofs : col_ndofs
     (row_ndofs == 1 || col_ndofs == 1) && length(value) == expected_length ||
         throw(DimensionMismatch("vector value is incompatible with matrix entry dimensions"))
 end
 @noinline function check_matrix_entry_size(value::AbstractMatrix, row_ndofs, col_ndofs)
-    (size(value, 1) == 1 || size(value, 1) == row_ndofs) &&
-        (size(value, 2) == 1 || size(value, 2) == col_ndofs) ||
+    size(value) == (row_ndofs, col_ndofs) ||
         throw(DimensionMismatch("matrix value is incompatible with matrix entry dimensions"))
 end
 
@@ -408,7 +404,7 @@ end
         col = col_dof_table[b, col_node]
         slot = first(nzrange(matrix, col)) + row_offset
         for a in 1:row_ndofs
-            values[slot] += matrix_entry_value(value, a, b, row_ndofs, col_ndofs)
+            values[slot] += value[(b - 1) * row_ndofs + a]
             slot += 1
         end
     end
@@ -449,7 +445,7 @@ end
     col_ndofs = size(col_dof_table, 1)
     @boundscheck check_matrix_entry_size(value, row_ndofs, col_ndofs)
     @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
-        matrix[row_dof_table[a,row_node], col_dof_table[b,col_node]] += matrix_entry_value(value, a, b, row_ndofs, col_ndofs)
+        matrix[row_dof_table[a,row_node], col_dof_table[b,col_node]] += value[(b - 1) * row_ndofs + a]
     end
     matrix
 end
@@ -600,10 +596,6 @@ function BlockMatrixBuffer(key::BlockMatrixBufferKey{T,N}) where {T,N}
     BlockMatrixBuffer(zeros(T, slot - 1), node_colptr, key)
 end
 
-function BlockMatrixBuffer(assembler::CartesianSparseMatrixAssembler, row_nodes::CartesianIndices, col_nodes::CartesianIndices)
-    BlockMatrixBuffer(BlockMatrixBufferKey(assembler, row_nodes, col_nodes))
-end
-
 # ---- buffer pool ----
 
 function acquire!(pool::BlockMatrixBufferPool, key::BlockMatrixBufferKey{T,N}) where {T,N}
@@ -658,16 +650,9 @@ function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{
     local_col = LinearIndices(col_size)[local_col_node]
 
     slot = node_colptr[local_col] + (local_row - 1) * row_ndofs * col_ndofs
-    if value isa AbstractMatrix && size(value) == (row_ndofs, col_ndofs)
-        for index in eachindex(value)
-            values[slot] += value[index]
-            slot += 1
-        end
-    else
-        for b in 1:col_ndofs, a in 1:row_ndofs
-            values[slot] += matrix_entry_value(value, a, b, row_ndofs, col_ndofs)
-            slot += 1
-        end
+    for index in eachindex(value)
+        values[slot] += value[index]
+        slot += 1
     end
 
     buffer
@@ -1047,7 +1032,6 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         quote
             $Tarraydict = Dict{Tuple{Int,Int}, Matrix{eltype($gmat)}}
             $arraydict = $TaskLocalValue{$Tarraydict}(() -> $Tarraydict())
-            $arraydict[] # initialize
         end
     end
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -306,6 +306,34 @@ function add!(A::AbstractMatrix, I::AbstractVector{Int}, J::AbstractVector{Int},
     @inbounds @views A[I,J] .+= K
 end
 
+# -----------------------------------------------------------------------------
+#  Matrix assemblers
+# -----------------------------------------------------------------------------
+
+# ---- matrix entries ----
+
+# Expand a scalar, vector, or matrix value into one node-pair DoF block.
+@propagate_inbounds matrix_entry_value(value::Number, a, b, row_ndofs, col_ndofs) = value
+@propagate_inbounds matrix_entry_value(value::AbstractVector, a, b, row_ndofs, col_ndofs) = col_ndofs == 1 ? value[a] : value[b]
+@propagate_inbounds matrix_entry_value(value::AbstractMatrix, a, b, row_ndofs, col_ndofs) = value[ifelse(size(value, 1) == 1, 1, a), ifelse(size(value, 2) == 1, 1, b)]
+
+orient_matrix_entry(::typeof(identity), value) = value
+orient_matrix_entry(::typeof(reverse), value) = value'
+
+@noinline check_matrix_entry_size(::Number, row_ndofs, col_ndofs) = nothing
+@noinline function check_matrix_entry_size(value::AbstractVector, row_ndofs, col_ndofs)
+    expected_length = col_ndofs == 1 ? row_ndofs : col_ndofs
+    (row_ndofs == 1 || col_ndofs == 1) && length(value) == expected_length ||
+        throw(DimensionMismatch("vector value is incompatible with matrix entry dimensions"))
+end
+@noinline function check_matrix_entry_size(value::AbstractMatrix, row_ndofs, col_ndofs)
+    (size(value, 1) == 1 || size(value, 1) == row_ndofs) &&
+        (size(value, 2) == 1 || size(value, 2) == col_ndofs) ||
+        throw(DimensionMismatch("matrix value is incompatible with matrix entry dimensions"))
+end
+
+# ---- CartesianSparseMatrixAssembler ----
+
 struct CartesianSparseMatrixAssembler{A <: SparseMatrixCSC, R <: LinearIndices, C <: LinearIndices}
     matrix::A
     row_dof_table::R
@@ -362,23 +390,6 @@ function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
     true
 end
 
-# Expand a scalar, vector, or matrix value into one node-pair DoF block.
-@propagate_inbounds matrix_entry_value(value::Number, a, b, row_ndofs, col_ndofs) = value
-@propagate_inbounds matrix_entry_value(value::AbstractVector, a, b, row_ndofs, col_ndofs) = col_ndofs == 1 ? value[a] : value[b]
-@propagate_inbounds matrix_entry_value(value::AbstractMatrix, a, b, row_ndofs, col_ndofs) = value[ifelse(size(value, 1) == 1, 1, a), ifelse(size(value, 2) == 1, 1, b)]
-
-@noinline check_matrix_entry_size(::Number, row_ndofs, col_ndofs) = nothing
-@noinline function check_matrix_entry_size(value::AbstractVector, row_ndofs, col_ndofs)
-    expected_length = col_ndofs == 1 ? row_ndofs : col_ndofs
-    (row_ndofs == 1 || col_ndofs == 1) && length(value) == expected_length ||
-        throw(DimensionMismatch("vector value is incompatible with matrix entry dimensions"))
-end
-@noinline function check_matrix_entry_size(value::AbstractMatrix, row_ndofs, col_ndofs)
-    (size(value, 1) == 1 || size(value, 1) == row_ndofs) &&
-        (size(value, 2) == 1 || size(value, 2) == col_ndofs) ||
-        throw(DimensionMismatch("matrix value is incompatible with matrix entry dimensions"))
-end
-
 # The canonical Cartesian CSC pattern allows its destination slots to be computed directly.
 @inline function add_entry!(assembler::CartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
     @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
@@ -416,6 +427,8 @@ end
     nothing
 end
 
+# ---- GenericMatrixAssembler ----
+
 struct GenericMatrixAssembler{A <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices}
     matrix::A
     row_dof_table::R
@@ -429,7 +442,7 @@ function add!(assembler::GenericMatrixAssembler, row_nodes, col_nodes, local_mat
     add!(matrix, row_dofs, col_dofs, local_matrix)
 end
 
-# Fallback for matrices that do not have the canonical Cartesian CSC pattern.
+# GenericMatrixAssembler writes entries through the matrix indexing interface.
 @inline function add_entry!(assembler::GenericMatrixAssembler, row_node, col_node, value)
     (; matrix, row_dof_table, col_dof_table) = assembler
     row_ndofs = size(row_dof_table, 1)
@@ -451,6 +464,8 @@ function support_dofs(table_i, nodes_i, table_j, nodes_j)
     end
 end
 
+# ---- assembler construction ----
+
 function matrix_assembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
     GenericMatrixAssembler(matrix, row_dof_table, col_dof_table)
@@ -466,17 +481,9 @@ function matrix_dof_tables(gmat, row_grid, col_grid)
     row_table, col_table
 end
 
-struct ParticleAssembly end
-struct CellAssembly end
-struct BlockAssembly{I <: CartesianIndices}
-    nodes_i::I
-    nodes_j::I
-    matrix_buffer_pool::BlockMatrixBufferPool
-end
-
-#-------------------
-# LocalMatrixBuffer
-#-------------------
+# -----------------------------------------------------------------------------
+#  LocalMatrixBuffer
+# -----------------------------------------------------------------------------
 
 struct LocalMatrixBuffer{M <: Matrix, R <: LinearIndices, C <: LinearIndices}
     matrix::M
@@ -491,6 +498,25 @@ end
     matrix = get!(() -> Matrix{T}(undef, dims), cache, dims)
     LocalMatrixBuffer(matrix, row_dof_table, col_dof_table)
 end
+
+# ---- DoF indexing ----
+
+function local_dof_table(dof_table, nodes)
+    @_propagate_inbounds_meta
+    LinearIndices((size(dof_table, 1), size(nodes)...))
+end
+
+function local_dofs(local_table, ip)
+    @_propagate_inbounds_meta
+    vec(view(local_table, :, ip))
+end
+
+matrix_row_dofs(buffer::LocalMatrixBuffer, ip) = (@_propagate_inbounds_meta; local_dofs(buffer.row_dof_table, ip))
+matrix_col_dofs(buffer::LocalMatrixBuffer, jp) = (@_propagate_inbounds_meta; local_dofs(buffer.col_dof_table, jp))
+matrix_row_dofs(::Nothing, ip) = nothing
+matrix_col_dofs(::Nothing, jp) = nothing
+
+# ---- assembly ----
 
 function assemble_first!(assembler, buffer::LocalMatrixBuffer, orientation, row_node, col_node, I, J, value)
     @_propagate_inbounds_meta
@@ -524,9 +550,15 @@ end
 
 finish_assembly!(assembler, ::Nothing, orientation, row_nodes, col_nodes) = assembler.matrix
 
-#-------------------
-# BlockMatrixBuffer
-#-------------------
+# -----------------------------------------------------------------------------
+#  BlockMatrixBuffer
+# -----------------------------------------------------------------------------
+
+struct BlockAssembly{I <: CartesianIndices}
+    nodes_i::I
+    nodes_j::I
+    matrix_buffer_pool::BlockMatrixBufferPool
+end
 
 struct BlockMatrixBufferKey{T,N}
     row_size::Dims{N}
@@ -572,6 +604,8 @@ function BlockMatrixBuffer(assembler::CartesianSparseMatrixAssembler, row_nodes:
     BlockMatrixBuffer(BlockMatrixBufferKey(assembler, row_nodes, col_nodes))
 end
 
+# ---- buffer pool ----
+
 function acquire!(pool::BlockMatrixBufferPool, key::BlockMatrixBufferKey{T,N}) where {T,N}
     lock(pool.lock)
     buffer = try
@@ -596,6 +630,8 @@ function release!(pool::BlockMatrixBufferPool, buffer::BlockMatrixBuffer)
     nothing
 end
 
+# ---- block buffer selection ----
+
 # Canonical Cartesian CSC matrices use a block buffer. Matrices using
 # GenericMatrixAssembler are written directly within the thread-safe block schedule.
 function block_matrix_buffer(assembler::CartesianSparseMatrixAssembler, assembly::BlockAssembly, orientation)
@@ -604,6 +640,8 @@ function block_matrix_buffer(assembler::CartesianSparseMatrixAssembler, assembly
 end
 
 block_matrix_buffer(::GenericMatrixAssembler, ::BlockAssembly, orientation) = nothing
+
+# ---- assembly ----
 
 function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, row_node::CartesianIndex{N}, col_node::CartesianIndex{N}, value) where {T,N}
     @_propagate_inbounds_meta
@@ -619,9 +657,14 @@ function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{
     local_row = LinearIndices(neighboring_rows)[neighboring_row]
     local_col = LinearIndices(col_size)[local_col_node]
 
-    for b in 1:col_ndofs
-        slot = node_colptr[local_col] + ((b - 1) * length(neighboring_rows) + local_row - 1) * row_ndofs
-        for a in 1:row_ndofs
+    slot = node_colptr[local_col] + (local_row - 1) * row_ndofs * col_ndofs
+    if value isa AbstractMatrix && size(value) == (row_ndofs, col_ndofs)
+        for index in eachindex(value)
+            values[slot] += value[index]
+            slot += 1
+        end
+    else
+        for b in 1:col_ndofs, a in 1:row_ndofs
             values[slot] += matrix_entry_value(value, a, b, row_ndofs, col_ndofs)
             slot += 1
         end
@@ -665,8 +708,8 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
         for b in 1:col_ndofs
             col = col_dof_table[b,col_node]
             matrix_col_start = first(nzrange(matrix, col))
-            local_slot = node_colptr[local_col] + (b - 1) * length(neighboring_rows) * row_ndofs
-            for local_row_node in neighboring_rows
+            for (local_row, local_row_node) in enumerate(neighboring_rows)
+                local_slot = node_colptr[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
                 row_node = local_row_node + first_row_node - oneunit(first_row_node)
                 matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
                 matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * row_ndofs
@@ -700,29 +743,83 @@ end
     nothing
 end
 
-# --- helpers ---
-
-function local_dof_table(dof_table, nodes)
+# Canonical Cartesian CSC entries are accumulated in the block buffer.
+function assemble_block_entry!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation, row_node, col_node, value)
     @_propagate_inbounds_meta
-    LinearIndices((size(dof_table, 1), size(nodes)...))
+    row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
+    row_node, col_node = orientation((row_node, col_node))
+    add_entry!(buffer, row_nodes, col_nodes, row_node, col_node, orient_matrix_entry(orientation, value))
 end
 
-function local_dofs(local_table, ip)
+# Generic matrices are written directly within the thread-safe block schedule.
+function assemble_block_entry!(assembler::GenericMatrixAssembler, ::Nothing, assembly::BlockAssembly, orientation, row_node, col_node, value)
     @_propagate_inbounds_meta
-    vec(view(local_table, :, ip))
+    row_node, col_node = orientation((row_node, col_node))
+    add_entry!(assembler, row_node, col_node, orient_matrix_entry(orientation, value))
 end
 
-matrix_row_dofs(buffer::LocalMatrixBuffer, ip) = (@_propagate_inbounds_meta; local_dofs(buffer.row_dof_table, ip))
-matrix_col_dofs(buffer::LocalMatrixBuffer, jp) = (@_propagate_inbounds_meta; local_dofs(buffer.col_dof_table, jp))
-matrix_row_dofs(::Nothing, ip) = nothing
-matrix_col_dofs(::Nothing, jp) = nothing
+function finish_block_assembly!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation)
+    @_propagate_inbounds_meta
+    row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
+    try
+        scatter!(assembler, buffer, row_nodes, col_nodes)
+    finally
+        release!(assembly.matrix_buffer_pool, buffer)
+    end
+end
 
-orient_matrix_entry(::typeof(identity), value) = value
-orient_matrix_entry(::typeof(reverse), value) = value'
+function finish_block_assembly!(assembler::GenericMatrixAssembler, ::Nothing, assembly::BlockAssembly, orientation)
+    assembler.matrix
+end
 
-#------------
-# P2G_Matrix
-#------------
+# -----------------------------------------------------------------------------
+#  P2G_Matrix
+# -----------------------------------------------------------------------------
+
+struct ParticleAssembly end
+struct CellAssembly end
+
+# ---- support nodes ----
+
+@inline function matrix_supportnodes(bw, grid)
+    @_propagate_inbounds_meta
+    # Matrix assembly indexes global DOF tables, which are built on logical
+    # grid indices. For an SpGrid, supportnodes(bw, grid) returns SpIndex
+    # storage tokens instead. Using those here would require SpIndex to fully
+    # support AbstractArray indexing.
+    nodes = supportnodes(bw)
+    @boundscheck checkbounds(get_mesh(grid), nodes)
+    nodes, nodes
+end
+
+@inline function matrix_supportnodes(bw_i, grid_i, bw_j, grid_j)
+    @_propagate_inbounds_meta
+    # See the single-grid method: matrix DOF tables need logical grid indices,
+    # not SpGrid storage tokens.
+    nodes_i = supportnodes(bw_i)
+    nodes_j = supportnodes(bw_j)
+    @boundscheck checkbounds(get_mesh(grid_i), nodes_i)
+    @boundscheck checkbounds(get_mesh(grid_j), nodes_j)
+    nodes_i, nodes_j
+end
+
+function matrix_block_supportnodes(weights, particle_indices, grid)
+    @_propagate_inbounds_meta
+    p, remaining_particles = Iterators.peel(particle_indices)
+    nodes = supportnodes(weights[p])
+    first_node = first(nodes)
+    last_node = last(nodes)
+    for p in remaining_particles
+        nodes = supportnodes(weights[p])
+        first_node = CartesianIndex(map(min, Tuple(first_node), Tuple(first(nodes))))
+        last_node = CartesianIndex(map(max, Tuple(last_node), Tuple(last(nodes))))
+    end
+    nodes = first_node:last_node
+    @boundscheck checkbounds(get_mesh(grid), nodes)
+    nodes
+end
+
+# ---- assembly scheduling ----
 
 function P2G_Matrix(f, device::CPUDevice, schedule::Val, grids, particles, weights, partition)
     P2G((grids, particles, weights, p) -> (@inline f(grids, particles, weights, (p,), ParticleAssembly())), device, schedule, grids, particles, weights, partition)
@@ -760,6 +857,13 @@ function P2G_Matrix(f, ::CPUDevice, ::Val{scheduler}, grids, particles::Quadratu
         end
     end
 end
+
+function check_arguments_for_P2G_Matrix(grid, particles, weights, partition)
+    check_arguments_for_P2G(grid, particles, weights, partition)
+    @assert get_device(grid) isa CPUDevice
+end
+
+# ---- macro implementation ----
 
 """
     @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) [partition] begin
@@ -806,19 +910,24 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     equations = map(equations) do eq
         TransferEquation(eq.kind, eq.lhs, resolve_refs(eq.rhs, scope), eq.op)
     end
-    replaced = scope.replacements
-    inner_symbols = p2g_cached_symbols(replaced, 1, 2, 4, 5)
+    particle_replacements = cached_replacements(scope, p)
+    i_replacements = cached_replacements(scope, i, ip)
+    j_replacements = cached_replacements(scope, j, jp)
+    inner_symbols = p2g_cached_symbols(cached_replacements(scope, i, j, ip, jp))
 
     fillzeros = Any[]
     gmats = Any[]
     assemblers_init = Any[]
     hoist_exprs = Any[]
     buffers_init = Any[]
+    block_buffers_init = Any[]
     local_jdofs = Any[]
     local_idofs = Any[]
     assemble_first = Any[]
     assemble_add = Any[]
+    assemble_block_entries = Any[]
     finish_assemblies = Any[]
+    finish_block_assemblies = Any[]
     for equation in equations
         (; lhs, rhs, op) = equation
         @capture(lhs, gmat_[gi_,gj_]) || error("@P2G_Matrix: Invalid global matrix expression, got `$lhs`")
@@ -849,12 +958,15 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
                 error("BlockAssembly must use block assembly")
             end
         end)
+        push!(block_buffers_init, :($buffer = Tesserae.block_matrix_buffer($assembler, $matrix_assembly, $orientation)))
         push!(local_jdofs, :($J = Tesserae.matrix_col_dofs($buffer, $jp)))
         push!(local_idofs, :($I = Tesserae.matrix_row_dofs($buffer, $ip)))
         push!(assemble_first, :(Tesserae.assemble_first!($assembler, $buffer, $orientation, $i, $j, $I, $J, $rhs)))
         push!(assemble_add, :(Tesserae.assemble_add!($assembler, $buffer, $orientation, $i, $j, $I, $J, $rhs)))
+        push!(assemble_block_entries, :(Tesserae.assemble_block_entry!($assembler, $buffer, $matrix_assembly, $orientation, $i, $j, $rhs)))
         push!(assemblers_init, :($assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($row_grid), Tesserae.get_mesh($col_grid), Tesserae.basis($row_weights), Tesserae.basis($col_weights))))
         push!(finish_assemblies, :(Tesserae.finish_assembly!($assembler, $buffer, $orientation, $gridindices_i, $gridindices_j)))
+        push!(finish_block_assemblies, :(Tesserae.finish_block_assembly!($assembler, $buffer, $matrix_assembly, $orientation)))
     end
 
     supportnodes_expr = if grid_i == grid_j && weights_i == weights_j
@@ -864,7 +976,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     end
 
     particle_init = quote
-        $(replaced[3]...)
+        $(particle_replacements...)
         $(hoist_exprs...)
         $bw_i, $bw_j = $weights_i′[$p], $weights_j′[$p]
     end
@@ -873,11 +985,11 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         quote
             for $jp in eachindex($gridindices_j)
                 $j = $gridindices_j[$jp]
-                $(cached_replacements(scope, 2, 5)...)
+                $(j_replacements...)
                 $(local_jdofs...)
                 for $ip in eachindex($gridindices_i)
                     $i = $gridindices_i[$ip]
-                    $(cached_replacements(scope, 1, 4)...)
+                    $(i_replacements...)
                     $(local_idofs...)
                     $(assembly...)
                 end
@@ -885,7 +997,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         end
     end
 
-    body = quote
+    particle_or_cell_body = quote
         $p, $remaining_particles = Base.Iterators.peel($particle_indices)
         $particle_init
         $supportnodes_expr
@@ -896,6 +1008,32 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
             $(assemble_particle(assemble_add))
         end
         $(finish_assemblies...)
+    end
+
+    block_body = quote
+        $(block_buffers_init...)
+        for $p in $particle_indices
+            $particle_init
+            $supportnodes_expr
+            for $jp in eachindex($gridindices_j)
+                $j = $gridindices_j[$jp]
+                $(j_replacements...)
+                for $ip in eachindex($gridindices_i)
+                    $i = $gridindices_i[$ip]
+                    $(i_replacements...)
+                    $(assemble_block_entries...)
+                end
+            end
+        end
+        $(finish_block_assemblies...)
+    end
+
+    body = quote
+        if $matrix_assembly isa Tesserae.BlockAssembly
+            $block_body
+        else
+            $particle_or_cell_body
+        end
     end
 
     if !DEBUG
@@ -928,44 +1066,6 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     esc(interpolate_transfer_values(body, program))
 end
 
-@inline function matrix_supportnodes(bw, grid)
-    @_propagate_inbounds_meta
-    # Matrix assembly indexes global DOF tables, which are built on logical
-    # grid indices. For an SpGrid, supportnodes(bw, grid) returns SpIndex
-    # storage tokens instead. Using those here would require SpIndex to fully
-    # support AbstractArray indexing.
-    nodes = supportnodes(bw)
-    @boundscheck checkbounds(get_mesh(grid), nodes)
-    nodes, nodes
-end
-
-@inline function matrix_supportnodes(bw_i, grid_i, bw_j, grid_j)
-    @_propagate_inbounds_meta
-    # See the single-grid method: matrix DOF tables need logical grid indices,
-    # not SpGrid storage tokens.
-    nodes_i = supportnodes(bw_i)
-    nodes_j = supportnodes(bw_j)
-    @boundscheck checkbounds(get_mesh(grid_i), nodes_i)
-    @boundscheck checkbounds(get_mesh(grid_j), nodes_j)
-    nodes_i, nodes_j
-end
-
-function matrix_block_supportnodes(weights, particle_indices, grid)
-    @_propagate_inbounds_meta
-    p, remaining_particles = Iterators.peel(particle_indices)
-    nodes = supportnodes(weights[p])
-    first_node = first(nodes)
-    last_node = last(nodes)
-    for p in remaining_particles
-        nodes = supportnodes(weights[p])
-        first_node = CartesianIndex(map(min, Tuple(first_node), Tuple(first(nodes))))
-        last_node = CartesianIndex(map(max, Tuple(last_node), Tuple(last(nodes))))
-    end
-    nodes = first_node:last_node
-    @boundscheck checkbounds(get_mesh(grid), nodes)
-    nodes
-end
-
 function unpair2(ex::Expr)
     if @capture(ex, lhs_Symbol => (rhs1_Symbol, rhs2_Symbol))
         return (lhs, lhs), (rhs1, rhs2)
@@ -974,11 +1074,6 @@ function unpair2(ex::Expr)
     else
         error("invalid expression, $ex")
     end
-end
-
-function check_arguments_for_P2G_Matrix(grid, particles, weights, partition)
-    check_arguments_for_P2G(grid, particles, weights, partition)
-    @assert get_device(grid) isa CPUDevice
 end
 
 """

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -315,9 +315,11 @@ end
 orient_matrix_entry(::typeof(identity), value) = value
 orient_matrix_entry(::typeof(reverse), value) = value'
 
-@noinline function check_matrix_entry_size(::Number, row_ndofs, col_ndofs)
-    (row_ndofs, col_ndofs) == (1, 1) || throw(DimensionMismatch("scalar value requires a scalar matrix entry"))
-end
+# Scalars broadcast over every entry in the DoF block.
+check_matrix_entry_size(::Number, row_ndofs, col_ndofs) = nothing
+matrix_entry_value(value::Number, index) = value
+matrix_entry_value(value, index) = value[index]
+
 @noinline function check_matrix_entry_size(value::AbstractVector, row_ndofs, col_ndofs)
     expected_length = col_ndofs == 1 ? row_ndofs : col_ndofs
     (row_ndofs == 1 || col_ndofs == 1) && length(value) == expected_length ||
@@ -404,7 +406,7 @@ end
         col = col_dof_table[b, col_node]
         slot = first(nzrange(matrix, col)) + row_offset
         for a in 1:row_ndofs
-            values[slot] += value[(b - 1) * row_ndofs + a]
+            values[slot] += matrix_entry_value(value, (b - 1) * row_ndofs + a)
             slot += 1
         end
     end
@@ -445,7 +447,7 @@ end
     col_ndofs = size(col_dof_table, 1)
     @boundscheck check_matrix_entry_size(value, row_ndofs, col_ndofs)
     @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
-        matrix[row_dof_table[a,row_node], col_dof_table[b,col_node]] += value[(b - 1) * row_ndofs + a]
+        matrix[row_dof_table[a,row_node], col_dof_table[b,col_node]] += matrix_entry_value(value, (b - 1) * row_ndofs + a)
     end
     matrix
 end
@@ -648,8 +650,8 @@ function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{
     local_col = LinearIndices(col_size)[local_col_node]
 
     slot = node_colstarts[local_col] + (local_row - 1) * row_ndofs * col_ndofs
-    for index in eachindex(value)
-        values[slot] += value[index]
+    for index in 1:row_ndofs * col_ndofs
+        values[slot] += matrix_entry_value(value, index)
         slot += 1
     end
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -306,12 +306,11 @@ function add!(A::AbstractMatrix, I::AbstractVector{Int}, J::AbstractVector{Int},
     @inbounds @views A[I,J] .+= K
 end
 
-struct CartesianSparseMatrixAssembler{A <: SparseMatrixCSC, N}
+struct CartesianSparseMatrixAssembler{A <: SparseMatrixCSC, R <: LinearIndices, C <: LinearIndices}
     matrix::A
-    mesh_size::Dims{N}
+    row_dof_table::R
+    col_dof_table::C
     sparsity_radius::Int
-    row_dofs_per_node::Int
-    col_dofs_per_node::Int
 end
 
 function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, sparsity_radius::Int)
@@ -322,7 +321,9 @@ function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, spa
     iszero(row_remainder) && iszero(col_remainder) || throw(DimensionMismatch("matrix dimensions must be multiples of the number of mesh nodes"))
     row_dofs_per_node > 0 && col_dofs_per_node > 0 || throw(DimensionMismatch("matrix must have at least one row and column DoF per node"))
     sparsity_radius ≥ 0 || throw(ArgumentError("sparsity radius must be nonnegative"))
-    assembler = CartesianSparseMatrixAssembler(A, mesh_size, sparsity_radius, row_dofs_per_node, col_dofs_per_node)
+    row_dof_table = LinearIndices((row_dofs_per_node, mesh_size...))
+    col_dof_table = LinearIndices((col_dofs_per_node, mesh_size...))
+    assembler = CartesianSparseMatrixAssembler(A, row_dof_table, col_dof_table, sparsity_radius)
     has_cartesian_sparse_pattern(assembler) || throw(ArgumentError("Cartesian sparse matrix must use the canonical sparsity pattern"))
     assembler
 end
@@ -341,18 +342,19 @@ function cartesian_neighbor_nodes(node::CartesianIndex{N}, mesh_size::Dims{N}, s
 end
 
 function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
-    (; matrix, mesh_size, sparsity_radius, row_dofs_per_node, col_dofs_per_node) = assembler
-    row_dofs = LinearIndices((row_dofs_per_node, mesh_size...))
-    col_dofs = LinearIndices((col_dofs_per_node, mesh_size...))
+    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
+    mesh_size = Base.tail(size(row_dof_table))
+    row_dofs_per_node = size(row_dof_table, 1)
+    col_dofs_per_node = size(col_dof_table, 1)
     rows = rowvals(matrix)
     for col_node in CartesianIndices(mesh_size), b in 1:col_dofs_per_node
-        col = col_dofs[b, col_node]
+        col = col_dof_table[b, col_node]
         indices = nzrange(matrix, col)
         k = first(indices)
         stop = last(indices) + 1
         for row_node in cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius), a in 1:row_dofs_per_node
             k < stop || return false
-            rows[k] == row_dofs[a, row_node] || return false
+            rows[k] == row_dof_table[a, row_node] || return false
             k += 1
         end
         k == stop || return false
@@ -360,8 +362,11 @@ function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
     true
 end
 
-@inline function add!(assembler::CartesianSparseMatrixAssembler{A, N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, K::AbstractMatrix) where {A, N}
-    (; matrix, mesh_size, sparsity_radius, row_dofs_per_node, col_dofs_per_node) = assembler
+@inline function add!(assembler::CartesianSparseMatrixAssembler, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, K::AbstractMatrix) where {N}
+    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
+    mesh_size = Base.tail(size(row_dof_table))
+    row_dofs_per_node = size(row_dof_table, 1)
+    col_dofs_per_node = size(col_dof_table, 1)
 
     mesh_nodes = CartesianIndices(mesh_size)
     @boundscheck begin
@@ -372,9 +377,8 @@ end
     end
 
     values = nonzeros(matrix)
-    col_dofs = LinearIndices((col_dofs_per_node, mesh_size...))
     @inbounds for (jp, col_node) in enumerate(col_nodes), b in 1:col_dofs_per_node
-        col = col_dofs[b, col_node]
+        col = col_dof_table[b, col_node]
         neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
         col_start = first(nzrange(matrix, col))
         local_col = col_dofs_per_node * (jp - 1) + b
@@ -393,7 +397,23 @@ end
     matrix
 end
 
-matrix_assembler(args...) = nothing
+struct GenericMatrixAssembler{A <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices}
+    matrix::A
+    row_dof_table::R
+    col_dof_table::C
+end
+
+@inline function add!(assembler::GenericMatrixAssembler, row_nodes, col_nodes, local_matrix)
+    @_propagate_inbounds_meta
+    (; matrix, row_dof_table, col_dof_table) = assembler
+    row_dofs, col_dofs = support_dofs(row_dof_table, row_nodes, col_dof_table, col_nodes)
+    add!(matrix, row_dofs, col_dofs, local_matrix)
+end
+
+function matrix_assembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
+    row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
+    GenericMatrixAssembler(matrix, row_dof_table, col_dof_table)
+end
 matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis) = CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 
 function P2G_Matrix(f, device::CPUDevice, schedule::Val, grids, particles, weights, partition)
@@ -471,7 +491,6 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
 
     fillzeros = Any[]
     gmats = Any[]
-    gdofs_init = Any[]
     assemblers_init = Any[]
     hoist_exprs = Any[]
     lmat_init = Any[]
@@ -487,13 +506,9 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         gmat in gmats && error("@P2G_Matrix: each global matrix may appear only once in a block; combine terms for `$gmat` into one `@∑` expression")
 
         lmat = gensym(gmat)
-        gdofs_i = gensym(Symbol(gmat, :gdofs_i))
-        gdofs_j = gensym(Symbol(gmat, :gdofs_j))
         ldofs_i = gensym(Symbol(gmat, :ldofs_i))
         ldofs_j = gensym(Symbol(gmat, :ldofs_j))
         assembler = gensym(Symbol(gmat, :assembler))
-        dofs_i = gensym(Symbol(gmat, :dofs_i))
-        dofs_j = gensym(Symbol(gmat, :dofs_j))
         I = gensym(Symbol(gmat, :I))
         J = gensym(Symbol(gmat, :J))
 
@@ -503,13 +518,23 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         lmat_dims = Symbol(lmat, :dims)
         push!(gmats, gmat)
         if gi == i && gj == j
-            push!(gdofs_init, :(($gdofs_i, $gdofs_j) = Tesserae.matrix_dof_tables($gmat, $grid_i, $grid_j)))
+            row_grid, col_grid = grid_i, grid_j
+            row_weights, col_weights = weights_i, weights_j
+            dof_table_i = :($(assembler).row_dof_table)
+            dof_table_j = :($(assembler).col_dof_table)
+            row_nodes, col_nodes = gridindices_i, gridindices_j
+            scatter_lmat = lmat
         else
-            push!(gdofs_init, :(($gdofs_j, $gdofs_i) = Tesserae.matrix_dof_tables($gmat, $grid_j, $grid_i)))
+            row_grid, col_grid = grid_j, grid_i
+            row_weights, col_weights = weights_j, weights_i
+            dof_table_i = :($(assembler).col_dof_table)
+            dof_table_j = :($(assembler).row_dof_table)
+            row_nodes, col_nodes = gridindices_j, gridindices_i
+            scatter_lmat = :($lmat')
         end
         push!(lmat_init, quote
-            $ldofs_i = Tesserae.local_dof_table($gdofs_i, $gridindices_i)
-            $ldofs_j = Tesserae.local_dof_table($gdofs_j, $gridindices_j)
+            $ldofs_i = Tesserae.local_dof_table($dof_table_i, $gridindices_i)
+            $ldofs_j = Tesserae.local_dof_table($dof_table_j, $gridindices_j)
             $lmat_dims = length($ldofs_i), length($ldofs_j)
             $lmat = get!(()->Array{eltype($gmat)}(undef, $lmat_dims), $(Symbol(gmat,:dict))[], $lmat_dims)
         end)
@@ -517,27 +542,8 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         push!(local_idofs, :($I = Tesserae.local_dofs($ldofs_i, $ip)))
         push!(lmat_assign, :(@inbounds $lmat[$I,$J] .= $rhs))
         push!(lmat_add, :(@inbounds @views $lmat[$I,$J] .+= $rhs))
-        if gi == i && gj == j
-            push!(assemblers_init, :($assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($grid_i), Tesserae.get_mesh($grid_j), Tesserae.basis($weights_i), Tesserae.basis($weights_j))))
-            push!(lmat2gmat, quote
-                if $assembler === nothing
-                    ($dofs_i, $dofs_j) = Tesserae.support_dofs($gdofs_i, $gridindices_i, $gdofs_j, $gridindices_j)
-                    Tesserae.add!($gmat, $dofs_i, $dofs_j, $lmat)
-                else
-                    Tesserae.add!($assembler, $gridindices_i, $gridindices_j, $lmat)
-                end
-            end)
-        else
-            push!(assemblers_init, :($assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($grid_j), Tesserae.get_mesh($grid_i), Tesserae.basis($weights_j), Tesserae.basis($weights_i))))
-            push!(lmat2gmat, quote
-                if $assembler === nothing
-                    ($dofs_j, $dofs_i) = Tesserae.support_dofs($gdofs_j, $gridindices_j, $gdofs_i, $gridindices_i)
-                    Tesserae.add!($gmat, $dofs_j, $dofs_i, $lmat')
-                else
-                    Tesserae.add!($assembler, $gridindices_j, $gridindices_i, $lmat')
-                end
-            end)
-        end
+        push!(assemblers_init, :($assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($row_grid), Tesserae.get_mesh($col_grid), Tesserae.basis($row_weights), Tesserae.basis($col_weights))))
+        push!(lmat2gmat, :(Tesserae.add!($assembler, $row_nodes, $col_nodes, $scatter_lmat)))
     end
 
     supportnodes_expr = if grid_i == grid_j && weights_i == weights_j
@@ -604,7 +610,6 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
             $check_arguments_for_P2G_Matrix($grid_i, $particles, $weights_i, $partition)
             $check_arguments_for_P2G_Matrix($grid_j, $particles, $weights_j, $partition)
             $(fillzeros...)
-            $(gdofs_init...)
             $(assemblers_init...)
             Tesserae.P2G_Matrix((($grid_i′,$grid_j′), $particles, ($weights_i′,$weights_j′), $particle_indices) -> $body,
                                 $get_device($grid_i), Val($schedule), ($grid_i,$grid_j), $particles, ($weights_i,$weights_j), $partition)

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -306,6 +306,96 @@ function add!(A::AbstractMatrix, I::AbstractVector{Int}, J::AbstractVector{Int},
     @inbounds @views A[I,J] .+= K
 end
 
+struct CartesianSparseMatrixAssembler{A <: SparseMatrixCSC, N}
+    matrix::A
+    mesh_size::Dims{N}
+    sparsity_radius::Int
+    row_dofs_per_node::Int
+    col_dofs_per_node::Int
+end
+
+function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, sparsity_radius::Int)
+    node_count = prod(mesh_size)
+    node_count > 0 || throw(ArgumentError("mesh must contain at least one node"))
+    row_dofs_per_node, row_remainder = divrem(size(A, 1), node_count)
+    col_dofs_per_node, col_remainder = divrem(size(A, 2), node_count)
+    iszero(row_remainder) && iszero(col_remainder) || throw(DimensionMismatch("matrix dimensions must be multiples of the number of mesh nodes"))
+    row_dofs_per_node > 0 && col_dofs_per_node > 0 || throw(DimensionMismatch("matrix must have at least one row and column DoF per node"))
+    sparsity_radius ≥ 0 || throw(ArgumentError("sparsity radius must be nonnegative"))
+    assembler = CartesianSparseMatrixAssembler(A, mesh_size, sparsity_radius, row_dofs_per_node, col_dofs_per_node)
+    has_cartesian_sparse_pattern(assembler) || throw(ArgumentError("Cartesian sparse matrix must use the canonical sparsity pattern"))
+    assembler
+end
+
+function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
+    size(row_mesh) == size(col_mesh) || throw(DimensionMismatch("row and column meshes must have the same size"))
+    row_sparsity_radius = support_width(row_basis) - 1
+    col_sparsity_radius = support_width(col_basis) - 1
+    row_sparsity_radius == col_sparsity_radius || throw(ArgumentError("row and column bases must have the same support width"))
+    CartesianSparseMatrixAssembler(A, size(row_mesh), row_sparsity_radius)
+end
+
+function cartesian_neighbor_nodes(node::CartesianIndex{N}, mesh_size::Dims{N}, sparsity_radius::Int) where {N}
+    shift = sparsity_radius * oneunit(CartesianIndex{N})
+    ((node-shift) : (node+shift)) ∩ CartesianIndices(mesh_size)
+end
+
+function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
+    (; matrix, mesh_size, sparsity_radius, row_dofs_per_node, col_dofs_per_node) = assembler
+    row_dofs = LinearIndices((row_dofs_per_node, mesh_size...))
+    col_dofs = LinearIndices((col_dofs_per_node, mesh_size...))
+    rows = rowvals(matrix)
+    for col_node in CartesianIndices(mesh_size), b in 1:col_dofs_per_node
+        col = col_dofs[b, col_node]
+        indices = nzrange(matrix, col)
+        k = first(indices)
+        stop = last(indices) + 1
+        for row_node in cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius), a in 1:row_dofs_per_node
+            k < stop || return false
+            rows[k] == row_dofs[a, row_node] || return false
+            k += 1
+        end
+        k == stop || return false
+    end
+    true
+end
+
+@inline function add!(assembler::CartesianSparseMatrixAssembler{A, N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, K::AbstractMatrix) where {A, N}
+    (; matrix, mesh_size, sparsity_radius, row_dofs_per_node, col_dofs_per_node) = assembler
+
+    mesh_nodes = CartesianIndices(mesh_size)
+    @boundscheck begin
+        checkbounds(mesh_nodes, row_nodes)
+        checkbounds(mesh_nodes, col_nodes)
+        size(K) == (row_dofs_per_node * length(row_nodes), col_dofs_per_node * length(col_nodes)) || throw(DimensionMismatch("local matrix size does not match Cartesian support DoFs"))
+        all(row_nodes ⊆ cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius) for col_node in col_nodes) || throw(ArgumentError("local matrix contains entries outside the Cartesian sparsity pattern"))
+    end
+
+    values = nonzeros(matrix)
+    col_dofs = LinearIndices((col_dofs_per_node, mesh_size...))
+    @inbounds for (jp, col_node) in enumerate(col_nodes), b in 1:col_dofs_per_node
+        col = col_dofs[b, col_node]
+        neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
+        col_start = first(nzrange(matrix, col))
+        local_col = col_dofs_per_node * (jp - 1) + b
+        local_row = 1
+        for tail_node in CartesianIndices(Base.tail(row_nodes.indices))
+            first_row_node = CartesianIndex(first(row_nodes)[1], tail_node)
+            local_node = first_row_node - first(neighboring_nodes) + oneunit(first_row_node)
+            slot = col_start + (LinearIndices(neighboring_nodes)[local_node] - 1) * row_dofs_per_node
+            for _ in 1:size(row_nodes, 1), a in 1:row_dofs_per_node
+                values[slot] += K[local_row, local_col]
+                slot += 1
+                local_row += 1
+            end
+        end
+    end
+    matrix
+end
+
+matrix_assembler(args...) = nothing
+matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis) = CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
+
 """
     @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) [partition] begin
         equations...
@@ -357,12 +447,12 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     fillzeros = Any[]
     gmats = Any[]
     gdofs_init = Any[]
+    assemblers_init = Any[]
     hoist_exprs = Any[]
     lmat_init = Any[]
     local_jdofs = Any[]
     local_idofs = Any[]
     lmat_asm = Any[]
-    gdofs_extract = Any[]
     lmat2gmat = Any[]
     for k in eachindex(equations)
         (; lhs, rhs, op) = equations[k]
@@ -375,6 +465,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         gdofs_j = gensym(Symbol(gmat, :gdofs_j))
         ldofs_i = gensym(Symbol(gmat, :ldofs_i))
         ldofs_j = gensym(Symbol(gmat, :ldofs_j))
+        assembler = gensym(Symbol(gmat, :assembler))
         dofs_i = gensym(Symbol(gmat, :dofs_i))
         dofs_j = gensym(Symbol(gmat, :dofs_j))
         I = gensym(Symbol(gmat, :I))
@@ -399,11 +490,26 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         push!(local_jdofs, :($J = Tesserae.local_dofs($ldofs_j, $jp)))
         push!(local_idofs, :($I = Tesserae.local_dofs($ldofs_i, $ip)))
         push!(lmat_asm, :(@inbounds $lmat[$I,$J] .= $rhs))
-        push!(gdofs_extract, :(($dofs_i, $dofs_j) = Tesserae.support_dofs($gdofs_i, $gridindices_i, $gdofs_j, $gridindices_j)))
         if gi == i && gj == j
-            push!(lmat2gmat, :(Tesserae.add!($gmat, $dofs_i, $dofs_j, $lmat)))
+            push!(assemblers_init, :($assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($grid_i), Tesserae.get_mesh($grid_j), Tesserae.basis($weights_i), Tesserae.basis($weights_j))))
+            push!(lmat2gmat, quote
+                if $assembler === nothing
+                    ($dofs_i, $dofs_j) = Tesserae.support_dofs($gdofs_i, $gridindices_i, $gdofs_j, $gridindices_j)
+                    Tesserae.add!($gmat, $dofs_i, $dofs_j, $lmat)
+                else
+                    Tesserae.add!($assembler, $gridindices_i, $gridindices_j, $lmat)
+                end
+            end)
         else
-            push!(lmat2gmat, :(Tesserae.add!($gmat, $dofs_j, $dofs_i, $lmat')))
+            push!(assemblers_init, :($assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($grid_j), Tesserae.get_mesh($grid_i), Tesserae.basis($weights_j), Tesserae.basis($weights_i))))
+            push!(lmat2gmat, quote
+                if $assembler === nothing
+                    ($dofs_j, $dofs_i) = Tesserae.support_dofs($gdofs_j, $gridindices_j, $gdofs_i, $gridindices_i)
+                    Tesserae.add!($gmat, $dofs_j, $dofs_i, $lmat')
+                else
+                    Tesserae.add!($assembler, $gridindices_j, $gridindices_i, $lmat')
+                end
+            end)
         end
     end
 
@@ -430,7 +536,6 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
                 $(lmat_asm...)
             end
         end
-        $(gdofs_extract...)
         $(lmat2gmat...)
     end
 
@@ -458,6 +563,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
             $check_arguments_for_P2G_Matrix($grid_j, $particles, $weights_j, $partition)
             $(fillzeros...)
             $(gdofs_init...)
+            $(assemblers_init...)
             $P2G((($grid_i′,$grid_j′), $particles, ($weights_i′,$weights_j′), $p) -> $body, $get_device($grid_i), Val($schedule), ($grid_i,$grid_j), $particles, ($weights_i,$weights_j), $partition)
         end
     end

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -603,12 +603,9 @@ end
 # ---- buffer pool ----
 
 function acquire!(pool::BlockMatrixBufferPool, key::BlockMatrixBufferKey{T,N}) where {T,N}
-    lock(pool.lock)
-    buffer = try
+    buffer = lock(pool.lock) do
         buffers = get!(Vector{Any}, pool.buffers, key)
         isempty(buffers) ? nothing : pop!(buffers)
-    finally
-        unlock(pool.lock)
     end
     buffer === nothing && return BlockMatrixBuffer(key)
     buffer = buffer::BlockMatrixBuffer{T,N}
@@ -617,11 +614,8 @@ function acquire!(pool::BlockMatrixBufferPool, key::BlockMatrixBufferKey{T,N}) w
 end
 
 function release!(pool::BlockMatrixBufferPool, buffer::BlockMatrixBuffer)
-    lock(pool.lock)
-    try
+    lock(pool.lock) do
         push!(get!(Vector{Any}, pool.buffers, buffer.key), buffer)
-    finally
-        unlock(pool.lock)
     end
     nothing
 end

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -481,44 +481,39 @@ end
 #  LocalMatrixBuffer
 # -----------------------------------------------------------------------------
 
-struct LocalMatrixBuffer{M <: Matrix, R <: LinearIndices, C <: LinearIndices}
+struct LocalMatrixBuffer{M <: Matrix}
     matrix::M
-    row_dof_table::R
-    col_dof_table::C
+    row_ndofs::Int
+    col_ndofs::Int
 end
 
-function local_matrix_cache(assembler, row_weights, col_weights)
-    T = eltype(assembler.matrix)
+function local_matrix_cache(matrix, dof_table_i, weights_i, dof_table_j, weights_j)
+    T = eltype(matrix)
     TaskLocalValue{Matrix{T}}() do
-        row_size = size(assembler.row_dof_table, 1) * nsupportnodes(basis(row_weights))
-        col_size = size(assembler.col_dof_table, 1) * nsupportnodes(basis(col_weights))
+        row_size = size(dof_table_i, 1) * nsupportnodes(basis(weights_i))
+        col_size = size(dof_table_j, 1) * nsupportnodes(basis(weights_j))
         Matrix{T}(undef, row_size, col_size)
     end
 end
 
 @inline function local_matrix_buffer(cache::TaskLocalValue{<:Matrix}, row_dof_table, row_nodes, col_dof_table, col_nodes)
-    row_dof_table = local_dof_table(row_dof_table, row_nodes)
-    col_dof_table = local_dof_table(col_dof_table, col_nodes)
-    dims = length(row_dof_table), length(col_dof_table)
+    row_ndofs = size(row_dof_table, 1)
+    col_ndofs = size(col_dof_table, 1)
+    dims = row_ndofs * length(row_nodes), col_ndofs * length(col_nodes)
     matrix = cache[]
     @boundscheck size(matrix) == dims || throw(DimensionMismatch("local matrix size changed during assembly"))
-    LocalMatrixBuffer(matrix, row_dof_table, col_dof_table)
+    LocalMatrixBuffer(matrix, row_ndofs, col_ndofs)
 end
 
 # ---- DoF indexing ----
 
-function local_dof_table(dof_table, nodes)
+function local_dofs(ndofs::Int, index::Integer)
     @_propagate_inbounds_meta
-    LinearIndices((size(dof_table, 1), size(nodes)...))
+    vec(view(LinearIndices((ndofs, index)), :, index))
 end
 
-function local_dofs(local_table, ip)
-    @_propagate_inbounds_meta
-    vec(view(local_table, :, ip))
-end
-
-matrix_row_dofs(buffer::LocalMatrixBuffer, ip) = (@_propagate_inbounds_meta; local_dofs(buffer.row_dof_table, ip))
-matrix_col_dofs(buffer::LocalMatrixBuffer, jp) = (@_propagate_inbounds_meta; local_dofs(buffer.col_dof_table, jp))
+matrix_row_dofs(buffer::LocalMatrixBuffer, ip) = (@_propagate_inbounds_meta; local_dofs(buffer.row_ndofs, ip))
+matrix_col_dofs(buffer::LocalMatrixBuffer, jp) = (@_propagate_inbounds_meta; local_dofs(buffer.col_ndofs, jp))
 matrix_row_dofs(::Nothing, ip) = nothing
 matrix_col_dofs(::Nothing, jp) = nothing
 
@@ -909,10 +904,8 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     j_replacements = cached_replacements(scope, j, jp)
     inner_symbols = p2g_cached_symbols(cached_replacements(scope, i, j, ip, jp))
 
-    fillzeros = Any[]
     gmats = Any[]
-    assemblers_init = Any[]
-    matrix_caches = Any[]
+    matrices_init = Any[]
     hoist_exprs = Any[]
     buffers_init = Any[]
     block_buffers_init = Any[]
@@ -934,7 +927,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         I = gensym(Symbol(gmat, :I))
         J = gensym(Symbol(gmat, :J))
 
-        op == :(=)  && push!(fillzeros, :(Tesserae.fillzero!($gmat)))
+        fillzero = op == :(=) ? :(Tesserae.fillzero!($gmat)) : nothing
         op == :(-=) && (rhs = :(-$rhs))
         rhs = hoist_p2g_rhs!(hoist_exprs, inner_symbols, rhs)
         push!(gmats, gmat)
@@ -944,12 +937,17 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         row_grid, col_grid = reorder_pair((grid_i, grid_j))
         row_weights, col_weights = reorder_pair((weights_i, weights_j))
         dof_table_i, dof_table_j = reorder_pair((:($(assembler).row_dof_table), :($(assembler).col_dof_table)))
-        push!(matrix_caches, :($(Symbol(gmat,:cache)) = Tesserae.local_matrix_cache($assembler, $row_weights, $col_weights)))
+        matrix_cache = Symbol(gmat, :cache)
+        push!(matrices_init, quote
+            $fillzero
+            $assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($row_grid), Tesserae.get_mesh($col_grid), Tesserae.basis($row_weights), Tesserae.basis($col_weights))
+            $matrix_cache = Tesserae.local_matrix_cache($gmat, $dof_table_i, $weights_i, $dof_table_j, $weights_j)
+        end)
         push!(buffers_init, quote
             if $matrix_assembly isa Tesserae.ParticleAssembly
                 $buffer = nothing
             elseif $matrix_assembly isa Tesserae.CellAssembly
-                $buffer = Tesserae.local_matrix_buffer($(Symbol(gmat,:cache)), $dof_table_i, $gridindices_i, $dof_table_j, $gridindices_j)
+                $buffer = Tesserae.local_matrix_buffer($matrix_cache, $dof_table_i, $gridindices_i, $dof_table_j, $gridindices_j)
             else
                 error("BlockAssembly must use block assembly")
             end
@@ -960,7 +958,6 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         push!(assemble_first, :(Tesserae.assemble_first!($assembler, $buffer, $orientation, $i, $j, $I, $J, $rhs)))
         push!(assemble_add, :(Tesserae.assemble_add!($assembler, $buffer, $orientation, $i, $j, $I, $J, $rhs)))
         push!(assemble_block_entries, :(Tesserae.assemble_block_entry!($assembler, $buffer, $matrix_assembly, $orientation, $i, $j, $rhs)))
-        push!(assemblers_init, :($assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($row_grid), Tesserae.get_mesh($col_grid), Tesserae.basis($row_weights), Tesserae.basis($col_weights))))
         push!(finish_assemblies, :(Tesserae.finish_assembly!($assembler, $buffer, $orientation, $gridindices_i, $gridindices_j)))
         push!(finish_block_assemblies, :(Tesserae.finish_block_assembly!($assembler, $buffer, $matrix_assembly, $orientation)))
     end
@@ -1040,9 +1037,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         let
             $check_arguments_for_P2G_Matrix($grid_i, $particles, $weights_i, $partition)
             $check_arguments_for_P2G_Matrix($grid_j, $particles, $weights_j, $partition)
-            $(fillzeros...)
-            $(assemblers_init...)
-            $(matrix_caches...)
+            $(matrices_init...)
             Tesserae.P2G_Matrix((($grid_i′,$grid_j′), $particles, ($weights_i′,$weights_j′), $particle_indices, $matrix_assembly) -> $body,
                                 $get_device($grid_i), Val($schedule), ($grid_i,$grid_j), $particles, ($weights_i,$weights_j), $partition)
         end

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -315,11 +315,9 @@ end
 orient_matrix_entry(::typeof(identity), value) = value
 orient_matrix_entry(::typeof(reverse), value) = value'
 
-# Scalars broadcast over every entry in the DoF block.
-check_matrix_entry_size(::Number, row_ndofs, col_ndofs) = nothing
-matrix_entry_value(value::Number, index) = value
-matrix_entry_value(value, index) = value[index]
-
+@noinline function check_matrix_entry_size(::Number, row_ndofs, col_ndofs)
+    (row_ndofs, col_ndofs) == (1, 1) || throw(DimensionMismatch("scalar value requires a scalar matrix entry"))
+end
 @noinline function check_matrix_entry_size(value::AbstractVector, row_ndofs, col_ndofs)
     expected_length = col_ndofs == 1 ? row_ndofs : col_ndofs
     (row_ndofs == 1 || col_ndofs == 1) && length(value) == expected_length ||
@@ -406,7 +404,7 @@ end
         col = col_dof_table[b, col_node]
         slot = first(nzrange(matrix, col)) + row_offset
         for a in 1:row_ndofs
-            values[slot] += matrix_entry_value(value, (b - 1) * row_ndofs + a)
+            values[slot] += value[(b - 1) * row_ndofs + a]
             slot += 1
         end
     end
@@ -447,7 +445,7 @@ end
     col_ndofs = size(col_dof_table, 1)
     @boundscheck check_matrix_entry_size(value, row_ndofs, col_ndofs)
     @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
-        matrix[row_dof_table[a,row_node], col_dof_table[b,col_node]] += matrix_entry_value(value, (b - 1) * row_ndofs + a)
+        matrix[row_dof_table[a,row_node], col_dof_table[b,col_node]] += value[(b - 1) * row_ndofs + a]
     end
     matrix
 end
@@ -650,8 +648,8 @@ function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{
     local_col = LinearIndices(col_size)[local_col_node]
 
     slot = node_colstarts[local_col] + (local_row - 1) * row_ndofs * col_ndofs
-    for index in 1:row_ndofs * col_ndofs
-        values[slot] += matrix_entry_value(value, index)
+    for index in eachindex(value)
+        values[slot] += value[index]
         slot += 1
     end
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -517,21 +517,13 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         rhs = hoist_p2g_rhs!(hoist_exprs, inner_symbols, rhs)
         lmat_dims = Symbol(lmat, :dims)
         push!(gmats, gmat)
-        if gi == i && gj == j
-            row_grid, col_grid = grid_i, grid_j
-            row_weights, col_weights = weights_i, weights_j
-            dof_table_i = :($(assembler).row_dof_table)
-            dof_table_j = :($(assembler).col_dof_table)
-            row_nodes, col_nodes = gridindices_i, gridindices_j
-            scatter_lmat = lmat
-        else
-            row_grid, col_grid = grid_j, grid_i
-            row_weights, col_weights = weights_j, weights_i
-            dof_table_i = :($(assembler).col_dof_table)
-            dof_table_j = :($(assembler).row_dof_table)
-            row_nodes, col_nodes = gridindices_j, gridindices_i
-            scatter_lmat = :($lmat')
-        end
+        forward = gi == i && gj == j
+        reorder_pair = forward ? identity : reverse
+        row_grid, col_grid = reorder_pair((grid_i, grid_j))
+        row_weights, col_weights = reorder_pair((weights_i, weights_j))
+        dof_table_i, dof_table_j = reorder_pair((:($(assembler).row_dof_table), :($(assembler).col_dof_table)))
+        row_nodes, col_nodes = reorder_pair((gridindices_i, gridindices_j))
+        scatter_lmat = forward ? lmat : :($lmat')
         push!(lmat_init, quote
             $ldofs_i = Tesserae.local_dof_table($dof_table_i, $gridindices_i)
             $ldofs_j = Tesserae.local_dof_table($dof_table_j, $gridindices_j)

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -487,15 +487,20 @@ struct LocalMatrixBuffer{M <: Matrix, R <: LinearIndices, C <: LinearIndices}
     col_dof_table::C
 end
 
-@inline function local_matrix_buffer(cache::TaskLocalValue{Union{Nothing,Matrix{T}}}, row_dof_table, row_nodes, col_dof_table, col_nodes) where {T}
+function local_matrix_cache(assembler, row_weights, col_weights)
+    T = eltype(assembler.matrix)
+    TaskLocalValue{Matrix{T}}() do
+        row_size = size(assembler.row_dof_table, 1) * nsupportnodes(basis(row_weights))
+        col_size = size(assembler.col_dof_table, 1) * nsupportnodes(basis(col_weights))
+        Matrix{T}(undef, row_size, col_size)
+    end
+end
+
+@inline function local_matrix_buffer(cache::TaskLocalValue{<:Matrix}, row_dof_table, row_nodes, col_dof_table, col_nodes)
     row_dof_table = local_dof_table(row_dof_table, row_nodes)
     col_dof_table = local_dof_table(col_dof_table, col_nodes)
     dims = length(row_dof_table), length(col_dof_table)
     matrix = cache[]
-    if matrix === nothing
-        matrix = Matrix{T}(undef, dims)
-        cache[] = matrix
-    end
     @boundscheck size(matrix) == dims || throw(DimensionMismatch("local matrix size changed during assembly"))
     LocalMatrixBuffer(matrix, row_dof_table, col_dof_table)
 end
@@ -907,6 +912,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     fillzeros = Any[]
     gmats = Any[]
     assemblers_init = Any[]
+    matrix_caches = Any[]
     hoist_exprs = Any[]
     buffers_init = Any[]
     block_buffers_init = Any[]
@@ -938,6 +944,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         row_grid, col_grid = reorder_pair((grid_i, grid_j))
         row_weights, col_weights = reorder_pair((weights_i, weights_j))
         dof_table_i, dof_table_j = reorder_pair((:($(assembler).row_dof_table), :($(assembler).col_dof_table)))
+        push!(matrix_caches, :($(Symbol(gmat,:cache)) = Tesserae.local_matrix_cache($assembler, $row_weights, $col_weights)))
         push!(buffers_init, quote
             if $matrix_assembly isa Tesserae.ParticleAssembly
                 $buffer = nothing
@@ -1029,23 +1036,13 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         body = :(@inbounds $body)
     end
 
-    # cache for local matrices
-    matrix_caches = map(gmats) do gmat
-        matrix_cache = Symbol(gmat, :cache)
-        Tmatrix_cache = Symbol(:T, matrix_cache)
-        quote
-            $Tmatrix_cache = Union{Nothing,Matrix{eltype($gmat)}}
-            $matrix_cache = $TaskLocalValue{$Tmatrix_cache}(() -> nothing)
-        end
-    end
-
     body = quote
         let
-            $(matrix_caches...)
             $check_arguments_for_P2G_Matrix($grid_i, $particles, $weights_i, $partition)
             $check_arguments_for_P2G_Matrix($grid_j, $particles, $weights_j, $partition)
             $(fillzeros...)
             $(assemblers_init...)
+            $(matrix_caches...)
             Tesserae.P2G_Matrix((($grid_i′,$grid_j′), $particles, ($weights_i′,$weights_j′), $particle_indices, $matrix_assembly) -> $body,
                                 $get_device($grid_i), Val($schedule), ($grid_i,$grid_j), $particles, ($weights_i,$weights_j), $partition)
         end

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -487,11 +487,16 @@ struct LocalMatrixBuffer{M <: Matrix, R <: LinearIndices, C <: LinearIndices}
     col_dof_table::C
 end
 
-@inline function local_matrix_buffer(cache, ::Type{T}, row_dof_table, row_nodes, col_dof_table, col_nodes) where {T}
+@inline function local_matrix_buffer(cache::TaskLocalValue{Union{Nothing,Matrix{T}}}, row_dof_table, row_nodes, col_dof_table, col_nodes) where {T}
     row_dof_table = local_dof_table(row_dof_table, row_nodes)
     col_dof_table = local_dof_table(col_dof_table, col_nodes)
     dims = length(row_dof_table), length(col_dof_table)
-    matrix = get!(() -> Matrix{T}(undef, dims), cache, dims)
+    matrix = cache[]
+    if matrix === nothing
+        matrix = Matrix{T}(undef, dims)
+        cache[] = matrix
+    end
+    @boundscheck size(matrix) == dims || throw(DimensionMismatch("local matrix size changed during assembly"))
     LocalMatrixBuffer(matrix, row_dof_table, col_dof_table)
 end
 
@@ -567,7 +572,7 @@ end
 
 struct BlockMatrixBuffer{T,N}
     values::Vector{T}
-    node_colptr::Vector{Int}
+    node_colstarts::Vector{Int}
     key::BlockMatrixBufferKey{T,N}
 end
 
@@ -585,15 +590,14 @@ end
 
 function BlockMatrixBuffer(key::BlockMatrixBufferKey{T,N}) where {T,N}
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs, sparsity_radius) = key
-    node_colptr = Vector{Int}(undef, prod(col_size) + 1)
+    node_colstarts = Vector{Int}(undef, prod(col_size))
     slot = 1
     for (col, col_node) in enumerate(CartesianIndices(col_size))
-        node_colptr[col] = slot
+        node_colstarts[col] = slot
         row_nodes = cartesian_neighbor_nodes(col_node + col_offset, row_size, sparsity_radius)
         slot += row_ndofs * col_ndofs * length(row_nodes)
     end
-    node_colptr[end] = slot
-    BlockMatrixBuffer(zeros(T, slot - 1), node_colptr, key)
+    BlockMatrixBuffer(zeros(T, slot - 1), node_colstarts, key)
 end
 
 # ---- buffer pool ----
@@ -639,7 +643,7 @@ function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{
     @_propagate_inbounds_meta
     @boundscheck check_block_matrix_entry(buffer, row_nodes, col_nodes, row_node, col_node, value)
 
-    (; values, node_colptr, key) = buffer
+    (; values, node_colstarts, key) = buffer
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs, sparsity_radius) = key
 
     local_row_node = row_node - first(row_nodes) + oneunit(row_node)
@@ -649,7 +653,7 @@ function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{
     local_row = LinearIndices(neighboring_rows)[neighboring_row]
     local_col = LinearIndices(col_size)[local_col_node]
 
-    slot = node_colptr[local_col] + (local_row - 1) * row_ndofs * col_ndofs
+    slot = node_colstarts[local_col] + (local_row - 1) * row_ndofs * col_ndofs
     for index in eachindex(value)
         values[slot] += value[index]
         slot += 1
@@ -679,7 +683,7 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
     @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
 
     (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
-    (; values, node_colptr, key) = buffer
+    (; values, node_colstarts, key) = buffer
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
 
     mesh_size = Base.tail(size(row_dof_table))
@@ -694,7 +698,7 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
             col = col_dof_table[b,col_node]
             matrix_col_start = first(nzrange(matrix, col))
             for (local_row, local_row_node) in enumerate(neighboring_rows)
-                local_slot = node_colptr[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
+                local_slot = node_colstarts[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
                 row_node = local_row_node + first_row_node - oneunit(first_row_node)
                 matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
                 matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * row_ndofs
@@ -938,7 +942,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
             if $matrix_assembly isa Tesserae.ParticleAssembly
                 $buffer = nothing
             elseif $matrix_assembly isa Tesserae.CellAssembly
-                $buffer = Tesserae.local_matrix_buffer($(Symbol(gmat,:dict))[], eltype($gmat), $dof_table_i, $gridindices_i, $dof_table_j, $gridindices_j)
+                $buffer = Tesserae.local_matrix_buffer($(Symbol(gmat,:cache)), $dof_table_i, $gridindices_i, $dof_table_j, $gridindices_j)
             else
                 error("BlockAssembly must use block assembly")
             end
@@ -1026,18 +1030,18 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     end
 
     # cache for local matrices
-    arraydicts = map(gmats) do gmat
-        arraydict = Symbol(gmat, :dict)
-        Tarraydict = Symbol(:T, arraydict)
+    matrix_caches = map(gmats) do gmat
+        matrix_cache = Symbol(gmat, :cache)
+        Tmatrix_cache = Symbol(:T, matrix_cache)
         quote
-            $Tarraydict = Dict{Tuple{Int,Int}, Matrix{eltype($gmat)}}
-            $arraydict = $TaskLocalValue{$Tarraydict}(() -> $Tarraydict())
+            $Tmatrix_cache = Union{Nothing,Matrix{eltype($gmat)}}
+            $matrix_cache = $TaskLocalValue{$Tmatrix_cache}(() -> nothing)
         end
     end
 
     body = quote
         let
-            $(arraydicts...)
+            $(matrix_caches...)
             $check_arguments_for_P2G_Matrix($grid_i, $particles, $weights_i, $partition)
             $check_arguments_for_P2G_Matrix($grid_j, $particles, $weights_j, $partition)
             $(fillzeros...)

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -396,6 +396,31 @@ end
 matrix_assembler(args...) = nothing
 matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis) = CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 
+function P2G_Matrix(f, device::CPUDevice, schedule::Val, grids, particles, weights, partition)
+    P2G((grids, particles, weights, p) -> (@inline f(grids, particles, weights, (p,))), device, schedule, grids, particles, weights, partition)
+end
+
+function P2G_Matrix(f, ::CPUDevice, ::Val{scheduler}, grids, particles::QuadraturePoints,
+                    weights::Tuple{<:BasisWeightArray{<:Any, <:Any, <:CellSupportMatrix}, <:BasisWeightArray{<:Any, <:Any, <:CellSupportMatrix}},
+                    ::Nothing) where {scheduler}
+    scheduler == :nothing || @warn "@P2G_Matrix: `ThreadPartition` must be given for threaded computation" maxlog=1
+
+    for cell in axes(particles, 2)
+        particle_indices = (CartesianIndex(q, cell) for q in axes(particles, 1))
+        @inline f(grids, particles, weights, particle_indices)
+    end
+end
+
+function P2G_Matrix(f, ::CPUDevice, ::Val{scheduler}, grids, particles::QuadraturePoints,
+                    weights::Tuple{<:BasisWeightArray{<:Any, <:Any, <:CellSupportMatrix}, <:BasisWeightArray{<:Any, <:Any, <:CellSupportMatrix}},
+                    partition::ThreadPartition{<:CellStrategy}) where {scheduler}
+    for group in threadsafe_groups(partition)
+        tforeach(group, scheduler) do cell
+            @inline f(grids, particles, weights, particle_indices(partition, particles, cell))
+        end
+    end
+end
+
 """
     @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) [partition] begin
         equations...
@@ -431,7 +456,7 @@ function P2G_Matrix_expr(schedule, grid_ij, particles_p, weights_ipjp, partition
 end
 
 function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particles,p), ((weights_i,weights_j),(ip,jp)), partition, program::TransferProgram)
-    @gensym grid_i′ grid_j′ weights_i′ weights_j′ bw_i bw_j gridindices_i gridindices_j
+    @gensym grid_i′ grid_j′ weights_i′ weights_j′ bw_i bw_j gridindices_i gridindices_j particle_indices remaining_particles
 
     equations = program.equations
     isempty(equations) && error("@P2G_Matrix: at least one equation is required")
@@ -452,7 +477,8 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     lmat_init = Any[]
     local_jdofs = Any[]
     local_idofs = Any[]
-    lmat_asm = Any[]
+    lmat_assign = Any[]
+    lmat_add = Any[]
     lmat2gmat = Any[]
     for k in eachindex(equations)
         (; lhs, rhs, op) = equations[k]
@@ -489,7 +515,8 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         end)
         push!(local_jdofs, :($J = Tesserae.local_dofs($ldofs_j, $jp)))
         push!(local_idofs, :($I = Tesserae.local_dofs($ldofs_i, $ip)))
-        push!(lmat_asm, :(@inbounds $lmat[$I,$J] .= $rhs))
+        push!(lmat_assign, :(@inbounds $lmat[$I,$J] .= $rhs))
+        push!(lmat_add, :(@inbounds @views $lmat[$I,$J] .+= $rhs))
         if gi == i && gj == j
             push!(assemblers_init, :($assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($grid_i), Tesserae.get_mesh($grid_j), Tesserae.basis($weights_i), Tesserae.basis($weights_j))))
             push!(lmat2gmat, quote
@@ -519,22 +546,37 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         :(($gridindices_i, $gridindices_j) = Tesserae.matrix_supportnodes($bw_i, $grid_i′, $bw_j, $grid_j′))
     end
 
-    body = quote
+    particle_init = quote
         $(replaced[3]...)
         $(hoist_exprs...)
         $bw_i, $bw_j = $weights_i′[$p], $weights_j′[$p]
+    end
+
+    function assemble_particle(lmat_asm)
+        quote
+            for $jp in eachindex($gridindices_j)
+                $j = $gridindices_j[$jp]
+                $(cached_replacements(scope, 2, 5)...)
+                $(local_jdofs...)
+                for $ip in eachindex($gridindices_i)
+                    $i = $gridindices_i[$ip]
+                    $(cached_replacements(scope, 1, 4)...)
+                    $(local_idofs...)
+                    $(lmat_asm...)
+                end
+            end
+        end
+    end
+
+    body = quote
+        $p, $remaining_particles = Base.Iterators.peel($particle_indices)
+        $particle_init
         $supportnodes_expr
         $(lmat_init...)
-        for $jp in eachindex($gridindices_j)
-            $j = $gridindices_j[$jp]
-            $(cached_replacements(scope, 2, 5)...)
-            $(local_jdofs...)
-            for $ip in eachindex($gridindices_i)
-                $i = $gridindices_i[$ip]
-                $(cached_replacements(scope, 1, 4)...)
-                $(local_idofs...)
-                $(lmat_asm...)
-            end
+        $(assemble_particle(lmat_assign))
+        for $p in $remaining_particles
+            $particle_init
+            $(assemble_particle(lmat_add))
         end
         $(lmat2gmat...)
     end
@@ -564,7 +606,8 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
             $(fillzeros...)
             $(gdofs_init...)
             $(assemblers_init...)
-            $P2G((($grid_i′,$grid_j′), $particles, ($weights_i′,$weights_j′), $p) -> $body, $get_device($grid_i), Val($schedule), ($grid_i,$grid_j), $particles, ($weights_i,$weights_j), $partition)
+            Tesserae.P2G_Matrix((($grid_i′,$grid_j′), $particles, ($weights_i′,$weights_j′), $particle_indices) -> $body,
+                                $get_device($grid_i), Val($schedule), ($grid_i,$grid_j), $particles, ($weights_i,$weights_j), $partition)
         end
     end
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -362,39 +362,58 @@ function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
     true
 end
 
-@inline function add!(assembler::CartesianSparseMatrixAssembler, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, K::AbstractMatrix) where {N}
+# Expand a scalar, vector, or matrix value into one node-pair DoF block.
+@propagate_inbounds matrix_entry_value(value::Number, a, b, row_ndofs, col_ndofs) = value
+@propagate_inbounds matrix_entry_value(value::AbstractVector, a, b, row_ndofs, col_ndofs) = col_ndofs == 1 ? value[a] : value[b]
+@propagate_inbounds matrix_entry_value(value::AbstractMatrix, a, b, row_ndofs, col_ndofs) = value[ifelse(size(value, 1) == 1, 1, a), ifelse(size(value, 2) == 1, 1, b)]
+
+@noinline check_matrix_entry_size(::Number, row_ndofs, col_ndofs) = nothing
+@noinline function check_matrix_entry_size(value::AbstractVector, row_ndofs, col_ndofs)
+    expected_length = col_ndofs == 1 ? row_ndofs : col_ndofs
+    (row_ndofs == 1 || col_ndofs == 1) && length(value) == expected_length ||
+        throw(DimensionMismatch("vector value is incompatible with matrix entry dimensions"))
+end
+@noinline function check_matrix_entry_size(value::AbstractMatrix, row_ndofs, col_ndofs)
+    (size(value, 1) == 1 || size(value, 1) == row_ndofs) &&
+        (size(value, 2) == 1 || size(value, 2) == col_ndofs) ||
+        throw(DimensionMismatch("matrix value is incompatible with matrix entry dimensions"))
+end
+
+# The canonical Cartesian CSC pattern allows its destination slots to be computed directly.
+@inline function add_entry!(assembler::CartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
+    @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
+
     (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
     mesh_size = Base.tail(size(row_dof_table))
-    row_dofs_per_node = size(row_dof_table, 1)
-    col_dofs_per_node = size(col_dof_table, 1)
+    row_ndofs = size(row_dof_table, 1)
+    col_ndofs = size(col_dof_table, 1)
+    neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
 
-    mesh_nodes = CartesianIndices(mesh_size)
-    @boundscheck begin
-        checkbounds(mesh_nodes, row_nodes)
-        checkbounds(mesh_nodes, col_nodes)
-        size(K) == (row_dofs_per_node * length(row_nodes), col_dofs_per_node * length(col_nodes)) || throw(DimensionMismatch("local matrix size does not match Cartesian support DoFs"))
-        all(row_nodes ⊆ cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius) for col_node in col_nodes) || throw(ArgumentError("local matrix contains entries outside the Cartesian sparsity pattern"))
-    end
-
+    neighboring_node = row_node - first(neighboring_nodes) + oneunit(row_node)
+    row_offset = (LinearIndices(neighboring_nodes)[neighboring_node] - 1) * row_ndofs
     values = nonzeros(matrix)
-    @inbounds for (jp, col_node) in enumerate(col_nodes), b in 1:col_dofs_per_node
+
+    @inbounds for b in 1:col_ndofs
         col = col_dof_table[b, col_node]
-        neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
-        col_start = first(nzrange(matrix, col))
-        local_col = col_dofs_per_node * (jp - 1) + b
-        local_row = 1
-        for tail_node in CartesianIndices(Base.tail(row_nodes.indices))
-            first_row_node = CartesianIndex(first(row_nodes)[1], tail_node)
-            local_node = first_row_node - first(neighboring_nodes) + oneunit(first_row_node)
-            slot = col_start + (LinearIndices(neighboring_nodes)[local_node] - 1) * row_dofs_per_node
-            for _ in 1:size(row_nodes, 1), a in 1:row_dofs_per_node
-                values[slot] += K[local_row, local_col]
-                slot += 1
-                local_row += 1
-            end
+        slot = first(nzrange(matrix, col)) + row_offset
+        for a in 1:row_ndofs
+            values[slot] += matrix_entry_value(value, a, b, row_ndofs, col_ndofs)
+            slot += 1
         end
     end
+
     matrix
+end
+
+@noinline function check_cartesian_matrix_entry(assembler::CartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
+    (; row_dof_table, col_dof_table, sparsity_radius) = assembler
+    mesh_size = Base.tail(size(row_dof_table))
+    mesh_nodes = CartesianIndices(mesh_size)
+    checkbounds(mesh_nodes, row_node)
+    checkbounds(mesh_nodes, col_node)
+    row_node ∈ cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius) || throw(ArgumentError("matrix entry is outside the Cartesian sparsity pattern"))
+    check_matrix_entry_size(value, size(row_dof_table, 1), size(col_dof_table, 1))
+    nothing
 end
 
 struct GenericMatrixAssembler{A <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices}
@@ -403,21 +422,322 @@ struct GenericMatrixAssembler{A <: AbstractMatrix, R <: LinearIndices, C <: Line
     col_dof_table::C
 end
 
-@inline function add!(assembler::GenericMatrixAssembler, row_nodes, col_nodes, local_matrix)
+function add!(assembler::GenericMatrixAssembler, row_nodes, col_nodes, local_matrix)
     @_propagate_inbounds_meta
     (; matrix, row_dof_table, col_dof_table) = assembler
     row_dofs, col_dofs = support_dofs(row_dof_table, row_nodes, col_dof_table, col_nodes)
     add!(matrix, row_dofs, col_dofs, local_matrix)
 end
 
+# Fallback for matrices that do not have the canonical Cartesian CSC pattern.
+@inline function add_entry!(assembler::GenericMatrixAssembler, row_node, col_node, value)
+    (; matrix, row_dof_table, col_dof_table) = assembler
+    row_ndofs = size(row_dof_table, 1)
+    col_ndofs = size(col_dof_table, 1)
+    @boundscheck check_matrix_entry_size(value, row_ndofs, col_ndofs)
+    @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
+        matrix[row_dof_table[a,row_node], col_dof_table[b,col_node]] += matrix_entry_value(value, a, b, row_ndofs, col_ndofs)
+    end
+    matrix
+end
+
+function support_dofs(table_i, nodes_i, table_j, nodes_j)
+    @_propagate_inbounds_meta
+    if size(table_i, 1) == size(table_j, 1) && nodes_i === nodes_j
+        dofs = vec(table_i[:, nodes_i])
+        return dofs, dofs
+    else
+        return vec(table_i[:, nodes_i]), vec(table_j[:, nodes_j])
+    end
+end
+
 function matrix_assembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
     GenericMatrixAssembler(matrix, row_dof_table, col_dof_table)
 end
-matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis) = CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
+function matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
+    CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
+end
+
+function matrix_dof_tables(gmat, row_grid, col_grid)
+    row_table = LinearIndices((size(gmat, 1) ÷ length(row_grid), size(row_grid)...))
+    col_table = LinearIndices((size(gmat, 2) ÷ length(col_grid), size(col_grid)...))
+    @assert size(gmat) == (length(row_table), length(col_table))
+    row_table, col_table
+end
+
+struct ParticleAssembly end
+struct CellAssembly end
+struct BlockAssembly{I <: CartesianIndices}
+    nodes_i::I
+    nodes_j::I
+    matrix_buffer_pool::BlockMatrixBufferPool
+end
+
+#-------------------
+# LocalMatrixBuffer
+#-------------------
+
+struct LocalMatrixBuffer{M <: Matrix, R <: LinearIndices, C <: LinearIndices}
+    matrix::M
+    row_dof_table::R
+    col_dof_table::C
+end
+
+@inline function local_matrix_buffer(cache, ::Type{T}, row_dof_table, row_nodes, col_dof_table, col_nodes) where {T}
+    row_dof_table = local_dof_table(row_dof_table, row_nodes)
+    col_dof_table = local_dof_table(col_dof_table, col_nodes)
+    dims = length(row_dof_table), length(col_dof_table)
+    matrix = get!(() -> Matrix{T}(undef, dims), cache, dims)
+    LocalMatrixBuffer(matrix, row_dof_table, col_dof_table)
+end
+
+function assemble_first!(assembler, buffer::LocalMatrixBuffer, orientation, row_node, col_node, I, J, value)
+    @_propagate_inbounds_meta
+    buffer.matrix[I,J] .= value
+    buffer
+end
+
+function assemble_add!(assembler, buffer::LocalMatrixBuffer, orientation, row_node, col_node, I, J, value)
+    @_propagate_inbounds_meta
+    @views buffer.matrix[I,J] .+= value
+    buffer
+end
+
+function finish_assembly!(assembler, buffer::LocalMatrixBuffer, orientation, row_nodes, col_nodes)
+    @_propagate_inbounds_meta
+    row_nodes, col_nodes = orientation((row_nodes, col_nodes))
+    add!(assembler, row_nodes, col_nodes, orient_matrix_entry(orientation, buffer.matrix))
+end
+
+function assemble_first!(assembler, ::Nothing, orientation, row_node, col_node, I, J, value)
+    @_propagate_inbounds_meta
+    row_node, col_node = orientation((row_node, col_node))
+    add_entry!(assembler, row_node, col_node, orient_matrix_entry(orientation, value))
+end
+
+function assemble_add!(assembler, ::Nothing, orientation, row_node, col_node, I, J, value)
+    @_propagate_inbounds_meta
+    row_node, col_node = orientation((row_node, col_node))
+    add_entry!(assembler, row_node, col_node, orient_matrix_entry(orientation, value))
+end
+
+finish_assembly!(assembler, ::Nothing, orientation, row_nodes, col_nodes) = assembler.matrix
+
+#-------------------
+# BlockMatrixBuffer
+#-------------------
+
+struct BlockMatrixBufferKey{T,N}
+    row_size::Dims{N}
+    col_size::Dims{N}
+    col_offset::CartesianIndex{N}
+    row_ndofs::Int
+    col_ndofs::Int
+    sparsity_radius::Int
+end
+
+struct BlockMatrixBuffer{T,N}
+    values::Vector{T}
+    node_colptr::Vector{Int}
+    key::BlockMatrixBufferKey{T,N}
+end
+
+function BlockMatrixBufferKey(assembler::CartesianSparseMatrixAssembler, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {N}
+    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
+    BlockMatrixBufferKey{eltype(matrix),N}(
+        size(row_nodes),
+        size(col_nodes),
+        first(col_nodes) - first(row_nodes),
+        size(row_dof_table, 1),
+        size(col_dof_table, 1),
+        sparsity_radius,
+    )
+end
+
+function BlockMatrixBuffer(key::BlockMatrixBufferKey{T,N}) where {T,N}
+    (; row_size, col_size, col_offset, row_ndofs, col_ndofs, sparsity_radius) = key
+    node_colptr = Vector{Int}(undef, prod(col_size) + 1)
+    slot = 1
+    for (col, col_node) in enumerate(CartesianIndices(col_size))
+        node_colptr[col] = slot
+        row_nodes = cartesian_neighbor_nodes(col_node + col_offset, row_size, sparsity_radius)
+        slot += row_ndofs * col_ndofs * length(row_nodes)
+    end
+    node_colptr[end] = slot
+    BlockMatrixBuffer(zeros(T, slot - 1), node_colptr, key)
+end
+
+function BlockMatrixBuffer(assembler::CartesianSparseMatrixAssembler, row_nodes::CartesianIndices, col_nodes::CartesianIndices)
+    BlockMatrixBuffer(BlockMatrixBufferKey(assembler, row_nodes, col_nodes))
+end
+
+function acquire!(pool::BlockMatrixBufferPool, key::BlockMatrixBufferKey{T,N}) where {T,N}
+    lock(pool.lock)
+    buffer = try
+        buffers = get!(Vector{Any}, pool.buffers, key)
+        isempty(buffers) ? nothing : pop!(buffers)
+    finally
+        unlock(pool.lock)
+    end
+    buffer === nothing && return BlockMatrixBuffer(key)
+    buffer = buffer::BlockMatrixBuffer{T,N}
+    fillzero!(buffer.values)
+    buffer
+end
+
+function release!(pool::BlockMatrixBufferPool, buffer::BlockMatrixBuffer)
+    lock(pool.lock)
+    try
+        push!(get!(Vector{Any}, pool.buffers, buffer.key), buffer)
+    finally
+        unlock(pool.lock)
+    end
+    nothing
+end
+
+# Canonical Cartesian CSC matrices use a block buffer. Matrices using
+# GenericMatrixAssembler are written directly within the thread-safe block schedule.
+function block_matrix_buffer(assembler::CartesianSparseMatrixAssembler, assembly::BlockAssembly, orientation)
+    row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
+    acquire!(assembly.matrix_buffer_pool, BlockMatrixBufferKey(assembler, row_nodes, col_nodes))
+end
+
+block_matrix_buffer(::GenericMatrixAssembler, ::BlockAssembly, orientation) = nothing
+
+function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, row_node::CartesianIndex{N}, col_node::CartesianIndex{N}, value) where {T,N}
+    @_propagate_inbounds_meta
+    @boundscheck check_block_matrix_entry(buffer, row_nodes, col_nodes, row_node, col_node, value)
+
+    (; values, node_colptr, key) = buffer
+    (; row_size, col_size, col_offset, row_ndofs, col_ndofs, sparsity_radius) = key
+
+    local_row_node = row_node - first(row_nodes) + oneunit(row_node)
+    local_col_node = col_node - first(col_nodes) + oneunit(col_node)
+    neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
+    neighboring_row = local_row_node - first(neighboring_rows) + oneunit(local_row_node)
+    local_row = LinearIndices(neighboring_rows)[neighboring_row]
+    local_col = LinearIndices(col_size)[local_col_node]
+
+    for b in 1:col_ndofs
+        slot = node_colptr[local_col] + ((b - 1) * length(neighboring_rows) + local_row - 1) * row_ndofs
+        for a in 1:row_ndofs
+            values[slot] += matrix_entry_value(value, a, b, row_ndofs, col_ndofs)
+            slot += 1
+        end
+    end
+
+    buffer
+end
+
+@noinline function check_block_matrix_entry(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, row_node::CartesianIndex{N}, col_node::CartesianIndex{N}, value) where {T,N}
+    (; key) = buffer
+    (; row_size, col_size, col_offset, row_ndofs, col_ndofs, sparsity_radius) = key
+    size(row_nodes) == row_size || throw(DimensionMismatch("row support size does not match block matrix buffer"))
+    size(col_nodes) == col_size || throw(DimensionMismatch("column support size does not match block matrix buffer"))
+    first(col_nodes) - first(row_nodes) == col_offset || throw(DimensionMismatch("support offset does not match block matrix buffer"))
+    row_node ∈ row_nodes || throw(BoundsError(row_nodes, row_node))
+    col_node ∈ col_nodes || throw(BoundsError(col_nodes, col_node))
+    check_matrix_entry_size(value, row_ndofs, col_ndofs)
+    local_row_node = row_node - first(row_nodes) + oneunit(row_node)
+    local_col_node = col_node - first(col_nodes) + oneunit(col_node)
+    neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
+    local_row_node ∈ neighboring_rows || throw(ArgumentError("matrix entry is outside the block sparsity pattern"))
+    nothing
+end
+
+function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {T,N}
+    @_propagate_inbounds_meta
+    @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
+
+    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
+    (; values, node_colptr, key) = buffer
+    (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
+
+    mesh_size = Base.tail(size(row_dof_table))
+    matrix_values = nonzeros(matrix)
+    first_row_node = first(row_nodes)
+    first_col_node = first(col_nodes)
+    for (local_col, local_col_node) in enumerate(CartesianIndices(col_size))
+        col_node = local_col_node + first_col_node - oneunit(first_col_node)
+        neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
+        matrix_neighboring_rows = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
+        for b in 1:col_ndofs
+            col = col_dof_table[b,col_node]
+            matrix_col_start = first(nzrange(matrix, col))
+            local_slot = node_colptr[local_col] + (b - 1) * length(neighboring_rows) * row_ndofs
+            for local_row_node in neighboring_rows
+                row_node = local_row_node + first_row_node - oneunit(first_row_node)
+                matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
+                matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * row_ndofs
+                for _ in 1:row_ndofs
+                    matrix_values[matrix_slot] += values[local_slot]
+                    matrix_slot += 1
+                    local_slot += 1
+                end
+            end
+        end
+    end
+
+    matrix
+end
+
+@noinline function check_block_matrix_scatter(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, row_nodes::CartesianIndices, col_nodes::CartesianIndices)
+    (; row_dof_table, col_dof_table, sparsity_radius) = assembler
+    (; key) = buffer
+    (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
+    mesh_size = Base.tail(size(row_dof_table))
+    size(row_nodes) == row_size || throw(DimensionMismatch("row support size does not match block matrix buffer"))
+    size(col_nodes) == col_size || throw(DimensionMismatch("column support size does not match block matrix buffer"))
+    first(col_nodes) - first(row_nodes) == col_offset || throw(DimensionMismatch("support offset does not match block matrix buffer"))
+    Base.tail(size(col_dof_table)) == mesh_size || throw(DimensionMismatch("row and column DoF tables must have the same mesh size"))
+    size(row_dof_table, 1) == row_ndofs || throw(DimensionMismatch("row DoF count does not match block matrix buffer"))
+    size(col_dof_table, 1) == col_ndofs || throw(DimensionMismatch("column DoF count does not match block matrix buffer"))
+    sparsity_radius == key.sparsity_radius || throw(DimensionMismatch("sparsity radius does not match block matrix buffer"))
+    mesh_nodes = CartesianIndices(mesh_size)
+    checkbounds(mesh_nodes, row_nodes)
+    checkbounds(mesh_nodes, col_nodes)
+    nothing
+end
+
+# --- helpers ---
+
+function local_dof_table(dof_table, nodes)
+    @_propagate_inbounds_meta
+    LinearIndices((size(dof_table, 1), size(nodes)...))
+end
+
+function local_dofs(local_table, ip)
+    @_propagate_inbounds_meta
+    vec(view(local_table, :, ip))
+end
+
+matrix_row_dofs(buffer::LocalMatrixBuffer, ip) = (@_propagate_inbounds_meta; local_dofs(buffer.row_dof_table, ip))
+matrix_col_dofs(buffer::LocalMatrixBuffer, jp) = (@_propagate_inbounds_meta; local_dofs(buffer.col_dof_table, jp))
+matrix_row_dofs(::Nothing, ip) = nothing
+matrix_col_dofs(::Nothing, jp) = nothing
+
+orient_matrix_entry(::typeof(identity), value) = value
+orient_matrix_entry(::typeof(reverse), value) = value'
+
+#------------
+# P2G_Matrix
+#------------
 
 function P2G_Matrix(f, device::CPUDevice, schedule::Val, grids, particles, weights, partition)
-    P2G((grids, particles, weights, p) -> (@inline f(grids, particles, weights, (p,))), device, schedule, grids, particles, weights, partition)
+    P2G((grids, particles, weights, p) -> (@inline f(grids, particles, weights, (p,), ParticleAssembly())), device, schedule, grids, particles, weights, partition)
+end
+
+function P2G_Matrix(f, ::CPUDevice, ::Val{scheduler}, grids, particles, weights, partition::ThreadPartition{<:BlockStrategy}) where {scheduler}
+    matrix_buffer_pool = strategy(partition).matrix_buffer_pool
+    for group in threadsafe_groups(partition)
+        tforeach(group, scheduler) do block
+            block_particle_indices = particle_indices(partition, particles, block)
+            nodes_i = matrix_block_supportnodes(weights[1], block_particle_indices, grids[1])
+            nodes_j = grids[1] === grids[2] && weights[1] === weights[2] ? nodes_i : matrix_block_supportnodes(weights[2], block_particle_indices, grids[2])
+            @inline f(grids, particles, weights, block_particle_indices, BlockAssembly(nodes_i, nodes_j, matrix_buffer_pool))
+        end
+    end
 end
 
 function P2G_Matrix(f, ::CPUDevice, ::Val{scheduler}, grids, particles::QuadraturePoints,
@@ -427,7 +747,7 @@ function P2G_Matrix(f, ::CPUDevice, ::Val{scheduler}, grids, particles::Quadratu
 
     for cell in axes(particles, 2)
         particle_indices = (CartesianIndex(q, cell) for q in axes(particles, 1))
-        @inline f(grids, particles, weights, particle_indices)
+        @inline f(grids, particles, weights, particle_indices, CellAssembly())
     end
 end
 
@@ -436,7 +756,7 @@ function P2G_Matrix(f, ::CPUDevice, ::Val{scheduler}, grids, particles::Quadratu
                     partition::ThreadPartition{<:CellStrategy}) where {scheduler}
     for group in threadsafe_groups(partition)
         tforeach(group, scheduler) do cell
-            @inline f(grids, particles, weights, particle_indices(partition, particles, cell))
+            @inline f(grids, particles, weights, particle_indices(partition, particles, cell), CellAssembly())
         end
     end
 end
@@ -476,7 +796,7 @@ function P2G_Matrix_expr(schedule, grid_ij, particles_p, weights_ipjp, partition
 end
 
 function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particles,p), ((weights_i,weights_j),(ip,jp)), partition, program::TransferProgram)
-    @gensym grid_i′ grid_j′ weights_i′ weights_j′ bw_i bw_j gridindices_i gridindices_j particle_indices remaining_particles
+    @gensym grid_i′ grid_j′ weights_i′ weights_j′ bw_i bw_j gridindices_i gridindices_j particle_indices matrix_assembly remaining_particles
 
     equations = program.equations
     isempty(equations) && error("@P2G_Matrix: at least one equation is required")
@@ -493,21 +813,19 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     gmats = Any[]
     assemblers_init = Any[]
     hoist_exprs = Any[]
-    lmat_init = Any[]
+    buffers_init = Any[]
     local_jdofs = Any[]
     local_idofs = Any[]
-    lmat_assign = Any[]
-    lmat_add = Any[]
-    lmat2gmat = Any[]
+    assemble_first = Any[]
+    assemble_add = Any[]
+    finish_assemblies = Any[]
     for equation in equations
         (; lhs, rhs, op) = equation
         @capture(lhs, gmat_[gi_,gj_]) || error("@P2G_Matrix: Invalid global matrix expression, got `$lhs`")
         ((gi == i && gj == j) || (gi == j && gj == i)) || error("@P2G_Matrix: Expected expression of the form `$gmat[$i, $j]` or `$gmat[$j, $i]`, got `$lhs`")
         gmat in gmats && error("@P2G_Matrix: each global matrix may appear only once in a block; combine terms for `$gmat` into one `@∑` expression")
 
-        lmat = gensym(gmat)
-        ldofs_i = gensym(Symbol(gmat, :ldofs_i))
-        ldofs_j = gensym(Symbol(gmat, :ldofs_j))
+        buffer = gensym(Symbol(gmat, :buffer))
         assembler = gensym(Symbol(gmat, :assembler))
         I = gensym(Symbol(gmat, :I))
         J = gensym(Symbol(gmat, :J))
@@ -515,27 +833,28 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         op == :(=)  && push!(fillzeros, :(Tesserae.fillzero!($gmat)))
         op == :(-=) && (rhs = :(-$rhs))
         rhs = hoist_p2g_rhs!(hoist_exprs, inner_symbols, rhs)
-        lmat_dims = Symbol(lmat, :dims)
         push!(gmats, gmat)
         forward = gi == i && gj == j
         reorder_pair = forward ? identity : reverse
+        orientation = forward ? :(Base.identity) : :(Base.reverse)
         row_grid, col_grid = reorder_pair((grid_i, grid_j))
         row_weights, col_weights = reorder_pair((weights_i, weights_j))
         dof_table_i, dof_table_j = reorder_pair((:($(assembler).row_dof_table), :($(assembler).col_dof_table)))
-        row_nodes, col_nodes = reorder_pair((gridindices_i, gridindices_j))
-        scatter_lmat = forward ? lmat : :($lmat')
-        push!(lmat_init, quote
-            $ldofs_i = Tesserae.local_dof_table($dof_table_i, $gridindices_i)
-            $ldofs_j = Tesserae.local_dof_table($dof_table_j, $gridindices_j)
-            $lmat_dims = length($ldofs_i), length($ldofs_j)
-            $lmat = get!(()->Array{eltype($gmat)}(undef, $lmat_dims), $(Symbol(gmat,:dict))[], $lmat_dims)
+        push!(buffers_init, quote
+            if $matrix_assembly isa Tesserae.ParticleAssembly
+                $buffer = nothing
+            elseif $matrix_assembly isa Tesserae.CellAssembly
+                $buffer = Tesserae.local_matrix_buffer($(Symbol(gmat,:dict))[], eltype($gmat), $dof_table_i, $gridindices_i, $dof_table_j, $gridindices_j)
+            else
+                error("BlockAssembly must use block assembly")
+            end
         end)
-        push!(local_jdofs, :($J = Tesserae.local_dofs($ldofs_j, $jp)))
-        push!(local_idofs, :($I = Tesserae.local_dofs($ldofs_i, $ip)))
-        push!(lmat_assign, :(@inbounds $lmat[$I,$J] .= $rhs))
-        push!(lmat_add, :(@inbounds @views $lmat[$I,$J] .+= $rhs))
+        push!(local_jdofs, :($J = Tesserae.matrix_col_dofs($buffer, $jp)))
+        push!(local_idofs, :($I = Tesserae.matrix_row_dofs($buffer, $ip)))
+        push!(assemble_first, :(Tesserae.assemble_first!($assembler, $buffer, $orientation, $i, $j, $I, $J, $rhs)))
+        push!(assemble_add, :(Tesserae.assemble_add!($assembler, $buffer, $orientation, $i, $j, $I, $J, $rhs)))
         push!(assemblers_init, :($assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($row_grid), Tesserae.get_mesh($col_grid), Tesserae.basis($row_weights), Tesserae.basis($col_weights))))
-        push!(lmat2gmat, :(Tesserae.add!($assembler, $row_nodes, $col_nodes, $scatter_lmat)))
+        push!(finish_assemblies, :(Tesserae.finish_assembly!($assembler, $buffer, $orientation, $gridindices_i, $gridindices_j)))
     end
 
     supportnodes_expr = if grid_i == grid_j && weights_i == weights_j
@@ -550,7 +869,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         $bw_i, $bw_j = $weights_i′[$p], $weights_j′[$p]
     end
 
-    function assemble_particle(lmat_asm)
+    function assemble_particle(assembly)
         quote
             for $jp in eachindex($gridindices_j)
                 $j = $gridindices_j[$jp]
@@ -560,7 +879,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
                     $i = $gridindices_i[$ip]
                     $(cached_replacements(scope, 1, 4)...)
                     $(local_idofs...)
-                    $(lmat_asm...)
+                    $(assembly...)
                 end
             end
         end
@@ -570,13 +889,13 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         $p, $remaining_particles = Base.Iterators.peel($particle_indices)
         $particle_init
         $supportnodes_expr
-        $(lmat_init...)
-        $(assemble_particle(lmat_assign))
+        $(buffers_init...)
+        $(assemble_particle(assemble_first))
         for $p in $remaining_particles
             $particle_init
-            $(assemble_particle(lmat_add))
+            $(assemble_particle(assemble_add))
         end
-        $(lmat2gmat...)
+        $(finish_assemblies...)
     end
 
     if !DEBUG
@@ -601,7 +920,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
             $check_arguments_for_P2G_Matrix($grid_j, $particles, $weights_j, $partition)
             $(fillzeros...)
             $(assemblers_init...)
-            Tesserae.P2G_Matrix((($grid_i′,$grid_j′), $particles, ($weights_i′,$weights_j′), $particle_indices) -> $body,
+            Tesserae.P2G_Matrix((($grid_i′,$grid_j′), $particles, ($weights_i′,$weights_j′), $particle_indices, $matrix_assembly) -> $body,
                                 $get_device($grid_i), Val($schedule), ($grid_i,$grid_j), $particles, ($weights_i,$weights_j), $partition)
         end
     end
@@ -631,31 +950,20 @@ end
     nodes_i, nodes_j
 end
 
-function matrix_dof_tables(gmat, row_grid, col_grid)
-    row_table = LinearIndices((size(gmat, 1) ÷ length(row_grid), size(row_grid)...))
-    col_table = LinearIndices((size(gmat, 2) ÷ length(col_grid), size(col_grid)...))
-    @assert size(gmat) == (length(row_table), length(col_table))
-    row_table, col_table
-end
-
-@inline function local_dof_table(dof_table, nodes)
+function matrix_block_supportnodes(weights, particle_indices, grid)
     @_propagate_inbounds_meta
-    LinearIndices((size(dof_table, 1), size(nodes)...))
-end
-
-@inline function local_dofs(local_table, ip)
-    @_propagate_inbounds_meta
-    vec(view(local_table, :, ip))
-end
-
-@inline function support_dofs(table_i, nodes_i, table_j, nodes_j)
-    @_propagate_inbounds_meta
-    if size(table_i, 1) == size(table_j, 1) && nodes_i === nodes_j
-        dofs = vec(table_i[:, nodes_i])
-        return dofs, dofs
-    else
-        return vec(table_i[:, nodes_i]), vec(table_j[:, nodes_j])
+    p, remaining_particles = Iterators.peel(particle_indices)
+    nodes = supportnodes(weights[p])
+    first_node = first(nodes)
+    last_node = last(nodes)
+    for p in remaining_particles
+        nodes = supportnodes(weights[p])
+        first_node = CartesianIndex(map(min, Tuple(first_node), Tuple(first(nodes))))
+        last_node = CartesianIndex(map(max, Tuple(last_node), Tuple(last(nodes))))
     end
+    nodes = first_node:last_node
+    @boundscheck checkbounds(get_mesh(grid), nodes)
+    nodes
 end
 
 function unpair2(ex::Expr)

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -5,6 +5,7 @@ abstract type Shape{dim} end
 localnodes(s::Shape) = localnodes(Float64, s)
 
 nlocalnodes(s::Shape) = length(localnodes(s))
+nsupportnodes(s::Shape) = nlocalnodes(s)
 
 get_dimension(::Shape{dim}) where {dim} = dim
 

--- a/src/thread_partition.jl
+++ b/src/thread_partition.jl
@@ -34,6 +34,12 @@ function BlockUpdateWorkspace(blkdims::Dims{dim}) where {dim}
     )
 end
 
+struct BlockMatrixBufferPool
+    lock::ReentrantLock
+    buffers::Dict{Any, Vector{Any}}
+end
+BlockMatrixBufferPool() = BlockMatrixBufferPool(ReentrantLock(), Dict{Any, Vector{Any}}())
+
 struct BlockStrategy{dim, Mesh <: CartesianMesh{dim}} <: PartitionStrategy
     mesh::Mesh
     particleindices::Vector{Int}
@@ -43,6 +49,7 @@ struct BlockStrategy{dim, Mesh <: CartesianMesh{dim}} <: PartitionStrategy
     activegroups::Vector{Vector{CartesianIndex{dim}}}
     blockcolors::Array{Int, dim}
     update_workspace::BlockUpdateWorkspace{dim}
+    matrix_buffer_pool::BlockMatrixBufferPool
 end
 
 function BlockStrategy(mesh::CartesianMesh{dim}) where {dim}
@@ -64,6 +71,7 @@ function BlockStrategy(mesh::CartesianMesh{dim}) where {dim}
         activegroups,
         blockcolors,
         BlockUpdateWorkspace(blkdims),
+        BlockMatrixBufferPool(),
     )
 end
 

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -46,7 +46,7 @@ function cached_replacements(scope::TransferScope, indices...)
     exprs = Expr[]
     for index in indices
         haskey(scope.replacements, index) || error("index `$index` is not bound in this transfer scope")
-        append_unique_exprs!(exprs, scope.replacements[index])
+        union!(exprs, scope.replacements[index])
     end
     exprs
 end
@@ -67,13 +67,6 @@ end
 function push_unique!(xs::Vector, x)
     x in xs || push!(xs, x)
     xs
-end
-
-function append_unique_exprs!(dst::Vector{Expr}, src::Vector{Expr})
-    for x in src
-        push_unique!(dst, x)
-    end
-    dst
 end
 
 """

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -64,21 +64,16 @@ function resolve_sum_equations(equations::Vector{TransferEquation}, scope::Trans
     end
 end
 
-function push_unique_expr!(xs::Vector{Expr}, x::Expr)
+function push_unique!(xs::Vector, x)
     x in xs || push!(xs, x)
     xs
 end
 
 function append_unique_exprs!(dst::Vector{Expr}, src::Vector{Expr})
     for x in src
-        push_unique_expr!(dst, x)
+        push_unique!(dst, x)
     end
     dst
-end
-
-function push_unique!(xs::Vector, x)
-    x in xs || push!(xs, x)
-    xs
 end
 
 """
@@ -861,7 +856,7 @@ function resolve_refs(expr, scope::TransferScope)
             resolved = :($parent.$x[$i])
             scope.replacements === nothing && return resolved
             sym = Symbol(resolved)
-            push_unique_expr!(scope.replacements[i], :($sym = $resolved))
+            push_unique!(scope.replacements[i], :($sym = $resolved))
             return sym
         end
         ex

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -23,29 +23,32 @@ function split_sum_equations(program::TransferProgram, macroname::String)
     equations[issum], equations[.!issum]
 end
 
-struct TransferBinding
-    parent::Symbol
-    index::Any
-end
-
 struct TransferScope
-    bindings::Vector{TransferBinding}
-    replacements::Union{Nothing, Vector{Vector{Expr}}}
+    bindings::Dict{Any,Symbol}
+    replacements::Union{Nothing,Dict{Any,Vector{Expr}}}
 end
 
 function TransferScope(maps::Vector{<: Pair}; cache::Bool=false)
-    bindings = map(maps) do map
-        TransferBinding(map.first, map.second)
+    bindings = Dict{Any,Symbol}()
+    for map in maps
+        parent, index = map
+        haskey(bindings, index) && error("transfer index `$index` is bound more than once")
+        bindings[index] = parent
     end
-    replacements = cache ? replacement_groups(length(bindings)) : nothing
+    replacements = cache ? Dict{Any,Vector{Expr}}(index => Expr[] for index in keys(bindings)) : nothing
     TransferScope(bindings, replacements)
 end
 
 uncached(scope::TransferScope) = TransferScope(scope.bindings, nothing)
 
-function cached_replacements(scope::TransferScope, groups::Integer...)
+function cached_replacements(scope::TransferScope, indices...)
     scope.replacements === nothing && error("reference cache is not enabled for this transfer scope")
-    replacements(scope.replacements, groups...)
+    exprs = Expr[]
+    for index in indices
+        haskey(scope.replacements, index) || error("index `$index` is not bound in this transfer scope")
+        append_unique_exprs!(exprs, scope.replacements[index])
+    end
+    exprs
 end
 
 function resolve_equation(eq::TransferEquation, scope::TransferScope)
@@ -61,8 +64,6 @@ function resolve_sum_equations(equations::Vector{TransferEquation}, scope::Trans
     end
 end
 
-replacement_groups(n::Integer) = [Expr[] for _ in 1:n]
-
 function push_unique_expr!(xs::Vector{Expr}, x::Expr)
     x in xs || push!(xs, x)
     xs
@@ -73,14 +74,6 @@ function append_unique_exprs!(dst::Vector{Expr}, src::Vector{Expr})
         push_unique_expr!(dst, x)
     end
     dst
-end
-
-function replacements(replaced::Vector{Vector{Expr}}, groups::Integer...)
-    exprs = Expr[]
-    for group in groups
-        append_unique_exprs!(exprs, replaced[group])
-    end
-    exprs
 end
 
 function push_unique!(xs::Vector, x)
@@ -205,8 +198,9 @@ function P2G_sum_expr((grid,i), (particles,p), (weights,ip), sum_equations::Vect
 
     scope = TransferScope([grid=>i, particles=>p, bw=>ip]; cache=true)
     sum_equations = resolve_sum_equations(sum_equations, scope, "@P2G", i)
-    replaced = scope.replacements
-    inner_symbols = p2g_cached_symbols(replaced, 1, 3)
+    particle_replacements = cached_replacements(scope, p)
+    inner_replacements = cached_replacements(scope, i, ip)
+    inner_symbols = p2g_cached_symbols(inner_replacements)
 
     fillzeros = Any[]
     hoist_exprs = Any[]
@@ -220,14 +214,14 @@ function P2G_sum_expr((grid,i), (particles,p), (weights,ip), sum_equations::Vect
     end
 
     body = quote
-        $(replaced[2]...)
+        $(particle_replacements...)
         $(hoist_exprs...)
         $bw = $weights[$p]
         $gridindices = supportnodes($bw, $grid)
         for $ip in eachindex($gridindices)
             $i = $gridindices[$ip]
             $gridwriteindex = Tesserae.p2g_write_index($grid, $i)
-            $(cached_replacements(scope, 1, 3)...)
+            $(inner_replacements...)
             $(sum_exprs...)
         end
     end
@@ -235,9 +229,9 @@ function P2G_sum_expr((grid,i), (particles,p), (weights,ip), sum_equations::Vect
     Expr(:block, fillzeros...), body
 end
 
-function p2g_cached_symbols(replaced::Vector{Vector{Expr}}, groups::Integer...)
+function p2g_cached_symbols(replacements)
     symbols = Set{Symbol}()
-    for ex in Iterators.flatten(replaced[group] for group in groups)
+    for ex in replacements
         Meta.isexpr(ex, :(=), 2) && ex.args[1] isa Symbol && push!(symbols, ex.args[1])
     end
     symbols
@@ -580,7 +574,8 @@ function G2P_sum_expr((grid,i), (particles,p), (weights,ip), sum_equations::Vect
 
     if !isempty(sum_equations)
         sum_equations = resolve_sum_equations(sum_equations, scope, "@G2P", p)
-        replaced = scope.replacements
+        particle_replacements = cached_replacements(scope, p)
+        inner_replacements = cached_replacements(scope, i, ip)
 
         inits = []
         saves = []
@@ -594,13 +589,13 @@ function G2P_sum_expr((grid,i), (particles,p), (weights,ip), sum_equations::Vect
         end
 
         code = quote
-            $(replaced[2]...)
+            $(particle_replacements...)
             $(inits...)
             $bw = $weights[$p]
             $gridindices = supportnodes($bw, $grid)
             for $ip in eachindex($gridindices)
                 $i = $gridindices[$ip]
-                $(cached_replacements(scope, 1, 3)...)
+                $(inner_replacements...)
                 $(sum_exprs...)
             end
             $(saves...)
@@ -861,17 +856,13 @@ end
 
 function resolve_refs(expr, scope::TransferScope)
     MacroTools.postwalk(expr) do ex
-        if @capture(ex, x_[i_])
-            for (k, binding) in enumerate(scope.bindings)
-                if i == binding.index
-                    parent = binding.parent
-                    resolved = :($parent.$x[$i])
-                    scope.replacements === nothing && return resolved
-                    sym = Symbol(resolved)
-                    push_unique_expr!(scope.replacements[k], :($sym = $resolved))
-                    return sym
-                end
-            end
+        if @capture(ex, x_[i_]) && haskey(scope.bindings, i)
+            parent = scope.bindings[i]
+            resolved = :($parent.$x[$i])
+            scope.replacements === nothing && return resolved
+            sym = Symbol(resolved)
+            push_unique_expr!(scope.replacements[i], :($sym = $resolved))
+            return sym
         end
         ex
     end

--- a/test/explain.jl
+++ b/test/explain.jl
@@ -632,8 +632,7 @@
         shown = sprint(show, MIME("text/plain"), ex)
         @test occursin("Tesserae.matrix_dof_tables(A, grid, grid)", shown)
         @test occursin("Tesserae.matrix_supportnodes(bw_i, grid)", shown)
-        @test occursin("Tesserae.local_dof_table(A_table_i, nodes_i)", shown)
-        @test occursin("Tesserae.local_dofs(A_local_i, ip)", shown)
+        @test occursin("Tesserae.local_dofs(size(A_table_i, 1), local_ip)", shown)
         @test occursin("Tesserae.support_dofs(A_table_i, nodes_i, A_table_j, nodes_j)", shown)
         @test occursin("A[A_dofs_i, A_dofs_j] .+= A_local", shown)
         @test occursin("A_local[A_i, A_j] .= ", shown)
@@ -644,7 +643,7 @@
         @test !occursin("LinearIndices", shown)
         @test !occursin("vec(view", shown)
         @test !occursin(r"(?m)^begin\b", shown)
-        @test occursin("for ip in eachindex(nodes_i)", shown)
+        @test occursin("for (local_ip, ip) in enumerate(eachindex(nodes_i))", shown)
         @test !occursin("for ip =", shown)
         @test occursin("Threads.@threads :dynamic for region in group", sprint(show, MIME("text/plain"), ex_threaded))
 
@@ -881,15 +880,13 @@ for p in eachindex(particles)
     bw_i = weights[p]
     bw_j = bw_i
     (nodes_i, nodes_j) = Tesserae.matrix_supportnodes(bw_i, grid)
-    A_local_i = Tesserae.local_dof_table(A_table_i, nodes_i)
-    A_local_j = Tesserae.local_dof_table(A_table_j, nodes_j)
-    A_local = zeros(eltype(A), (length(A_local_i), length(A_local_j)))
-    for jp in eachindex(nodes_j)
+    A_local = zeros(eltype(A), (size(A_table_i, 1) * length(nodes_i), size(A_table_j, 1) * length(nodes_j)))
+    for (local_jp, jp) in enumerate(eachindex(nodes_j))
         j = nodes_j[jp]
-        A_j = Tesserae.local_dofs(A_local_j, jp)
-        for ip in eachindex(nodes_i)
+        A_j = Tesserae.local_dofs(size(A_table_j, 1), local_jp)
+        for (local_ip, ip) in enumerate(eachindex(nodes_i))
             i = nodes_i[ip]
-            A_i = Tesserae.local_dofs(A_local_i, ip)
+            A_i = Tesserae.local_dofs(size(A_table_i, 1), local_ip)
             A_local[A_i, A_j] .= begin
                 K = bw_i.∇w[ip] ⊗ bw_j.∇w[jp]
                 K
@@ -913,15 +910,13 @@ for p in eachindex(particles)
     bw_i = weights_u[p]
     bw_j = weights_p[p]
     (nodes_i, nodes_j) = Tesserae.matrix_supportnodes(bw_i, grid_u, bw_j, grid_p)
-    A_local_i = Tesserae.local_dof_table(A_table_i, nodes_i)
-    A_local_j = Tesserae.local_dof_table(A_table_j, nodes_j)
-    A_local = zeros(eltype(A), (length(A_local_i), length(A_local_j)))
-    for jp in eachindex(nodes_j)
+    A_local = zeros(eltype(A), (size(A_table_i, 1) * length(nodes_i), size(A_table_j, 1) * length(nodes_j)))
+    for (local_jp, jp) in enumerate(eachindex(nodes_j))
         j = nodes_j[jp]
-        A_j = Tesserae.local_dofs(A_local_j, jp)
-        for ip in eachindex(nodes_i)
+        A_j = Tesserae.local_dofs(size(A_table_j, 1), local_jp)
+        for (local_ip, ip) in enumerate(eachindex(nodes_i))
             i = nodes_i[ip]
-            A_i = Tesserae.local_dofs(A_local_i, ip)
+            A_i = Tesserae.local_dofs(size(A_table_i, 1), local_ip)
             A_local[A_i, A_j] .= bw_i.∇N[ip] * bw_j.N[jp]
         end
     end

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -218,12 +218,10 @@
         @test Tesserae.matrix_block_supportnodes(weights, particle_indices, grid) ==
               first_node:last_node
 
-        local_i = Tesserae.local_dof_table(table_i, nodes_i)
-        local_j = Tesserae.local_dof_table(table_j, nodes_j)
-        ip = first(eachindex(nodes_i))
-        jp = first(eachindex(nodes_j))
-        @test Tesserae.local_dofs(local_i, ip) == vec(view(local_i, :, ip))
-        @test Tesserae.local_dofs(local_j, jp) == vec(view(local_j, :, jp))
+        ip = length(nodes_i)
+        jp = length(nodes_j)
+        @test Tesserae.local_dofs(2, ip) == (2ip-1):2ip
+        @test Tesserae.local_dofs(1, jp) == jp:jp
 
         dofs_i, dofs_j = Tesserae.support_dofs(table_i, nodes_i, table_j, nodes_j)
         @test dofs_i == vec(table_i[:, nodes_i])
@@ -393,6 +391,7 @@ end
     @test_throws UndefKeywordError create_sparse_matrix(quad4)
 
     A = create_sparse_matrix((quad9, quad4); ndofs=(2, 1))
+    B = create_sparse_matrix((quad4, quad9); ndofs=(1, 2))
     @test size(A) == (30, 6)
     @test Tesserae.SparseArrays.nnz(A) == 132
 
@@ -410,8 +409,10 @@ end
 
     @P2G_Matrix (velocity_grid,pressure_grid)=>(i,j) points=>p (velocity_weights,pressure_weights)=>(ip,jp) begin
         A[i,j] = @∑ ∇N[ip] * N[jp] * V[p]
+        B[j,i] = @∑ ∇N[ip] * N[jp] * V[p]
     end
     @test any(!iszero, Tesserae.SparseArrays.nonzeros(A))
+    @test B ≈ A'
 
     shifted = FEMesh(Tesserae.Quad4(), CartesianMesh(1, (2,4), (0,1)))
     @test_throws ArgumentError create_sparse_matrix((quad9, shifted); ndofs=(2, 1))

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -244,7 +244,7 @@
             col_dofs = LinearIndices((3, dims...))
 
             assembler = Tesserae.matrix_assembler(direct, scatter_mesh, scatter_mesh, basis, basis)
-            buffer = Tesserae.BlockMatrixBuffer(assembler, nodes, nodes)
+            buffer = Tesserae.BlockMatrixBuffer(Tesserae.BlockMatrixBufferKey(assembler, nodes, nodes))
             @test buffer.key.row_size == size(nodes)
             @test buffer.key.col_size == size(nodes)
             @test iszero(buffer.key.col_offset)

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -248,8 +248,7 @@
             @test buffer.key.row_size == size(nodes)
             @test buffer.key.col_size == size(nodes)
             @test iszero(buffer.key.col_offset)
-            @test length(buffer.node_colptr) == length(nodes) + 1
-            @test buffer.node_colptr[end] == length(buffer.values) + 1
+            @test length(buffer.node_colstarts) == length(nodes)
             pool = Tesserae.BlockMatrixBufferPool()
             fill!(buffer.values, 1)
             @test Tesserae.release!(pool, buffer) === nothing

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -270,6 +270,12 @@
             Tesserae.add!(merge, vec(row_dofs[:, nodes]), vec(col_dofs[:, nodes]), local_matrix)
             @test direct == merge
             @test block_matrix == merge
+
+            Tesserae.fillzero!(reused_buffer.values)
+            for col_node in nodes, row_node in nodes
+                Tesserae.add_entry!(reused_buffer, nodes, nodes, row_node, col_node, 1.0)
+            end
+            @test all(isone, reused_buffer.values)
         end
     end
 end

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -165,13 +165,19 @@
         A = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
         B = create_sparse_matrix(basis, mesh; ndofs=(1, 2))
 
+        table_i, table_j = Tesserae.matrix_dof_tables(A, grid, grid)
         assembler = @inferred Tesserae.matrix_assembler(A, mesh, mesh, basis, basis)
         @test assembler.matrix === A
-        @test Tesserae.matrix_assembler(Matrix(A), mesh, mesh, basis, basis) === nothing
+        @test assembler.row_dof_table == table_i
+        @test assembler.col_dof_table == table_j
+        dense = Matrix(A)
+        generic_assembler = @inferred Tesserae.matrix_assembler(dense, mesh, mesh, basis, basis)
+        @test generic_assembler.matrix === dense
+        @test generic_assembler.row_dof_table == table_i
+        @test generic_assembler.col_dof_table == table_j
         invalid = Tesserae.SparseArrays.dropzeros!(copy(A))
         @test_throws ArgumentError Tesserae.matrix_assembler(invalid, mesh, mesh, basis, basis)
 
-        table_i, table_j = Tesserae.matrix_dof_tables(A, grid, grid)
         @test size(table_i) == (2, size(grid)...)
         @test size(table_j) == (1, size(grid)...)
         @test size(A) == (length(table_i), length(table_j))

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -192,6 +192,13 @@
         @test nodes_i === nodes_j
         @test Tesserae.matrix_supportnodes(bw, grid, bw, grid) == (nodes_i, nodes_j)
 
+        particle_indices = firstindex(particles):(firstindex(particles) + 2)
+        particle_nodes = map(p -> supportnodes(weights[p]), particle_indices)
+        first_node = CartesianIndex(map(min, Tuple.(first.(particle_nodes))...))
+        last_node = CartesianIndex(map(max, Tuple.(last.(particle_nodes))...))
+        @test Tesserae.matrix_block_supportnodes(weights, particle_indices, grid) ==
+              first_node:last_node
+
         local_i = Tesserae.local_dof_table(table_i, nodes_i)
         local_j = Tesserae.local_dof_table(table_j, nodes_j)
         ip = first(eachindex(nodes_i))
@@ -218,9 +225,35 @@
             col_dofs = LinearIndices((3, dims...))
 
             assembler = Tesserae.matrix_assembler(direct, scatter_mesh, scatter_mesh, basis, basis)
-            Tesserae.add!(assembler, nodes, nodes, local_matrix)
+            buffer = Tesserae.BlockMatrixBuffer(assembler, nodes, nodes)
+            @test buffer.key.row_size == size(nodes)
+            @test buffer.key.col_size == size(nodes)
+            @test iszero(buffer.key.col_offset)
+            @test length(buffer.node_colptr) == length(nodes) + 1
+            @test buffer.node_colptr[end] == length(buffer.values) + 1
+            pool = Tesserae.BlockMatrixBufferPool()
+            fill!(buffer.values, 1)
+            @test Tesserae.release!(pool, buffer) === nothing
+            reused_buffer = Tesserae.acquire!(pool, buffer.key)
+            @test reused_buffer === buffer
+            @test all(iszero, reused_buffer.values)
+            for (jp, col_node) in enumerate(nodes), (ip, row_node) in enumerate(nodes)
+                I = (2ip-1):2ip
+                J = (3jp-2):3jp
+                Tesserae.add_entry!(reused_buffer, nodes, nodes, row_node, col_node, @view(local_matrix[I,J]))
+            end
+            @test sort(reused_buffer.values) == sort(vec(local_matrix))
+            block_matrix = copy(direct)
+            block_assembler = Tesserae.matrix_assembler(block_matrix, scatter_mesh, scatter_mesh, basis, basis)
+            @test Tesserae.scatter!(block_assembler, reused_buffer, nodes, nodes) === block_matrix
+            for (jp, col_node) in enumerate(nodes), (ip, row_node) in enumerate(nodes)
+                I = (2ip-1):2ip
+                J = (3jp-2):3jp
+                Tesserae.add_entry!(assembler, row_node, col_node, @view(local_matrix[I,J]))
+            end
             Tesserae.add!(merge, vec(row_dofs[:, nodes]), vec(col_dofs[:, nodes]), local_matrix)
             @test direct == merge
+            @test block_matrix == merge
         end
     end
 end

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -11,15 +11,16 @@
     @test_throws UndefKeywordError create_sparse_matrix(basis, mesh)
 
     @testset "square matrix" begin
-        A = create_sparse_matrix(basis, mesh; ndofs=1)
-        B = create_sparse_matrix(basis, mesh; ndofs=1)
+        entry = Mat{2,2}(1.0, 2.0, 2.0, 3.0)
+        A = create_sparse_matrix(basis, mesh; ndofs=2)
+        B = create_sparse_matrix(basis, mesh; ndofs=2)
         A_dense = zeros(size(A))
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
-            A[i,j] = @∑ w[ip] * sum(∇w[jp])
-            A_dense[i,j] = @∑ w[ip] * sum(∇w[jp])
+            A[i,j] = @∑ w[ip] * sum(∇w[jp]) * entry
+            A_dense[i,j] = @∑ w[ip] * sum(∇w[jp]) * entry
         end
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
-            B[j,i] = @∑ w[jp] * sum(∇w[ip])
+            B[j,i] = @∑ w[jp] * sum(∇w[ip]) * entry
         end
         @test !(A ≈ A')
         @test !(B ≈ B')
@@ -27,21 +28,22 @@
         @test A ≈ A_dense
     end
     @testset "multiple matrices" begin
-        A = create_sparse_matrix(basis, mesh; ndofs=1)
-        B = create_sparse_matrix(basis, mesh; ndofs=1)
-        Aref = create_sparse_matrix(basis, mesh; ndofs=1)
-        Bref = create_sparse_matrix(basis, mesh; ndofs=1)
+        entry = Mat{2,2}(1.0, 2.0, 2.0, 3.0)
+        A = create_sparse_matrix(basis, mesh; ndofs=2)
+        B = create_sparse_matrix(basis, mesh; ndofs=2)
+        Aref = create_sparse_matrix(basis, mesh; ndofs=2)
+        Bref = create_sparse_matrix(basis, mesh; ndofs=2)
 
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
-            A[i,j] = @∑ w[ip] * w[jp]
-            B[i,j] = @∑ sum(∇w[ip]) * sum(∇w[jp])
+            A[i,j] = @∑ w[ip] * w[jp] * entry
+            B[i,j] = @∑ sum(∇w[ip]) * sum(∇w[jp]) * entry
         end
 
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
-            Aref[i,j] = @∑ w[ip] * w[jp]
+            Aref[i,j] = @∑ w[ip] * w[jp] * entry
         end
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
-            Bref[i,j] = @∑ sum(∇w[ip]) * sum(∇w[jp])
+            Bref[i,j] = @∑ sum(∇w[ip]) * sum(∇w[jp]) * entry
         end
 
         @test A ≈ Aref
@@ -194,7 +196,6 @@
         @test generic_assembler.matrix === dense
         @test generic_assembler.row_dof_table == table_i
         @test generic_assembler.col_dof_table == table_j
-        @test_throws DimensionMismatch Tesserae.check_matrix_entry_size(1.0, 2, 1)
         invalid = Tesserae.SparseArrays.dropzeros!(copy(A))
         @test_throws ArgumentError Tesserae.matrix_assembler(invalid, mesh, mesh, basis, basis)
 
@@ -232,45 +233,65 @@
         scalar_dofs_i, scalar_dofs_j = Tesserae.support_dofs(scalar_table_i, nodes_i, scalar_table_j, nodes_j)
         @test scalar_dofs_i === scalar_dofs_j
     end
+    @testset "matrix entry sizes" begin
+        @test Tesserae.check_matrix_entry_size(1.0, 1, 1)
+        @test_throws DimensionMismatch Tesserae.check_matrix_entry_size(1.0, 2, 1)
+        @test Tesserae.check_matrix_entry_size(zeros(2), 2, 1)
+        @test Tesserae.check_matrix_entry_size(zeros(2), 1, 2)
+        @test_throws DimensionMismatch Tesserae.check_matrix_entry_size(zeros(2), 2, 2)
+        @test Tesserae.check_matrix_entry_size(zeros(2, 3), 2, 3)
+        @test_throws DimensionMismatch Tesserae.check_matrix_entry_size(zeros(2, 2), 2, 3)
+    end
+    @testset "Block matrix buffer pool" begin
+        scatter_mesh = CartesianMesh(1, (0, 4))
+        matrix = create_sparse_matrix(basis, scatter_mesh; ndofs=(2, 3))
+        assembler = Tesserae.matrix_assembler(matrix, scatter_mesh, scatter_mesh, basis, basis)
+        nodes = CartesianIndices((1:3,))
+        buffer = Tesserae.BlockMatrixBuffer(Tesserae.BlockMatrixBufferKey(assembler, nodes, nodes))
+        pool = Tesserae.BlockMatrixBufferPool()
+
+        fill!(buffer.values, 1)
+        @test Tesserae.release!(pool, buffer) === nothing
+        reused_buffer = Tesserae.acquire!(pool, buffer.key)
+        @test reused_buffer === buffer
+        @test all(iszero, reused_buffer.values)
+    end
     @testset "Cartesian sparse scatter" begin
         for dims in ((5,), (5, 6, 7))
             scatter_mesh = CartesianMesh(1, ((0, n - 1) for n in dims)...)
-            direct = create_sparse_matrix(basis, scatter_mesh; ndofs=(2, 3))
-            merge = copy(direct)
             nodes = CartesianIndices(ntuple(_ -> 1:3, length(dims)))
-            local_matrix = reshape(collect(1.0:6length(nodes)^2), 2length(nodes), 3length(nodes))
+            tail_ranges = ntuple(_ -> 1:3, length(dims) - 1)
+            shifted_row_nodes = CartesianIndices((1:2, tail_ranges...))
+            shifted_col_nodes = CartesianIndices((2:3, tail_ranges...))
             row_dofs = LinearIndices((2, dims...))
             col_dofs = LinearIndices((3, dims...))
 
-            assembler = Tesserae.matrix_assembler(direct, scatter_mesh, scatter_mesh, basis, basis)
-            buffer = Tesserae.BlockMatrixBuffer(Tesserae.BlockMatrixBufferKey(assembler, nodes, nodes))
-            @test buffer.key.row_size == size(nodes)
-            @test buffer.key.col_size == size(nodes)
-            @test iszero(buffer.key.col_offset)
-            @test length(buffer.node_colstarts) == length(nodes)
-            pool = Tesserae.BlockMatrixBufferPool()
-            fill!(buffer.values, 1)
-            @test Tesserae.release!(pool, buffer) === nothing
-            reused_buffer = Tesserae.acquire!(pool, buffer.key)
-            @test reused_buffer === buffer
-            @test all(iszero, reused_buffer.values)
-            for (jp, col_node) in enumerate(nodes), (ip, row_node) in enumerate(nodes)
-                I = (2ip-1):2ip
-                J = (3jp-2):3jp
-                Tesserae.add_entry!(reused_buffer, nodes, nodes, row_node, col_node, @view(local_matrix[I,J]))
+            for (row_nodes, col_nodes) in ((nodes, nodes), (shifted_row_nodes, shifted_col_nodes))
+                direct = create_sparse_matrix(basis, scatter_mesh; ndofs=(2, 3))
+                merge = copy(direct)
+                block_matrix = copy(direct)
+                row_size = 2length(row_nodes)
+                col_size = 3length(col_nodes)
+                local_matrix = reshape(collect(1.0:row_size*col_size), row_size, col_size)
+
+                assembler = Tesserae.matrix_assembler(direct, scatter_mesh, scatter_mesh, basis, basis)
+                buffer = Tesserae.BlockMatrixBuffer(Tesserae.BlockMatrixBufferKey(assembler, row_nodes, col_nodes))
+                for (jp, col_node) in enumerate(col_nodes), (ip, row_node) in enumerate(row_nodes)
+                    I = (2ip-1):2ip
+                    J = (3jp-2):3jp
+                    Tesserae.add_entry!(buffer, row_nodes, col_nodes, row_node, col_node, @view(local_matrix[I,J]))
+                end
+                block_assembler = Tesserae.matrix_assembler(block_matrix, scatter_mesh, scatter_mesh, basis, basis)
+                @test Tesserae.scatter!(block_assembler, buffer, row_nodes, col_nodes) === block_matrix
+                for (jp, col_node) in enumerate(col_nodes), (ip, row_node) in enumerate(row_nodes)
+                    I = (2ip-1):2ip
+                    J = (3jp-2):3jp
+                    Tesserae.add_entry!(assembler, row_node, col_node, @view(local_matrix[I,J]))
+                end
+                Tesserae.add!(merge, vec(row_dofs[:, row_nodes]), vec(col_dofs[:, col_nodes]), local_matrix)
+                @test direct == merge
+                @test block_matrix == merge
             end
-            @test sort(reused_buffer.values) == sort(vec(local_matrix))
-            block_matrix = copy(direct)
-            block_assembler = Tesserae.matrix_assembler(block_matrix, scatter_mesh, scatter_mesh, basis, basis)
-            @test Tesserae.scatter!(block_assembler, reused_buffer, nodes, nodes) === block_matrix
-            for (jp, col_node) in enumerate(nodes), (ip, row_node) in enumerate(nodes)
-                I = (2ip-1):2ip
-                J = (3jp-2):3jp
-                Tesserae.add_entry!(assembler, row_node, col_node, @view(local_matrix[I,J]))
-            end
-            Tesserae.add!(merge, vec(row_dofs[:, nodes]), vec(col_dofs[:, nodes]), local_matrix)
-            @test direct == merge
-            @test block_matrix == merge
         end
     end
 end

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -13,8 +13,10 @@
     @testset "square matrix" begin
         A = create_sparse_matrix(basis, mesh; ndofs=2)
         B = create_sparse_matrix(basis, mesh; ndofs=2)
+        A_dense = zeros(size(A))
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             A[i,j] = @∑ w[ip] * sum(∇w[jp])
+            A_dense[i,j] = @∑ w[ip] * sum(∇w[jp])
         end
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             B[j,i] = @∑ w[jp] * sum(∇w[ip])
@@ -22,6 +24,7 @@
         @test !(A ≈ A')
         @test !(B ≈ B')
         @test A ≈ B
+        @test A ≈ A_dense
     end
     @testset "multiple matrices" begin
         A = create_sparse_matrix(basis, mesh; ndofs=2)
@@ -162,6 +165,12 @@
         A = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
         B = create_sparse_matrix(basis, mesh; ndofs=(1, 2))
 
+        assembler = @inferred Tesserae.matrix_assembler(A, mesh, mesh, basis, basis)
+        @test assembler.matrix === A
+        @test Tesserae.matrix_assembler(Matrix(A), mesh, mesh, basis, basis) === nothing
+        invalid = Tesserae.SparseArrays.dropzeros!(copy(A))
+        @test_throws ArgumentError Tesserae.matrix_assembler(invalid, mesh, mesh, basis, basis)
+
         table_i, table_j = Tesserae.matrix_dof_tables(A, grid, grid)
         @test size(table_i) == (2, size(grid)...)
         @test size(table_j) == (1, size(grid)...)
@@ -191,6 +200,22 @@
         scalar_table_i, scalar_table_j = Tesserae.matrix_dof_tables(create_sparse_matrix(basis, mesh; ndofs=1), grid, grid)
         scalar_dofs_i, scalar_dofs_j = Tesserae.support_dofs(scalar_table_i, nodes_i, scalar_table_j, nodes_j)
         @test scalar_dofs_i === scalar_dofs_j
+    end
+    @testset "Cartesian sparse scatter" begin
+        for dims in ((5,), (5, 6, 7))
+            scatter_mesh = CartesianMesh(1, ((0, n - 1) for n in dims)...)
+            direct = create_sparse_matrix(basis, scatter_mesh; ndofs=(2, 3))
+            merge = copy(direct)
+            nodes = CartesianIndices(ntuple(_ -> 1:3, length(dims)))
+            local_matrix = reshape(collect(1.0:6length(nodes)^2), 2length(nodes), 3length(nodes))
+            row_dofs = LinearIndices((2, dims...))
+            col_dofs = LinearIndices((3, dims...))
+
+            assembler = Tesserae.matrix_assembler(direct, scatter_mesh, scatter_mesh, basis, basis)
+            Tesserae.add!(assembler, nodes, nodes, local_matrix)
+            Tesserae.add!(merge, vec(row_dofs[:, nodes]), vec(col_dofs[:, nodes]), local_matrix)
+            @test direct == merge
+        end
     end
 end
 

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -11,8 +11,8 @@
     @test_throws UndefKeywordError create_sparse_matrix(basis, mesh)
 
     @testset "square matrix" begin
-        A = create_sparse_matrix(basis, mesh; ndofs=2)
-        B = create_sparse_matrix(basis, mesh; ndofs=2)
+        A = create_sparse_matrix(basis, mesh; ndofs=1)
+        B = create_sparse_matrix(basis, mesh; ndofs=1)
         A_dense = zeros(size(A))
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             A[i,j] = @∑ w[ip] * sum(∇w[jp])
@@ -27,10 +27,10 @@
         @test A ≈ A_dense
     end
     @testset "multiple matrices" begin
-        A = create_sparse_matrix(basis, mesh; ndofs=2)
-        B = create_sparse_matrix(basis, mesh; ndofs=2)
-        Aref = create_sparse_matrix(basis, mesh; ndofs=2)
-        Bref = create_sparse_matrix(basis, mesh; ndofs=2)
+        A = create_sparse_matrix(basis, mesh; ndofs=1)
+        B = create_sparse_matrix(basis, mesh; ndofs=1)
+        Aref = create_sparse_matrix(basis, mesh; ndofs=1)
+        Bref = create_sparse_matrix(basis, mesh; ndofs=1)
 
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             A[i,j] = @∑ w[ip] * w[jp]
@@ -194,6 +194,7 @@
         @test generic_assembler.matrix === dense
         @test generic_assembler.row_dof_table == table_i
         @test generic_assembler.col_dof_table == table_j
+        @test_throws DimensionMismatch Tesserae.check_matrix_entry_size(1.0, 2, 1)
         invalid = Tesserae.SparseArrays.dropzeros!(copy(A))
         @test_throws ArgumentError Tesserae.matrix_assembler(invalid, mesh, mesh, basis, basis)
 
@@ -270,12 +271,6 @@
             Tesserae.add!(merge, vec(row_dofs[:, nodes]), vec(col_dofs[:, nodes]), local_matrix)
             @test direct == merge
             @test block_matrix == merge
-
-            Tesserae.fillzero!(reused_buffer.values)
-            for col_node in nodes, row_node in nodes
-                Tesserae.add_entry!(reused_buffer, nodes, nodes, row_node, col_node, 1.0)
-            end
-            @test all(isone, reused_buffer.values)
         end
     end
 end

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -105,6 +105,25 @@
         @test B ≈ Bref
         @test A ≈ B'
     end
+    @testset "block partition" begin
+        partition = ThreadPartition(mesh)
+        update!(partition, particles.x)
+
+        reference = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
+        block_sparse = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
+        block_dense = zeros(length(grid), 2length(grid))
+
+        @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
+            reference[i,j] = @∑ ∇w[ip] * w[jp]
+        end
+        @threaded :static @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) partition begin
+            block_sparse[i,j] = @∑ ∇w[ip] * w[jp]
+            block_dense[j,i] = @∑ ∇w[ip] * w[jp]
+        end
+
+        @test block_sparse ≈ reference
+        @test block_dense ≈ Matrix(reference')
+    end
     @testset "duplicate matrix" begin
         ex = quote
             @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin


### PR DESCRIPTION
Optimize `@P2G_Matrix` assembly by adding direct CSC slot updates for canonical Cartesian matrices and validating their sparsity pattern. Batch FEM/IGA quadrature contributions per cell so local matrices are scattered once per cell. Move scatter setup behind assembler dispatch, simplify the generated expressions, add coverage, and bump the package version to 0.7.3.