### PR TITLE
Support views of BasisWeightArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Tesserae.jl will be documented in this file.
 
+## v0.7.2
+
+### Added
+
+- Added `view` support for `BasisWeightArray`, allowing matching particle and
+  basis-weight subsets to be passed to transfer macros. (#177)
+
 ## v0.7.1
 
 ### Added

--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -341,6 +341,12 @@ generate_basis_weights(mesh::FEMesh, dims...; kwargs...) = _generate_basis_weigh
 
 Base.size(x::BasisWeightArray) = size(getfield(x, :indices))
 
+@inline function Base.view(x::BasisWeightArray, I...)
+    indices = view(getfield(x, :indices), I...)
+    vals = map(vals -> viewcol(vals, Val(ndims(x)), I...), getfield(x, :vals))
+    BasisWeightArray(getfield(x, :basis), vals, indices)
+end
+
 Base.propertynames(x::BasisWeightArray) = propertynames(getfield(x, :vals))
 @inline function Base.getproperty(x::BasisWeightArray, name::Symbol)
     getproperty(getfield(x, :vals), name)
@@ -362,6 +368,9 @@ end
 end
 
 @inline function viewcol(A::AbstractArray, I::Vararg{Integer, N}) where {N}
+    viewcol(A, Val(N), I...)
+end
+@inline function viewcol(A::AbstractArray, ::Val{N}, I...) where {N}
     colons = nfill(:, Val(ndims(A)-N))
     @boundscheck checkbounds(A, colons..., I...)
     @inbounds view(A, colons..., I...)

--- a/test/basis.jl
+++ b/test/basis.jl
@@ -102,6 +102,38 @@ end
     end
 end
 
+@testset "BasisWeightArray views" begin
+    mesh = CartesianMesh(1, (0,10), (0,10))
+    basis = BSpline(Linear())
+    weights = generate_basis_weights(basis, mesh, 4)
+    weights.w .= reshape(collect(eachindex(weights.w)), size(weights.w))
+
+    weights_view = @inferred view(weights, 2:3)
+    @test weights_view isa Tesserae.BasisWeightArray
+    @test size(weights_view) == (2,)
+    @test Tesserae.basis(weights_view) === basis
+    @test weights_view[1].w == weights[2].w
+    @test weights_view[2].w == weights[3].w
+    @test parent(weights_view.w) === weights.w
+    @test parent(weights_view.∇w) === weights.∇w
+
+    weights_view.w[1, 1, 1] = -1
+    @test weights.w[1, 1, 2] == -1
+
+    matrix_weights = generate_basis_weights(basis, mesh, 3, 4)
+    matrix_view = @inferred view(matrix_weights, :, 2:3)
+    @test size(matrix_view) == (3, 2)
+    @test matrix_view[2, 1].w == matrix_weights[2, 2].w
+
+    column_view = @inferred view(matrix_weights, :, 2)
+    @test size(column_view) == (3,)
+    @test column_view[2].w == matrix_weights[2, 2].w
+
+    cartesian_view = @inferred view(matrix_weights, CartesianIndex(2, 3))
+    @test size(cartesian_view) == ()
+    @test cartesian_view[].w == matrix_weights[2, 3].w
+end
+
 end # BasisWeight
 
 @testset "Basis functions" begin

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -190,6 +190,29 @@
         @test actual.v ≈ expected.v
     end
 
+    @testset "transfer with views" begin
+        grid, particles, weights = transfer_fixture()
+        expected = deepcopy(grid)
+        actual = deepcopy(grid)
+        subset = 2:length(particles)-1
+        particle_view = view(particles, subset)
+        weight_view = view(weights, subset)
+
+        fillzero!(expected.m)
+        for p in eachindex(particle_view)
+            bw = weight_view[p]
+            for (ip, i) in enumerate(supportnodes(bw, expected))
+                expected.m[i] += bw.w[ip] * particle_view.m[p]
+            end
+        end
+
+        @P2G actual=>i particle_view=>p weight_view=>ip begin
+            m[i] = @∑ w[ip] * m[p]
+        end
+
+        @test actual.m ≈ expected.m
+    end
+
     @testset "P2G RHS product hoisting" begin
         hoist_exprs = Any[]
         rhs = Tesserae.hoist_p2g_rhs!(hoist_exprs, Set([:wi, :∇wi]), :(2 * a * b * wi * c * d * ∇wi * e * f))


### PR DESCRIPTION
Add a `view` path for `BasisWeightArray` that slices both support indices and structure-of-arrays basis values without copying.

This allows matching particle and basis-weight subsets to be passed to transfer macros while preserving multidimensional and `CartesianIndex` indexing behavior.