### PR TITLE
Support property schemas for basis weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Tesserae.jl will be documented in this file.
 
+## v0.7.3
+
+### Added
+
+- Added property schemas for `BasisWeight` and `generate_basis_weights`, allowing
+  basis-value names, scalar types, and custom fields to be defined with a
+  `NamedTuple` type.
+
 ## v0.7.2
 
 ### Added

--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -207,8 +207,9 @@ derivatives of the requested `order`.
 This array may be larger than `supportnodes(weight)`. After an update, only
 entries corresponding to `eachindex(supportnodes(weight))` are valid.
 """
-@inline function nodal_basis_values(bw::BasisWeight, ::Order{k}) where {k}
-    getfield(bw, :vals)[k+1]
+@generated function nodal_basis_values(bw::BasisWeight{B, Vals, Indices, Order{n}}, ::Order{k}) where {B, Vals, Indices, n, k}
+    k ≤ n || return :(throw(ArgumentError("basis weight stores derivatives through Order($n), got Order($k)")))
+    :(getfield(bw, :vals)[$(k+1)])
 end
 
 @inline scalartype(bw::BasisWeight) = eltype(nodal_basis_values(bw, Order(0)))
@@ -252,14 +253,16 @@ end
 @inline supportnodes_storage(bw::BasisWeight) = getfield(bw, :indices)
 @inline derivative_order(bw::BasisWeight) = getfield(bw, :order)
 
-@generated function set_values!(bw::BasisWeight, ip, vals::Tuple{Vararg{Any, N}}) where {N}
+@generated function set_values!(bw::BasisWeight{B, Vals, Indices, Order{k}}, ip, vals::Tuple{Vararg{Any, N}}) where {B, Vals, Indices, k, N}
+    N ≤ k+1 || return :(throw(DimensionMismatch("cannot write $N basis-value derivatives to Order($k) storage")))
     quote
         @_inline_meta
         @_propagate_inbounds_meta
         @nexprs $N i -> nodal_basis_values(bw, Order(i-1))[ip] = vals[i]
     end
 end
-@generated function set_values!(bw::BasisWeight, vals::Tuple{Vararg{Any, N}}) where {N}
+@generated function set_values!(bw::BasisWeight{B, Vals, Indices, Order{k}}, vals::Tuple{Vararg{Any, N}}) where {B, Vals, Indices, k, N}
+    N ≤ k+1 || return :(throw(DimensionMismatch("cannot write $N basis-value derivatives to Order($k) storage")))
     quote
         @_inline_meta
         @nexprs $N i -> copyto!(nodal_basis_values(bw, Order(i-1)), vals[i])

--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -50,7 +50,7 @@ Such methods must update `supportnodes(bw)` and
 initial_supportnodes(::Basis, ::CartesianMesh{dim}) where {dim} = EmptyCartesianIndices(Val(dim))
 initial_supportnodes(shape::Shape, mesh::FEMesh) = zero(SVector{nlocalnodes(shape), Int})
 
-function allocate_basis_values(::Type{Vec{dim, T}}, basis; derivative::Order{k}=Order(1), name=nothing) where {dim, T, k}
+function allocate_basis_values(::Type{Vec{dim, T}}, basis; derivative::Order{k}, name=nothing) where {dim, T, k}
     map(Array, allocate_static_basis_values(Vec{dim, T}, basis; derivative, name))
 end
 function allocate_static_basis_values(::Type{Vec{dim, T}}, basis::Basis; kwargs...) where {dim, T}
@@ -61,7 +61,7 @@ function allocate_static_basis_values(::Type{Vec{dim, T}}, shape::Shape; kwargs.
     A = MArray{Tuple{nlocalnodes(shape)}}
     _allocate_basis_values(A, Vec{dim, T}; kwargs...)
 end
-@generated function _allocate_basis_values(::Type{A}, ::Type{Vec{dim, T}}; derivative::Order{k}=Order(1), name=nothing) where {A, dim, T, k}
+@generated function _allocate_basis_values(::Type{A}, ::Type{Vec{dim, T}}; derivative::Order{k}, name=nothing) where {A, dim, T, k}
     quote
         names = @ntuple $(k+1) i -> basis_value_name(Order(i-1), name)
         vals = @ntuple $(k+1) i -> fill(zero_basis_value(Vec{dim, T}, Order(i-1)), A)
@@ -138,17 +138,18 @@ julia> sum(eachindex(nodeindices)) do ip # linear field reproduction
 true
 ```
 """
-struct BasisWeight{B, Vals <: NamedTuple, Indices <: AbstractArray{<: Any}}
+struct BasisWeight{B, Vals <: NamedTuple, Indices <: AbstractArray{<: Any}, O <: Order}
     basis::B
     vals::Vals
     indices::Indices
+    order::O
 end
 
 # AbstractMesh
-function _basis_weight(::Type{T}, basis, mesh::AbstractMesh{dim}; kwargs...) where {T, dim}
-    vals = allocate_basis_values(Vec{dim, T}, basis; kwargs...)
+function _basis_weight(::Type{T}, basis, mesh::AbstractMesh{dim}; derivative::Order=Order(1), kwargs...) where {T, dim}
+    vals = allocate_basis_values(Vec{dim, T}, basis; derivative, kwargs...)
     indices = initial_supportnodes(basis, mesh)
-    BasisWeight(basis, vals, fill(indices))
+    BasisWeight(basis, vals, fill(indices), derivative)
 end
 
 # CartesianMesh
@@ -216,22 +217,7 @@ end
 end
 
 @inline supportnodes_storage(bw::BasisWeight) = getfield(bw, :indices)
-
-@inline function derivative_order(bw::BasisWeight)
-    @debug check_basis_value_names(bw)
-    k = length(propertynames(bw)) - 1
-    Order(k)
-end
-@inline function check_basis_value_names(bw::BasisWeight)
-    k = length(propertynames(bw)) - 1
-    check_basis_value_names(bw, Val(k))
-end
-@generated function check_basis_value_names(bw::BasisWeight, ::Val{k}) where {k}
-    quote
-        @_inline_meta
-        @assert @nall $(k+1) i -> basis_value_name(Order(i-1), Val(propertynames(bw)[1])) === propertynames(bw)[i]
-    end
-end
+@inline derivative_order(bw::BasisWeight) = getfield(bw, :order)
 
 @generated function set_values!(bw::BasisWeight, ip, vals::Tuple{Vararg{Any, N}}) where {N}
     quote
@@ -263,24 +249,25 @@ end
 Structure-of-arrays storage for multiple [`BasisWeight`](@ref)s.
 Use [`generate_basis_weights`](@ref) to construct a `BasisWeightArray`.
 """
-struct BasisWeightArray{B, Vals <: NamedTuple, Indices, ElType <: BasisWeight{B}, N} <: AbstractArray{ElType, N}
+struct BasisWeightArray{B, Vals <: NamedTuple, Indices, ElType <: BasisWeight{B}, N, O <: Order} <: AbstractArray{ElType, N}
     basis::B
     vals::Vals
     indices::Indices
+    order::O
 end
 
-function BasisWeightArray(basis::B, vals::Vals, indices::Indices) where {B, Vals <: NamedTuple, N, Indices <: AbstractArray{<: Any, N}}
-    ElType = Base._return_type(_getindex, Tuple{B, Vals, Indices, Vararg{Int, N}})
-    BasisWeightArray{B, Vals, Indices, ElType, N}(basis, vals, indices)
+function BasisWeightArray(basis::B, vals::Vals, indices::Indices, order::O) where {B, Vals <: NamedTuple, N, Indices <: AbstractArray{<: Any, N}, O <: Order}
+    ElType = Base._return_type(_getindex, Tuple{B, Vals, Indices, O, Vararg{Int, N}})
+    BasisWeightArray{B, Vals, Indices, ElType, N, O}(basis, vals, indices, order)
 end
 
 # AbstractMesh
-function _generate_basis_weights(::Type{T}, basis, mesh::AbstractMesh{dim}, dims::Dims; kwargs...) where {T, dim}
-    vals = map(allocate_basis_values(Vec{dim, T}, basis; kwargs...)) do vals
+function _generate_basis_weights(::Type{T}, basis, mesh::AbstractMesh{dim}, dims::Dims; derivative::Order=Order(1), kwargs...) where {T, dim}
+    vals = map(allocate_basis_values(Vec{dim, T}, basis; derivative, kwargs...)) do vals
         fill(zero(eltype(vals)), size(vals)..., dims...)
     end
     indices = _generate_supportnodes(basis, mesh, dims)
-    BasisWeightArray(basis, vals, indices)
+    BasisWeightArray(basis, vals, indices, derivative)
 end
 
 # CartesianMesh
@@ -344,7 +331,7 @@ Base.size(x::BasisWeightArray) = size(getfield(x, :indices))
 @inline function Base.view(x::BasisWeightArray, I...)
     indices = view(getfield(x, :indices), I...)
     vals = map(vals -> viewcol(vals, Val(ndims(x)), I...), getfield(x, :vals))
-    BasisWeightArray(getfield(x, :basis), vals, indices)
+    BasisWeightArray(getfield(x, :basis), vals, indices, derivative_order(x))
 end
 
 Base.propertynames(x::BasisWeightArray) = propertynames(getfield(x, :vals))
@@ -353,17 +340,18 @@ Base.propertynames(x::BasisWeightArray) = propertynames(getfield(x, :vals))
 end
 
 @inline basis(x::BasisWeightArray) = getfield(x, :basis)
+@inline derivative_order(x::BasisWeightArray) = getfield(x, :order)
 
 @inline function Base.getindex(x::BasisWeightArray{<: Any, <: Any, <: Any, <: Any, N}, I::Vararg{Integer, N}) where {N}
     @boundscheck checkbounds(x, I...)
-    @inbounds _getindex(getfield(x, :basis), getfield(x, :vals), getfield(x, :indices), I...)
+    @inbounds _getindex(getfield(x, :basis), getfield(x, :vals), getfield(x, :indices), derivative_order(x), I...)
 end
-@generated function _getindex(basis, vals::NamedTuple{names}, indices::AbstractArray{<: Any, N}, I::Vararg{Integer, N}) where {names, N}
+@generated function _getindex(basis, vals::NamedTuple{names}, indices::AbstractArray{<: Any, N}, order::Order, I::Vararg{Integer, N}) where {names, N}
     exps = [:(viewcol(vals.$name, I...)) for name in names]
     quote
         @_inline_meta
         @_propagate_inbounds_meta
-        BasisWeight(basis, NamedTuple{names}(tuple($(exps...))), view(indices, map(:, I, I)...))
+        BasisWeight(basis, NamedTuple{names}(tuple($(exps...))), view(indices, map(:, I, I)...), order)
     end
 end
 

--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -50,22 +50,40 @@ Such methods must update `supportnodes(bw)` and
 initial_supportnodes(::Basis, ::CartesianMesh{dim}) where {dim} = EmptyCartesianIndices(Val(dim))
 initial_supportnodes(shape::Shape, mesh::FEMesh) = zero(SVector{nlocalnodes(shape), Int})
 
-function allocate_basis_values(::Type{Vec{dim, T}}, basis; derivative::Order{k}, name=nothing) where {dim, T, k}
-    map(Array, allocate_static_basis_values(Vec{dim, T}, basis; derivative, name))
+function basis_property_type(::Type{T}, name) where {T}
+    NamedTuple{(basis_value_name(Order(0), name),), Tuple{T}}
 end
-function allocate_static_basis_values(::Type{Vec{dim, T}}, basis::Basis; kwargs...) where {dim, T}
+
+function allocate_basis_values(::Type{Prop}, basis, ::Val{dim}; derivative::Order) where {Prop <: NamedTuple, dim}
+    map(Array, allocate_static_basis_values(Prop, basis, Val(dim); derivative))
+end
+function allocate_static_basis_values(::Type{Prop}, basis::Basis, ::Val{dim}; kwargs...) where {Prop <: NamedTuple, dim}
     A = MArray{Tuple{nfill(support_width(basis), Val(dim))...}}
-    _allocate_basis_values(A, Vec{dim, T}; kwargs...)
+    _allocate_basis_values(A, Prop, Val(dim); kwargs...)
 end
-function allocate_static_basis_values(::Type{Vec{dim, T}}, shape::Shape; kwargs...) where {dim, T}
+function allocate_static_basis_values(::Type{Prop}, shape::Shape, ::Val{dim}; kwargs...) where {Prop <: NamedTuple, dim}
     A = MArray{Tuple{nlocalnodes(shape)}}
-    _allocate_basis_values(A, Vec{dim, T}; kwargs...)
+    _allocate_basis_values(A, Prop, Val(dim); kwargs...)
 end
-@generated function _allocate_basis_values(::Type{A}, ::Type{Vec{dim, T}}; derivative::Order{k}, name=nothing) where {A, dim, T, k}
+
+function _allocate_basis_values(::Type{A}, ::Type{Prop}, ::Val{dim}; derivative::Order) where {A, Prop <: NamedTuple, dim}
+    map(v -> fill(v, A), basis_value_zeros(Prop, Val(dim), derivative))
+end
+
+@generated function basis_value_zeros(::Type{Prop}, ::Val{dim}, ::Order{k}) where {Prop <: NamedTuple, dim, k}
+    prop_names = fieldnames(Prop)
+    isempty(prop_names) && return :(throw(ArgumentError("basis-weight property type must have at least one field")))
+    T = fieldtype(Prop, 1)
+
+    jet_names = ntuple(i -> basis_value_name(Order(i-1), Val(first(prop_names))), k+1)
+    names = (jet_names..., Base.tail(prop_names)...)
+    allunique(names) || return :(throw(ArgumentError("generated basis-value names overlap custom property names")))
+    jet_zeros = [:(zero_basis_value(Vec{$dim, $T}, Order($(i-1)))) for i in 1:k+1]
+    custom_zeros = [:(zero_recursive($(fieldtype(Prop, i)))) for i in 2:fieldcount(Prop)]
+
     quote
-        names = @ntuple $(k+1) i -> basis_value_name(Order(i-1), name)
-        vals = @ntuple $(k+1) i -> fill(zero_basis_value(Vec{dim, T}, Order(i-1)), A)
-        NamedTuple{names}(vals)
+        @_inline_meta
+        NamedTuple{$names}(($(jet_zeros...), $(custom_zeros...)))
     end
 end
 
@@ -73,11 +91,9 @@ zero_basis_value(::Type{Vec{dim, T}}, ::Order{0}) where {dim, T} = zero(T)
 zero_basis_value(::Type{Vec{dim, T}}, ::Order{1}) where {dim, T} = zero(Vec{dim, T})
 zero_basis_value(::Type{Vec{dim, T}}, ::Order{k}) where {dim, T, k} = zero(Tensor{Tuple{@Symmetry{ntuple(i->dim, k)...}}, T})
 basis_value_name(::Order{0}, ::Val{name}) where {name} = name
-basis_value_name(::Order{0}, ::Nothing) = :w
 for (k, nabla) in enumerate((:∇, :∇², :∇³, :∇⁴, :∇⁵, :∇⁶, :∇⁷, :∇⁸, :∇⁹))
     @eval begin
         basis_value_name(::Order{$k}, ::Val{name}) where {name} = Symbol($(QuoteNode(nabla)), name)
-        basis_value_name(::Order{$k}, ::Nothing) = $(QuoteNode(Symbol(nabla, :w)))
     end
 end
 
@@ -146,8 +162,9 @@ struct BasisWeight{B, Vals <: NamedTuple, Indices <: AbstractArray{<: Any}, O <:
 end
 
 # AbstractMesh
-function _basis_weight(::Type{T}, basis, mesh::AbstractMesh{dim}; derivative::Order=Order(1), kwargs...) where {T, dim}
-    vals = allocate_basis_values(Vec{dim, T}, basis; derivative, kwargs...)
+function _basis_weight(::Type{T}, basis, mesh::AbstractMesh{dim}; derivative::Order=Order(1), name=Val(:w)) where {T, dim}
+    Prop = basis_property_type(T, name)
+    vals = allocate_basis_values(Prop, basis, Val(dim); derivative)
     indices = initial_supportnodes(basis, mesh)
     BasisWeight(basis, vals, fill(indices), derivative)
 end
@@ -262,8 +279,9 @@ function BasisWeightArray(basis::B, vals::Vals, indices::Indices, order::O) wher
 end
 
 # AbstractMesh
-function _generate_basis_weights(::Type{T}, basis, mesh::AbstractMesh{dim}, dims::Dims; derivative::Order=Order(1), kwargs...) where {T, dim}
-    vals = map(allocate_basis_values(Vec{dim, T}, basis; derivative, kwargs...)) do vals
+function _generate_basis_weights(::Type{T}, basis, mesh::AbstractMesh{dim}, dims::Dims; derivative::Order=Order(1), name=Val(:w)) where {T, dim}
+    Prop = basis_property_type(T, name)
+    vals = map(allocate_basis_values(Prop, basis, Val(dim); derivative)) do vals
         fill(zero(eltype(vals)), size(vals)..., dims...)
     end
     indices = _generate_supportnodes(basis, mesh, dims)

--- a/src/Basis/basis_weight.jl
+++ b/src/Basis/basis_weight.jl
@@ -124,9 +124,23 @@ end
 @inline tuple_otimes(x::Tuple) = SArray(⊗(map(Vec, x)...))
 
 """
-    BasisWeight([T,] basis, mesh)
+    BasisWeight([T,] basis, mesh; derivative=Order(1), name=Val(:w))
+    BasisWeight(Prop, basis, mesh; derivative=Order(1))
 
 `BasisWeight` stores basis function values and their spatial derivatives.
+
+In the first form, the scalar type defaults to `Float64`. `name` sets the name
+of the basis value, and `derivative` sets the highest derivative order to
+store.
+
+In the second form, `Prop` must be a non-empty `NamedTuple` type. Its first
+field defines the basis value name and scalar type. Fields generated through
+`derivative` are inserted after the first field, followed by the remaining
+fields of `Prop` in their original order.
+
+For example, `@NamedTuple{N::Float32, ψ::Vec{2,Float64}}` with
+`derivative=Order(2)` creates storage for `N`, `∇N`, `∇²N`, and `ψ`.
+Custom field names must not overlap generated derivative names.
 
 ```jldoctest
 julia> mesh = CartesianMesh(1.0, (0,5), (0,5));
@@ -162,11 +176,13 @@ struct BasisWeight{B, Vals <: NamedTuple, Indices <: AbstractArray{<: Any}, O <:
 end
 
 # AbstractMesh
-function _basis_weight(::Type{T}, basis, mesh::AbstractMesh{dim}; derivative::Order=Order(1), name=Val(:w)) where {T, dim}
-    Prop = basis_property_type(T, name)
+function _basis_weight(::Type{Prop}, basis, mesh::AbstractMesh{dim}; derivative::Order=Order(1)) where {Prop <: NamedTuple, dim}
     vals = allocate_basis_values(Prop, basis, Val(dim); derivative)
     indices = initial_supportnodes(basis, mesh)
     BasisWeight(basis, vals, fill(indices), derivative)
+end
+function _basis_weight(::Type{T}, basis, mesh::AbstractMesh; derivative::Order=Order(1), name=Val(:w)) where {T}
+    _basis_weight(basis_property_type(T, name), basis, mesh; derivative)
 end
 
 # CartesianMesh
@@ -279,13 +295,15 @@ function BasisWeightArray(basis::B, vals::Vals, indices::Indices, order::O) wher
 end
 
 # AbstractMesh
-function _generate_basis_weights(::Type{T}, basis, mesh::AbstractMesh{dim}, dims::Dims; derivative::Order=Order(1), name=Val(:w)) where {T, dim}
-    Prop = basis_property_type(T, name)
+function _generate_basis_weights(::Type{Prop}, basis, mesh::AbstractMesh{dim}, dims::Dims; derivative::Order=Order(1)) where {Prop <: NamedTuple, dim}
     vals = map(allocate_basis_values(Prop, basis, Val(dim); derivative)) do vals
         fill(zero(eltype(vals)), size(vals)..., dims...)
     end
     indices = _generate_supportnodes(basis, mesh, dims)
     BasisWeightArray(basis, vals, indices, derivative)
+end
+function _generate_basis_weights(::Type{T}, basis, mesh::AbstractMesh, dims::Dims; derivative::Order=Order(1), name=Val(:w)) where {T}
+    _generate_basis_weights(basis_property_type(T, name), basis, mesh, dims; derivative)
 end
 
 # CartesianMesh
@@ -328,11 +346,18 @@ _todims(x::Tuple{Vararg{Int}}) = x
 _todims(x::Vararg{Int}) = x
 
 """
-    generate_basis_weights([T,] ::Basis, mesh, dims...)
-    generate_basis_weights([T,] ::FEMesh, dims...)
+    generate_basis_weights([T,] ::Basis, mesh, dims...; derivative=Order(1), name=Val(:w))
+    generate_basis_weights([T,] ::FEMesh, dims...; derivative=Order(1), name=Val(:w))
+    generate_basis_weights(Prop, ::Basis, mesh, dims...; derivative=Order(1))
+    generate_basis_weights(Prop, ::FEMesh, dims...; derivative=Order(1))
 
 Generate an array of [`BasisWeight`](@ref)s for `basis` on `mesh`.
 For `FEMesh`, the mesh cell shape is used as the basis.
+
+In the `Prop` forms, `Prop` follows the same rules as in
+`BasisWeight(Prop, basis, mesh)`: its first field defines the basis value name
+and scalar type, generated derivative fields follow it, and its remaining
+fields are appended as custom storage.
 """
 function generate_basis_weights end
 

--- a/src/Basis/cpdi.jl
+++ b/src/Basis/cpdi.jl
@@ -31,14 +31,10 @@ Base.size(x::CPDISupportNodes) = (x.len,)
     @inbounds x.indices[i]
 end
 
-@generated function allocate_basis_values(::Type{Vec{dim, T}}, ::CPDI; derivative::Order{k}, name::Val{sym}=Val(:w)) where {dim, T, k, sym}
-    k == 1 || return :(throw(ArgumentError("CPDI supports derivative=Order(1) only")))
-    w = sym
-    ∇w = Symbol(:∇, sym)
-    quote
-        len = 2^dim * 2^dim # maximum length
-        (; $w=fill(zero(T), len), $∇w=fill(zero(Vec{dim, T}), len))
-    end
+function allocate_basis_values(::Type{Prop}, ::CPDI, ::Val{dim}; derivative::Order{k}) where {Prop <: NamedTuple, dim, k}
+    k == 1 || throw(ArgumentError("CPDI supports derivative=Order(1) only"))
+    len = 2^dim * 2^dim # maximum length
+    map(v -> fill(v, len), basis_value_zeros(Prop, Val(dim), derivative))
 end
 
 function initial_supportnodes(::CPDI, mesh::CartesianMesh{dim}) where {dim}

--- a/src/Basis/cpdi.jl
+++ b/src/Basis/cpdi.jl
@@ -31,7 +31,7 @@ Base.size(x::CPDISupportNodes) = (x.len,)
     @inbounds x.indices[i]
 end
 
-@generated function allocate_basis_values(::Type{Vec{dim, T}}, ::CPDI; derivative::Order{k}=Order(1), name::Val{sym}=Val(:w)) where {dim, T, k, sym}
+@generated function allocate_basis_values(::Type{Vec{dim, T}}, ::CPDI; derivative::Order{k}, name::Val{sym}=Val(:w)) where {dim, T, k, sym}
     k == 1 || return :(throw(ArgumentError("CPDI supports derivative=Order(1) only")))
     w = sym
     ∇w = Symbol(:∇, sym)

--- a/src/Basis/iga.jl
+++ b/src/Basis/iga.jl
@@ -16,9 +16,9 @@ initial_supportnodes(basis::IGABasis, mesh::IGAMesh) = zero(SVector{nsupportnode
 _generate_supportnodes(::IGABasis, mesh::IGAMesh, dims::Dims{2}) = _generate_cell_supportnodes(mesh, dims)
 _generate_supportnodes(::IGABasis, ::IGAMesh, ::Dims) = throw(DimensionMismatch("IGA basis weights must have dimensions (quadrature points, cells)"))
 
-function allocate_static_basis_values(::Type{Vec{dim, T}}, basis::IGABasis; kwargs...) where {dim, T}
+function allocate_static_basis_values(::Type{Prop}, basis::IGABasis, ::Val{dim}; kwargs...) where {Prop <: NamedTuple, dim}
     A = MArray{Tuple{nsupportnodes(basis)}}
-    _allocate_basis_values(A, Vec{dim, T}; kwargs...)
+    _allocate_basis_values(A, Prop, Val(dim); kwargs...)
 end
 
 generate_basis_weights(::Type{T}, mesh::IGAMesh, dims...; kwargs...) where {T} = _generate_basis_weights(T, basis(mesh), mesh, _todims(dims...); kwargs...)

--- a/src/Basis/wls.jl
+++ b/src/Basis/wls.jl
@@ -91,7 +91,7 @@ function update_basis_values!(bw::BasisWeight, wls::WLS{<: Union{BSpline{Quadrat
         mesh_1d = axismesh(mesh, d)
         vals_1d = allocate_static_basis_values(Vec{1,T}, wls_1d; derivative=order)
         indices_1d = CartesianIndices((supportnodes(bw).indices[d],))
-        bw_1d = BasisWeight(wls_1d, vals_1d, Scalar(indices_1d))
+        bw_1d = BasisWeight(wls_1d, vals_1d, Scalar(indices_1d), order)
         # Must be inlined: creates/updates a small StaticArray (MVector/MArray) on the GPU.
         # If not inlined, the temporary may escape and trigger dynamic allocation (gpu_gc_pool_alloc).
         update_basis_values!(bw_1d, wls_1d, Vec(getx(pt)[d]), mesh_1d, Trues(size(mesh_1d)))

--- a/src/Basis/wls.jl
+++ b/src/Basis/wls.jl
@@ -89,7 +89,7 @@ function update_basis_values!(bw::BasisWeight, wls::WLS{<: Union{BSpline{Quadrat
     order = derivative_order(bw)
     vals_axes = ntuple(Val(dim)) do d
         mesh_1d = axismesh(mesh, d)
-        vals_1d = allocate_static_basis_values(Vec{1,T}, wls_1d; derivative=order)
+        vals_1d = allocate_static_basis_values(@NamedTuple{w::T}, wls_1d, Val(1); derivative=order)
         indices_1d = CartesianIndices((supportnodes(bw).indices[d],))
         bw_1d = BasisWeight(wls_1d, vals_1d, Scalar(indices_1d), order)
         # Must be inlined: creates/updates a small StaticArray (MVector/MArray) on the GPU.

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -88,7 +88,7 @@ function Adapt.adapt_structure(to, weights::BasisWeightArray)
     b = basis(weights)
     vals = map(a -> adapt(to, a), getfield(weights, :vals))
     indices = adapt(to, getfield(weights, :indices))
-    BasisWeightArray(b, vals, indices)
+    BasisWeightArray(b, vals, indices, derivative_order(weights))
 end
 function KernelAbstractions.get_backend(weights::BasisWeightArray)
     vals = getfield(weights, :vals)

--- a/test/basis.jl
+++ b/test/basis.jl
@@ -43,6 +43,23 @@ function check_weight_layout(bw::Union{BasisWeight, Tesserae.BasisWeightArray}, 
     end
 end
 
+@testset "Basis-value allocation" begin
+    Prop = @NamedTuple{N::Float64, ψ::Vec{2,Float64}}
+    zeros = @inferred Tesserae.basis_value_zeros(Prop, Val(2), Order(2))
+    @test propertynames(zeros) === (:N, :∇N, :∇²N, :ψ)
+    @test zeros === (; N=0.0, ∇N=zero(Vec{2,Float64}), ∇²N=zero(SymmetricSecondOrderTensor{2,Float64}), ψ=zero(Vec{2,Float64}))
+
+    vals = @inferred Tesserae.allocate_basis_values(Prop, BSpline(Linear()), Val(2); derivative=Order(2))
+    @test propertynames(vals) === propertynames(zeros)
+    @test eltype(vals.N) === Float64
+    @test eltype(vals.∇N) === Vec{2,Float64}
+    @test eltype(vals.∇²N) <: SymmetricSecondOrderTensor{2,Float64}
+    @test eltype(vals.ψ) === Vec{2,Float64}
+
+    @test_throws ArgumentError Tesserae.basis_value_zeros(NamedTuple{(),Tuple{}}, Val(2), Order(1))
+    @test_throws ArgumentError Tesserae.basis_value_zeros(@NamedTuple{w::Float64, ∇w::Vec{2,Float64}}, Val(2), Order(1))
+end
+
 @testset "CartesianMesh layout" begin
     basis = BSpline(Quadratic())
     n = 2

--- a/test/basis.jl
+++ b/test/basis.jl
@@ -331,7 +331,9 @@ end # BasisWeight
         @test_throws MethodError KernelCorrection(cpdi)
         for dim in (1,2,3)
             mesh = CartesianMesh(0.1, ntuple(i->(0,1), Val(dim))...)
-            bw = BasisWeight(cpdi, mesh)
+            Prop = NamedTuple{(:w, :ψ), Tuple{Float64, Vec{dim,Float64}}}
+            bw = BasisWeight(Prop, cpdi, mesh)
+            bw.ψ .= Ref(ones(Vec{dim,Float64}))
             @test_throws ArgumentError BasisWeight(cpdi, mesh; derivative=Order(0))
             l = 0.5*spacing(mesh)
             F = one(Mat{dim,dim})
@@ -340,6 +342,7 @@ end # BasisWeight
             filter[begin] = false
             @test_throws ArgumentError update!(bw, (;x,l,F), mesh, filter)
             check_update!(bw, (;x,l,F), x, mesh; partition=true, reproduces_linear=true)
+            @test all(==(ones(Vec{dim,Float64})), bw.ψ)
 
             GridProp = NamedTuple{(:x, :m), Tuple{Vec{dim, Float64}, Float64}}
             spgrid = generate_grid(SpArray, GridProp, mesh)

--- a/test/basis.jl
+++ b/test/basis.jl
@@ -102,6 +102,20 @@ end
     end
 end
 
+@testset "Explicit derivative order" begin
+    mesh = CartesianMesh(1, (0,10), (0,10))
+    basis = BSpline(Linear())
+    original = BasisWeight(basis, mesh; derivative=Order(1))
+    ψ = fill(Vec(1.0, 2.0), size(original.w))
+    vals = merge(getfield(original, :vals), (; ψ))
+    bw = Tesserae.BasisWeight(basis, vals, getfield(original, :indices), Order(1))
+
+    @test Tesserae.derivative_order(bw) isa Order{1}
+    @test propertynames(bw) === (:w, :∇w, :ψ)
+    update!(bw, Vec(2.2, 3.4), mesh)
+    @test all(==(Vec(1.0, 2.0)), bw.ψ)
+end
+
 @testset "BasisWeightArray views" begin
     mesh = CartesianMesh(1, (0,10), (0,10))
     basis = BSpline(Linear())

--- a/test/basis.jl
+++ b/test/basis.jl
@@ -129,6 +129,12 @@ end
 
     @test Tesserae.derivative_order(bw) isa Order{1}
     @test propertynames(bw) === (:w, :∇w, :ψ)
+    @test_throws ArgumentError Tesserae.nodal_basis_values(bw, Order(2))
+    @test_throws DimensionMismatch Tesserae.set_values!(bw, 1, (1.0, Vec(1.0, 2.0), Vec(3.0, 4.0)))
+    @test_throws DimensionMismatch Tesserae.set_values!(bw, (bw.w, bw.∇w, bw.ψ))
+    @test iszero(bw.w[1])
+    @test iszero(bw.∇w[1])
+    @test bw.ψ[1] == Vec(1.0, 2.0)
     update!(bw, Vec(2.2, 3.4), mesh)
     @test all(==(Vec(1.0, 2.0)), bw.ψ)
 end
@@ -155,6 +161,19 @@ end
     @test eltype(weights.ψ) === Vec{2,Float64}
     @test Tesserae.derivative_order(weights) isa Order{1}
     @test Tesserae.derivative_order(first(weights)) isa Order{1}
+
+    fill!(weights.ψ, Vec(1.0, 2.0))
+    weights_view = @inferred view(weights, 2:2)
+    @test propertynames(weights_view) === (:N, :∇N, :ψ)
+    @test parent(weights_view.ψ) === weights.ψ
+    @test Tesserae.derivative_order(weights_view) isa Order{1}
+    @test Tesserae.derivative_order(first(weights_view)) isa Order{1}
+
+    adapted = Tesserae.Adapt.adapt(Array, weights)
+    @test propertynames(adapted) === (:N, :∇N, :ψ)
+    @test adapted.ψ == weights.ψ
+    @test Tesserae.derivative_order(adapted) isa Order{1}
+    @test Tesserae.derivative_order(first(adapted)) isa Order{1}
 end
 
 @testset "BasisWeightArray views" begin

--- a/test/basis.jl
+++ b/test/basis.jl
@@ -133,6 +133,30 @@ end
     @test all(==(Vec(1.0, 2.0)), bw.ψ)
 end
 
+@testset "Property schema" begin
+    mesh = CartesianMesh(1, (0,10), (0,10))
+    basis = BSpline(Linear())
+    Prop = @NamedTuple{N::Float32, ψ::Vec{2,Float64}}
+
+    bw = @inferred BasisWeight(Prop, basis, mesh; derivative=Order(2))
+    @test propertynames(bw) === (:N, :∇N, :∇²N, :ψ)
+    @test eltype(bw.N) === Float32
+    @test eltype(bw.∇N) === Vec{2,Float32}
+    @test eltype(bw.∇²N) <: SymmetricSecondOrderTensor{2,Float32}
+    @test eltype(bw.ψ) === Vec{2,Float64}
+    bw.ψ .= Ref(Vec(1.0, 2.0))
+    update!(bw, Vec(2.2, 3.4), mesh)
+    @test all(==(Vec(1.0, 2.0)), bw.ψ)
+
+    weights = @inferred generate_basis_weights(Prop, basis, mesh, 2; derivative=Order(1))
+    @test propertynames(weights) === (:N, :∇N, :ψ)
+    @test eltype(weights.N) === Float32
+    @test eltype(weights.∇N) === Vec{2,Float32}
+    @test eltype(weights.ψ) === Vec{2,Float64}
+    @test Tesserae.derivative_order(weights) isa Order{1}
+    @test Tesserae.derivative_order(first(weights)) isa Order{1}
+end
+
 @testset "BasisWeightArray views" begin
     mesh = CartesianMesh(1, (0,10), (0,10))
     basis = BSpline(Linear())

--- a/test/fem.jl
+++ b/test/fem.jl
@@ -16,7 +16,9 @@
         )
         rule = generate_quadrature_rule(Tesserae.Quad9())
         points = @inferred generate_particles(@NamedTuple{x::Vec{2,Float64}, V::Float64}, geometry, rule)
-        weights = @inferred generate_basis_weights(field, size(points); name=Val(:N))
+        WeightProp = @NamedTuple{N::Float64, ψ::Float32}
+        weights = @inferred generate_basis_weights(WeightProp, field, size(points))
+        weights.ψ .= 1
 
         @test (@inferred basis(geometry)) === Tesserae.cellshape(geometry)
         @test_throws MethodError generate_particles(@NamedTuple{x::Vec{2,Float64}}, geometry)
@@ -38,6 +40,7 @@
         @test quadrature_rule(adapted_points) === rule
         @test supportnodes(weights[1,1]) == Tesserae.SVector(2, 3, 4, 5)
         @test (@inferred update!(weights, points, field; geometry, measure=points.V)) === weights
+        @test all(==(1), weights.ψ)
         for (q, (point, weight)) in enumerate(zip(rule.points, rule.weights))
             ξ, η = point
             N, dNdξ = Tesserae.jet(Order(1), Tesserae.Quad4(), point)

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -215,7 +215,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
 
         vals = (w=reshape(collect(1.0:16.0), 1, 16),)
         indices = reshape(collect(1:16), 1, 16)
-        weights = Tesserae.BasisWeightArray(nothing, vals, indices)
+        weights = Tesserae.BasisWeightArray(nothing, vals, indices, Order(0))
         @test weights[1, meshcells[end]].w[] == 16
         @test supportnodes(weights[1, meshcells[end]]) == 16
     end

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -206,11 +206,14 @@ const nurbs_cubic = Tesserae.NURBS.cubic
     @testset "Basis weights" begin
         # IGA basis-weight arrays should carry the same support-node layout as
         # direct mesh support queries.
-        igaweights = @inferred generate_basis_weights(Float64, mesh, 2, Tesserae.ncells(mesh))
+        WeightProp = @NamedTuple{w::Float64, ψ::Vec{2,Float32}}
+        igaweights = @inferred generate_basis_weights(WeightProp, mesh, 2, Tesserae.ncells(mesh))
         @test size(igaweights) == (2, Tesserae.ncells(mesh))
         @test typeof(Tesserae.basis(igaweights)) === typeof(mesh_basis)
         @test size(igaweights[1, meshcells[end]].w) == (9,)
         @test size(igaweights[1, meshcells[end]].∇w) == (9,)
+        @test size(igaweights[1, meshcells[end]].ψ) == (9,)
+        @test all(iszero, igaweights.ψ)
         @test length(supportnodes(igaweights[1, meshcells[end]])) == 9
 
         vals = (w=reshape(collect(1.0:16.0), 1, 16),)


### PR DESCRIPTION
- Accept `NamedTuple` property schemas in `BasisWeight` and `generate_basis_weights`.
- Generate derivative fields from the first property while preserving custom fields.
- Store derivative order explicitly and validate derivative access and writes.
- Preserve schemas and derivative order across views and adaptation.