### PR TITLE
Support sparse matrix views in P2G assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 All notable changes to Tesserae.jl will be documented in this file.
 
-## v0.7.3
+## v0.7.4
 
 ### Added
 
 - Added support for assembling into sparse matrix component views with
   `@P2G_Matrix`.
+
+## v0.7.3
+
+### Added
+
 - Added property schemas for `BasisWeight` and `generate_basis_weights`, allowing
   basis-value names, scalar types, and custom fields to be defined with a
   `NamedTuple` type. (#178)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Tesserae.jl will be documented in this file.
 
 ### Added
 
+- Added support for assembling into sparse matrix component views with
+  `@P2G_Matrix`.
 - Added property schemas for `BasisWeight` and `generate_basis_weights`, allowing
   basis-value names, scalar types, and custom fields to be defined with a
   `NamedTuple` type. (#178)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tesserae"
 uuid = "fd374396-9d9c-4d88-9aa5-37a7f6105aca"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
 
 [deps]

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -360,19 +360,22 @@ end
 
 # ---- CartesianSparseMatrixAssembler ----
 
-# `matrix` is the logical destination and `storage` is its canonical CSC
-# storage. They are identical for a plain CSC; a view uses its parent CSC.
-struct CartesianSparseMatrixAssembler{M <: AbstractMatrix, S <: SparseMatrixCSC, R <: LinearIndices, C <: LinearIndices, SR <: LinearIndices, SC <: LinearIndices, RI, CI}
+# `matrix` is the logical destination. A plain CSC stores values itself, while
+# a view obtains its storage and parent indices from the SubArray.
+struct CartesianSparseMatrixAssembler{M <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices, SR <: LinearIndices, SC <: LinearIndices}
     matrix::M
-    storage::S
     row_dof_table::R
     col_dof_table::C
     storage_row_dof_table::SR
     storage_col_dof_table::SC
-    row_parent_indices::RI
-    col_parent_indices::CI
     sparsity_radius::Int
 end
+
+matrix_storage(matrix) = matrix
+matrix_storage(matrix::SubArray{T,2,P}) where {T,P <: SparseMatrixCSC} = parent(matrix)
+
+matrix_storage_indices(matrix) = axes(matrix)
+matrix_storage_indices(matrix::SubArray{T,2,P}) where {T,P <: SparseMatrixCSC} = parentindices(matrix)
 
 function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, sparsity_radius::Int)
     node_count = prod(mesh_size)
@@ -386,13 +389,10 @@ function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, spa
     col_dof_table = LinearIndices((col_dofs_per_node, mesh_size...))
     assembler = CartesianSparseMatrixAssembler(
         A,
-        A,
         row_dof_table,
         col_dof_table,
         row_dof_table,
         col_dof_table,
-        axes(row_dof_table, 1),
-        axes(col_dof_table, 1),
         sparsity_radius,
     )
     has_cartesian_sparse_pattern(assembler) || throw(ArgumentError("Cartesian sparse matrix must use the canonical sparsity pattern"))
@@ -413,7 +413,8 @@ function cartesian_neighbor_nodes(node::CartesianIndex{N}, mesh_size::Dims{N}, s
 end
 
 function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
-    (; storage, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    (; matrix, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    storage = matrix_storage(matrix)
     mesh_size = Base.tail(size(storage_row_dof_table))
     row_dofs_per_node = size(storage_row_dof_table, 1)
     col_dofs_per_node = size(storage_col_dof_table, 1)
@@ -437,7 +438,9 @@ end
 @inline function add_entry!(assembler::CartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
     @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
 
-    (; matrix, storage, row_dof_table, col_dof_table, storage_row_dof_table, storage_col_dof_table, row_parent_indices, col_parent_indices, sparsity_radius) = assembler
+    (; matrix, row_dof_table, col_dof_table, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    storage = matrix_storage(matrix)
+    row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
     mesh_size = Base.tail(size(row_dof_table))
     row_ndofs = size(row_dof_table, 1)
     col_ndofs = size(col_dof_table, 1)
@@ -449,10 +452,10 @@ end
     values = nonzeros(storage)
 
     @inbounds for b in 1:col_ndofs
-        col = storage_col_dof_table[col_parent_indices[b],col_node]
+        col = storage_col_dof_table[col_storage_indices[b],col_node]
         slot = first(nzrange(storage, col)) + row_offset
         for a in 1:row_ndofs
-            values[slot + row_parent_indices[a] - 1] += value[(b - 1) * row_ndofs + a]
+            values[slot + row_storage_indices[a] - 1] += value[(b - 1) * row_ndofs + a]
         end
     end
 
@@ -473,16 +476,12 @@ end
 function CartesianSparseMatrixAssembler(matrix::SubArray{T,2,P}, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {T,P <: SparseMatrixCSC,N}
     storage_assembler = CartesianSparseMatrixAssembler(parent(matrix), row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
-    row_parent_indices, col_parent_indices = parentindices(matrix)
     assembler = CartesianSparseMatrixAssembler(
         matrix,
-        storage_assembler.storage,
         row_dof_table,
         col_dof_table,
         storage_assembler.storage_row_dof_table,
         storage_assembler.storage_col_dof_table,
-        row_parent_indices,
-        col_parent_indices,
         storage_assembler.sparsity_radius,
     )
     check_cartesian_sparse_matrix_view(assembler)
@@ -490,9 +489,10 @@ function CartesianSparseMatrixAssembler(matrix::SubArray{T,2,P}, row_mesh::Carte
 end
 
 @noinline function check_cartesian_sparse_matrix_view(assembler::CartesianSparseMatrixAssembler)
-    (; row_dof_table, col_dof_table, storage_row_dof_table, storage_col_dof_table, row_parent_indices, col_parent_indices) = assembler
-    check_cartesian_sparse_matrix_view_indices(row_parent_indices, row_dof_table, storage_row_dof_table)
-    check_cartesian_sparse_matrix_view_indices(col_parent_indices, col_dof_table, storage_col_dof_table)
+    (; matrix, row_dof_table, col_dof_table, storage_row_dof_table, storage_col_dof_table) = assembler
+    row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
+    check_cartesian_sparse_matrix_view_indices(row_storage_indices, row_dof_table, storage_row_dof_table)
+    check_cartesian_sparse_matrix_view_indices(col_storage_indices, col_dof_table, storage_col_dof_table)
     nothing
 end
 
@@ -512,35 +512,36 @@ end
 
 # ---- GenericMatrixAssembler ----
 
-struct GenericMatrixAssembler{M <: AbstractMatrix, S <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices, RI, CI}
+struct GenericMatrixAssembler{M <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices}
     matrix::M
-    storage::S
     row_dof_table::R
     col_dof_table::C
-    row_parent_indices::RI
-    col_parent_indices::CI
 end
 
 function add!(assembler::GenericMatrixAssembler, row_nodes, col_nodes, local_matrix)
     @_propagate_inbounds_meta
-    (; matrix, storage, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
+    (; matrix, row_dof_table, col_dof_table) = assembler
+    storage = matrix_storage(matrix)
+    row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
     row_dofs, col_dofs = support_dofs(row_dof_table, row_nodes, col_dof_table, col_nodes)
-    if row_dofs === col_dofs && row_parent_indices === col_parent_indices
-        dofs = storage_dofs(row_parent_indices, row_dofs)
+    if row_dofs === col_dofs && row_storage_indices === col_storage_indices
+        dofs = storage_dofs(row_storage_indices, row_dofs)
         add!(storage, dofs, dofs, local_matrix)
     else
-        add!(storage, storage_dofs(row_parent_indices, row_dofs), storage_dofs(col_parent_indices, col_dofs), local_matrix)
+        add!(storage, storage_dofs(row_storage_indices, row_dofs), storage_dofs(col_storage_indices, col_dofs), local_matrix)
     end
     matrix
 end
 
 # GenericMatrixAssembler writes entries through the storage indexing interface.
 @inline function add_entry!(assembler::GenericMatrixAssembler, row_node, col_node, value)
-    (; matrix, storage, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
+    (; matrix, row_dof_table, col_dof_table) = assembler
+    storage = matrix_storage(matrix)
+    row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
     row_ndofs = size(row_dof_table, 1)
     col_ndofs = size(col_dof_table, 1)
     @boundscheck check_matrix_entry_size(value, row_ndofs, col_ndofs)
-    @inbounds add_matrix_entry!(storage, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices, row_node, col_node, value, row_ndofs, col_ndofs)
+    @inbounds add_matrix_entry!(storage, row_dof_table, col_dof_table, row_storage_indices, col_storage_indices, row_node, col_node, value, row_ndofs, col_ndofs)
     matrix
 end
 
@@ -551,10 +552,10 @@ end
     nothing
 end
 
-@inline function add_matrix_entry!(storage, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices, row_node, col_node, value, row_ndofs, col_ndofs)
+@inline function add_matrix_entry!(storage, row_dof_table, col_dof_table, row_storage_indices, col_storage_indices, row_node, col_node, value, row_ndofs, col_ndofs)
     @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
-        row = row_parent_indices[row_dof_table[a,row_node]]
-        col = col_parent_indices[col_dof_table[b,col_node]]
+        row = row_storage_indices[row_dof_table[a,row_node]]
+        col = col_storage_indices[col_dof_table[b,col_node]]
         storage[row,col] += value[(b - 1) * row_ndofs + a]
     end
     nothing
@@ -562,9 +563,9 @@ end
 
 storage_dofs(::Base.OneTo, dofs) = dofs
 
-function storage_dofs(parent_indices, dofs)
+function storage_dofs(storage_indices, dofs)
     @_propagate_inbounds_meta
-    parent_indices[dofs]
+    storage_indices[dofs]
 end
 
 function support_dofs(table_i, nodes_i, table_j, nodes_j)
@@ -581,12 +582,7 @@ end
 
 function matrix_assembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
-    GenericMatrixAssembler(matrix, matrix, row_dof_table, col_dof_table, axes(matrix, 1), axes(matrix, 2))
-end
-function matrix_assembler(matrix::SubArray{T,2,P}, row_mesh, col_mesh, row_basis, col_basis) where {T,P <: SparseMatrixCSC}
-    row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
-    row_parent_indices, col_parent_indices = parentindices(matrix)
-    GenericMatrixAssembler(matrix, parent(matrix), row_dof_table, col_dof_table, row_parent_indices, col_parent_indices)
+    GenericMatrixAssembler(matrix, row_dof_table, col_dof_table)
 end
 function matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
@@ -801,7 +797,9 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
     @_propagate_inbounds_meta
     @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
 
-    (; matrix, storage, storage_row_dof_table, storage_col_dof_table, row_parent_indices, col_parent_indices, sparsity_radius) = assembler
+    (; matrix, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    storage = matrix_storage(matrix)
+    row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
     (; values, node_colstarts, key) = buffer
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
 
@@ -815,14 +813,14 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
         neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
         matrix_neighboring_rows = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
         for b in 1:col_ndofs
-            col = storage_col_dof_table[col_parent_indices[b],col_node]
+            col = storage_col_dof_table[col_storage_indices[b],col_node]
             matrix_col_start = first(nzrange(storage, col))
             for (local_row, local_row_node) in enumerate(neighboring_rows)
                 local_slot = node_colstarts[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
                 row_node = local_row_node + first_row_node - oneunit(first_row_node)
                 matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
                 matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * storage_row_ndofs
-                scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, row_parent_indices, row_ndofs)
+                scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, row_storage_indices, row_ndofs)
             end
         end
     end
@@ -839,9 +837,9 @@ end
     nothing
 end
 
-@inline function scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, row_parent_indices, row_ndofs)
+@inline function scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, row_storage_indices, row_ndofs)
     @inbounds for a in 1:row_ndofs
-        matrix_values[matrix_slot + row_parent_indices[a] - 1] += values[local_slot]
+        matrix_values[matrix_slot + row_storage_indices[a] - 1] += values[local_slot]
         local_slot += 1
     end
     nothing

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -299,6 +299,36 @@ function _add!(A::SparseMatrixCSC, I::AbstractVector{Int}, J::AbstractVector{Int
     A
 end
 
+function fillzero!(matrix::SubArray{T,2,P}) where {T,P <: SparseMatrixCSC}
+    selected_rows, selected_cols = parentindices(matrix)
+    sorted_rows = issorted(selected_rows) ? selected_rows : sort(selected_rows)
+    fillzero_sparse_matrix_view!(parent(matrix), sorted_rows, selected_cols)
+    matrix
+end
+
+function fillzero_sparse_matrix_view!(matrix::SparseMatrixCSC, selected_rows, selected_cols)
+    rows = rowvals(matrix)
+    values = nonzeros(matrix)
+    zero_value = zero_recursive(eltype(values))
+    @inbounds for col in selected_cols
+        slots = nzrange(matrix, col)
+        isempty(slots) && continue
+        selected_index = searchsortedfirst(selected_rows, rows[first(slots)])
+        selected_stop = lastindex(selected_rows)
+        for slot in slots
+            row = rows[slot]
+            while selected_index ≤ selected_stop && selected_rows[selected_index] < row
+                selected_index += 1
+            end
+            selected_index > selected_stop && break
+            if selected_rows[selected_index] == row
+                values[slot] = zero_value
+            end
+        end
+    end
+    matrix
+end
+
 function add!(A::AbstractMatrix, I::AbstractVector{Int}, J::AbstractVector{Int}, K::AbstractMatrix)
     @boundscheck checkbounds(A, I, J)
     @assert issorted(I)
@@ -330,7 +360,9 @@ end
 
 # ---- CartesianSparseMatrixAssembler ----
 
-struct CartesianSparseMatrixAssembler{A <: SparseMatrixCSC, R <: LinearIndices, C <: LinearIndices}
+abstract type AbstractCartesianSparseMatrixAssembler end
+
+struct CartesianSparseMatrixAssembler{A <: SparseMatrixCSC, R <: LinearIndices, C <: LinearIndices} <: AbstractCartesianSparseMatrixAssembler
     matrix::A
     row_dof_table::R
     col_dof_table::C
@@ -412,7 +444,7 @@ end
     matrix
 end
 
-@noinline function check_cartesian_matrix_entry(assembler::CartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
+@noinline function check_cartesian_matrix_entry(assembler::AbstractCartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
     (; row_dof_table, col_dof_table, sparsity_radius) = assembler
     mesh_size = Base.tail(size(row_dof_table))
     mesh_nodes = CartesianIndices(mesh_size)
@@ -421,6 +453,129 @@ end
     row_node ∈ cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius) || throw(ArgumentError("matrix entry is outside the Cartesian sparsity pattern"))
     check_matrix_entry_size(value, size(row_dof_table, 1), size(col_dof_table, 1))
     nothing
+end
+
+# ---- CartesianSparseMatrixViewAssembler ----
+
+struct CartesianSparseMatrixViewAssembler{V <: SubArray, A <: CartesianSparseMatrixAssembler, R <: LinearIndices, C <: LinearIndices, RI, CI} <: AbstractCartesianSparseMatrixAssembler
+    matrix::V
+    parent_assembler::A
+    row_dof_table::R
+    col_dof_table::C
+    row_parent_indices::RI
+    col_parent_indices::CI
+    sparsity_radius::Int
+end
+
+function CartesianSparseMatrixViewAssembler(matrix::SubArray{T,2,P}, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {T,P <: SparseMatrixCSC,N}
+    parent_assembler = CartesianSparseMatrixAssembler(parent(matrix), row_mesh, col_mesh, row_basis, col_basis)
+    row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
+    row_parent_indices, col_parent_indices = parentindices(matrix)
+    assembler = CartesianSparseMatrixViewAssembler(
+        matrix,
+        parent_assembler,
+        row_dof_table,
+        col_dof_table,
+        row_parent_indices,
+        col_parent_indices,
+        parent_assembler.sparsity_radius,
+    )
+    check_cartesian_sparse_matrix_view(assembler)
+    assembler
+end
+
+@noinline function check_cartesian_sparse_matrix_view(assembler::CartesianSparseMatrixViewAssembler)
+    (; parent_assembler, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
+    check_cartesian_sparse_matrix_view_indices(row_parent_indices, row_dof_table, parent_assembler.row_dof_table)
+    check_cartesian_sparse_matrix_view_indices(col_parent_indices, col_dof_table, parent_assembler.col_dof_table)
+    nothing
+end
+
+@noinline function check_cartesian_sparse_matrix_view_indices(parent_indices, dof_table, parent_dof_table)
+    ndofs = size(dof_table, 1)
+    parent_ndofs = size(parent_dof_table, 1)
+    mesh_nodes = CartesianIndices(Base.tail(size(dof_table)))
+    first_node = first(mesh_nodes)
+    for a in 1:ndofs
+        component = parent_indices[dof_table[a,first_node]]
+        component in 1:parent_ndofs || throw(ArgumentError("matrix view must select the same DoF components at every node"))
+        all(parent_indices[dof_table[b,first_node]] != component for b in 1:a-1) || throw(ArgumentError("matrix view must not select a DoF component more than once"))
+        all(parent_indices[dof_table[a,node]] == parent_dof_table[component,node] for node in mesh_nodes) || throw(ArgumentError("matrix view must select the same DoF components at every node"))
+    end
+    nothing
+end
+
+# The view selects fixed DoF components at every node, so parent CSC slots are
+# computed from those components without accessing the view indexing interface.
+@inline function add_entry!(assembler::CartesianSparseMatrixViewAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
+    @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
+
+    (; parent_assembler, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices, sparsity_radius) = assembler
+    matrix = parent_assembler.matrix
+    parent_row_dof_table = parent_assembler.row_dof_table
+    parent_col_dof_table = parent_assembler.col_dof_table
+    mesh_size = Base.tail(size(row_dof_table))
+    row_ndofs = size(row_dof_table, 1)
+    col_ndofs = size(col_dof_table, 1)
+    parent_row_ndofs = size(parent_row_dof_table, 1)
+    neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
+
+    neighboring_node = row_node - first(neighboring_nodes) + oneunit(row_node)
+    row_offset = (LinearIndices(neighboring_nodes)[neighboring_node] - 1) * parent_row_ndofs
+    values = nonzeros(matrix)
+
+    @inbounds for b in 1:col_ndofs
+        col = parent_col_dof_table[col_parent_indices[b],col_node]
+        slot = first(nzrange(matrix, col)) + row_offset
+        for a in 1:row_ndofs
+            values[slot + row_parent_indices[a] - 1] += value[(b - 1) * row_ndofs + a]
+        end
+    end
+
+    assembler.matrix
+end
+
+# ---- SparseMatrixViewAssembler ----
+
+struct SparseMatrixViewAssembler{V <: SubArray, A <: SparseMatrixCSC, R <: LinearIndices, C <: LinearIndices, RI, CI}
+    matrix::V
+    parent::A
+    row_dof_table::R
+    col_dof_table::C
+    row_parent_indices::RI
+    col_parent_indices::CI
+end
+
+function SparseMatrixViewAssembler(matrix::SubArray{T,2,P}, row_mesh, col_mesh) where {T,P <: SparseMatrixCSC}
+    row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
+    row_parent_indices, col_parent_indices = parentindices(matrix)
+    SparseMatrixViewAssembler(matrix, parent(matrix), row_dof_table, col_dof_table, row_parent_indices, col_parent_indices)
+end
+
+function add!(assembler::SparseMatrixViewAssembler, row_nodes, col_nodes, local_matrix)
+    @_propagate_inbounds_meta
+    (; matrix, parent, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
+    row_dofs, col_dofs = support_dofs(row_dof_table, row_nodes, col_dof_table, col_nodes)
+    if row_dofs === col_dofs && row_parent_indices === col_parent_indices
+        parent_dofs = row_parent_indices[row_dofs]
+        add!(parent, parent_dofs, parent_dofs, local_matrix)
+    else
+        add!(parent, row_parent_indices[row_dofs], col_parent_indices[col_dofs], local_matrix)
+    end
+    matrix
+end
+
+@inline function add_entry!(assembler::SparseMatrixViewAssembler, row_node, col_node, value)
+    (; matrix, parent, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
+    row_ndofs = size(row_dof_table, 1)
+    col_ndofs = size(col_dof_table, 1)
+    @boundscheck check_matrix_entry_size(value, row_ndofs, col_ndofs)
+    @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
+        row = row_parent_indices[row_dof_table[a,row_node]]
+        col = col_parent_indices[col_dof_table[b,col_node]]
+        parent[row,col] += value[(b - 1) * row_ndofs + a]
+    end
+    matrix
 end
 
 # ---- GenericMatrixAssembler ----
@@ -466,8 +621,14 @@ function matrix_assembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
     GenericMatrixAssembler(matrix, row_dof_table, col_dof_table)
 end
+function matrix_assembler(matrix::SubArray{T,2,P}, row_mesh, col_mesh, row_basis, col_basis) where {T,P <: SparseMatrixCSC}
+    SparseMatrixViewAssembler(matrix, row_mesh, col_mesh)
+end
 function matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
+end
+function matrix_assembler(matrix::SubArray{T,2,P}, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis) where {T,P <: SparseMatrixCSC}
+    CartesianSparseMatrixViewAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 end
 
 function matrix_dof_tables(gmat, row_grid, col_grid)
@@ -576,7 +737,7 @@ struct BlockMatrixBuffer{T,N}
     key::BlockMatrixBufferKey{T,N}
 end
 
-function BlockMatrixBufferKey(assembler::CartesianSparseMatrixAssembler, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {N}
+function BlockMatrixBufferKey(assembler::AbstractCartesianSparseMatrixAssembler, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {N}
     (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
     BlockMatrixBufferKey{eltype(matrix),N}(
         size(row_nodes),
@@ -622,14 +783,15 @@ end
 
 # ---- block buffer selection ----
 
-# Canonical Cartesian CSC matrices use a block buffer. Matrices using
-# GenericMatrixAssembler are written directly within the thread-safe block schedule.
-function block_matrix_buffer(assembler::CartesianSparseMatrixAssembler, assembly::BlockAssembly, orientation)
+# Canonical Cartesian CSC matrices and their component views use a block buffer.
+# Other matrices are written directly within the thread-safe block schedule.
+function block_matrix_buffer(assembler::AbstractCartesianSparseMatrixAssembler, assembly::BlockAssembly, orientation)
     row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
     acquire!(assembly.matrix_buffer_pool, BlockMatrixBufferKey(assembler, row_nodes, col_nodes))
 end
 
 block_matrix_buffer(::GenericMatrixAssembler, ::BlockAssembly, orientation) = nothing
+block_matrix_buffer(::SparseMatrixViewAssembler, ::BlockAssembly, orientation) = nothing
 
 # ---- assembly ----
 
@@ -708,7 +870,46 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
     matrix
 end
 
-@noinline function check_block_matrix_scatter(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, row_nodes::CartesianIndices, col_nodes::CartesianIndices)
+function scatter!(assembler::CartesianSparseMatrixViewAssembler, buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {T,N}
+    @_propagate_inbounds_meta
+    @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
+
+    (; matrix, parent_assembler, row_parent_indices, col_parent_indices, sparsity_radius) = assembler
+    parent_matrix = parent_assembler.matrix
+    parent_row_dof_table = parent_assembler.row_dof_table
+    parent_col_dof_table = parent_assembler.col_dof_table
+    (; values, node_colstarts, key) = buffer
+    (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
+
+    mesh_size = Base.tail(size(parent_row_dof_table))
+    parent_row_ndofs = size(parent_row_dof_table, 1)
+    matrix_values = nonzeros(parent_matrix)
+    first_row_node = first(row_nodes)
+    first_col_node = first(col_nodes)
+    for (local_col, local_col_node) in enumerate(CartesianIndices(col_size))
+        col_node = local_col_node + first_col_node - oneunit(first_col_node)
+        neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
+        matrix_neighboring_rows = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
+        for b in 1:col_ndofs
+            col = parent_col_dof_table[col_parent_indices[b],col_node]
+            matrix_col_start = first(nzrange(parent_matrix, col))
+            for (local_row, local_row_node) in enumerate(neighboring_rows)
+                local_slot = node_colstarts[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
+                row_node = local_row_node + first_row_node - oneunit(first_row_node)
+                matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
+                matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * parent_row_ndofs
+                for a in 1:row_ndofs
+                    matrix_values[matrix_slot + row_parent_indices[a] - 1] += values[local_slot]
+                    local_slot += 1
+                end
+            end
+        end
+    end
+
+    matrix
+end
+
+@noinline function check_block_matrix_scatter(assembler::AbstractCartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, row_nodes::CartesianIndices, col_nodes::CartesianIndices)
     (; row_dof_table, col_dof_table, sparsity_radius) = assembler
     (; key) = buffer
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
@@ -727,7 +928,7 @@ end
 end
 
 # Canonical Cartesian CSC entries are accumulated in the block buffer.
-function assemble_block_entry!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation, row_node, col_node, value)
+function assemble_block_entry!(assembler::AbstractCartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation, row_node, col_node, value)
     @_propagate_inbounds_meta
     row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
     row_node, col_node = orientation((row_node, col_node))
@@ -741,7 +942,13 @@ function assemble_block_entry!(assembler::GenericMatrixAssembler, ::Nothing, ass
     add_entry!(assembler, row_node, col_node, orient_matrix_entry(orientation, value))
 end
 
-function finish_block_assembly!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation)
+function assemble_block_entry!(assembler::SparseMatrixViewAssembler, ::Nothing, assembly::BlockAssembly, orientation, row_node, col_node, value)
+    @_propagate_inbounds_meta
+    row_node, col_node = orientation((row_node, col_node))
+    add_entry!(assembler, row_node, col_node, orient_matrix_entry(orientation, value))
+end
+
+function finish_block_assembly!(assembler::AbstractCartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation)
     @_propagate_inbounds_meta
     row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
     try
@@ -752,6 +959,10 @@ function finish_block_assembly!(assembler::CartesianSparseMatrixAssembler, buffe
 end
 
 function finish_block_assembly!(assembler::GenericMatrixAssembler, ::Nothing, assembly::BlockAssembly, orientation)
+    assembler.matrix
+end
+
+function finish_block_assembly!(assembler::SparseMatrixViewAssembler, ::Nothing, assembly::BlockAssembly, orientation)
     assembler.matrix
 end
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -360,12 +360,17 @@ end
 
 # ---- CartesianSparseMatrixAssembler ----
 
-abstract type AbstractCartesianSparseMatrixAssembler end
-
-struct CartesianSparseMatrixAssembler{A <: SparseMatrixCSC, R <: LinearIndices, C <: LinearIndices} <: AbstractCartesianSparseMatrixAssembler
-    matrix::A
+# `matrix` is the logical destination and `storage` is its canonical CSC
+# storage. They are identical for a plain CSC; a view uses its parent CSC.
+struct CartesianSparseMatrixAssembler{M <: AbstractMatrix, S <: SparseMatrixCSC, R <: LinearIndices, C <: LinearIndices, SR <: LinearIndices, SC <: LinearIndices, RI, CI}
+    matrix::M
+    storage::S
     row_dof_table::R
     col_dof_table::C
+    storage_row_dof_table::SR
+    storage_col_dof_table::SC
+    row_parent_indices::RI
+    col_parent_indices::CI
     sparsity_radius::Int
 end
 
@@ -379,7 +384,17 @@ function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, spa
     sparsity_radius ≥ 0 || throw(ArgumentError("sparsity radius must be nonnegative"))
     row_dof_table = LinearIndices((row_dofs_per_node, mesh_size...))
     col_dof_table = LinearIndices((col_dofs_per_node, mesh_size...))
-    assembler = CartesianSparseMatrixAssembler(A, row_dof_table, col_dof_table, sparsity_radius)
+    assembler = CartesianSparseMatrixAssembler(
+        A,
+        A,
+        row_dof_table,
+        col_dof_table,
+        row_dof_table,
+        col_dof_table,
+        axes(row_dof_table, 1),
+        axes(col_dof_table, 1),
+        sparsity_radius,
+    )
     has_cartesian_sparse_pattern(assembler) || throw(ArgumentError("Cartesian sparse matrix must use the canonical sparsity pattern"))
     assembler
 end
@@ -398,19 +413,19 @@ function cartesian_neighbor_nodes(node::CartesianIndex{N}, mesh_size::Dims{N}, s
 end
 
 function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
-    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
-    mesh_size = Base.tail(size(row_dof_table))
-    row_dofs_per_node = size(row_dof_table, 1)
-    col_dofs_per_node = size(col_dof_table, 1)
-    rows = rowvals(matrix)
+    (; storage, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    mesh_size = Base.tail(size(storage_row_dof_table))
+    row_dofs_per_node = size(storage_row_dof_table, 1)
+    col_dofs_per_node = size(storage_col_dof_table, 1)
+    rows = rowvals(storage)
     for col_node in CartesianIndices(mesh_size), b in 1:col_dofs_per_node
-        col = col_dof_table[b, col_node]
-        indices = nzrange(matrix, col)
+        col = storage_col_dof_table[b, col_node]
+        indices = nzrange(storage, col)
         k = first(indices)
         stop = last(indices) + 1
         for row_node in cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius), a in 1:row_dofs_per_node
             k < stop || return false
-            rows[k] == row_dof_table[a, row_node] || return false
+            rows[k] == storage_row_dof_table[a, row_node] || return false
             k += 1
         end
         k == stop || return false
@@ -422,29 +437,29 @@ end
 @inline function add_entry!(assembler::CartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
     @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
 
-    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
+    (; matrix, storage, row_dof_table, col_dof_table, storage_row_dof_table, storage_col_dof_table, row_parent_indices, col_parent_indices, sparsity_radius) = assembler
     mesh_size = Base.tail(size(row_dof_table))
     row_ndofs = size(row_dof_table, 1)
     col_ndofs = size(col_dof_table, 1)
+    storage_row_ndofs = size(storage_row_dof_table, 1)
     neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
 
     neighboring_node = row_node - first(neighboring_nodes) + oneunit(row_node)
-    row_offset = (LinearIndices(neighboring_nodes)[neighboring_node] - 1) * row_ndofs
-    values = nonzeros(matrix)
+    row_offset = (LinearIndices(neighboring_nodes)[neighboring_node] - 1) * storage_row_ndofs
+    values = nonzeros(storage)
 
     @inbounds for b in 1:col_ndofs
-        col = col_dof_table[b, col_node]
-        slot = first(nzrange(matrix, col)) + row_offset
+        col = storage_col_dof_table[col_parent_indices[b],col_node]
+        slot = first(nzrange(storage, col)) + row_offset
         for a in 1:row_ndofs
-            values[slot] += value[(b - 1) * row_ndofs + a]
-            slot += 1
+            values[slot + row_parent_indices[a] - 1] += value[(b - 1) * row_ndofs + a]
         end
     end
 
     matrix
 end
 
-@noinline function check_cartesian_matrix_entry(assembler::AbstractCartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
+@noinline function check_cartesian_matrix_entry(assembler::CartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
     (; row_dof_table, col_dof_table, sparsity_radius) = assembler
     mesh_size = Base.tail(size(row_dof_table))
     mesh_nodes = CartesianIndices(mesh_size)
@@ -455,39 +470,29 @@ end
     nothing
 end
 
-# ---- CartesianSparseMatrixViewAssembler ----
-
-struct CartesianSparseMatrixViewAssembler{V <: SubArray, A <: CartesianSparseMatrixAssembler, R <: LinearIndices, C <: LinearIndices, RI, CI} <: AbstractCartesianSparseMatrixAssembler
-    matrix::V
-    parent_assembler::A
-    row_dof_table::R
-    col_dof_table::C
-    row_parent_indices::RI
-    col_parent_indices::CI
-    sparsity_radius::Int
-end
-
-function CartesianSparseMatrixViewAssembler(matrix::SubArray{T,2,P}, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {T,P <: SparseMatrixCSC,N}
-    parent_assembler = CartesianSparseMatrixAssembler(parent(matrix), row_mesh, col_mesh, row_basis, col_basis)
+function CartesianSparseMatrixAssembler(matrix::SubArray{T,2,P}, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {T,P <: SparseMatrixCSC,N}
+    storage_assembler = CartesianSparseMatrixAssembler(parent(matrix), row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
     row_parent_indices, col_parent_indices = parentindices(matrix)
-    assembler = CartesianSparseMatrixViewAssembler(
+    assembler = CartesianSparseMatrixAssembler(
         matrix,
-        parent_assembler,
+        storage_assembler.storage,
         row_dof_table,
         col_dof_table,
+        storage_assembler.storage_row_dof_table,
+        storage_assembler.storage_col_dof_table,
         row_parent_indices,
         col_parent_indices,
-        parent_assembler.sparsity_radius,
+        storage_assembler.sparsity_radius,
     )
     check_cartesian_sparse_matrix_view(assembler)
     assembler
 end
 
-@noinline function check_cartesian_sparse_matrix_view(assembler::CartesianSparseMatrixViewAssembler)
-    (; parent_assembler, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
-    check_cartesian_sparse_matrix_view_indices(row_parent_indices, row_dof_table, parent_assembler.row_dof_table)
-    check_cartesian_sparse_matrix_view_indices(col_parent_indices, col_dof_table, parent_assembler.col_dof_table)
+@noinline function check_cartesian_sparse_matrix_view(assembler::CartesianSparseMatrixAssembler)
+    (; row_dof_table, col_dof_table, storage_row_dof_table, storage_col_dof_table, row_parent_indices, col_parent_indices) = assembler
+    check_cartesian_sparse_matrix_view_indices(row_parent_indices, row_dof_table, storage_row_dof_table)
+    check_cartesian_sparse_matrix_view_indices(col_parent_indices, col_dof_table, storage_col_dof_table)
     nothing
 end
 
@@ -498,111 +503,68 @@ end
     first_node = first(mesh_nodes)
     for a in 1:ndofs
         component = parent_indices[dof_table[a,first_node]]
-        component in 1:parent_ndofs || throw(ArgumentError("matrix view must select the same DoF components at every node"))
+        component ∈ 1:parent_ndofs || throw(ArgumentError("matrix view must select the same DoF components at every node"))
         all(parent_indices[dof_table[b,first_node]] != component for b in 1:a-1) || throw(ArgumentError("matrix view must not select a DoF component more than once"))
         all(parent_indices[dof_table[a,node]] == parent_dof_table[component,node] for node in mesh_nodes) || throw(ArgumentError("matrix view must select the same DoF components at every node"))
     end
     nothing
 end
 
-# The view selects fixed DoF components at every node, so parent CSC slots are
-# computed from those components without accessing the view indexing interface.
-@inline function add_entry!(assembler::CartesianSparseMatrixViewAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
-    @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
+# ---- GenericMatrixAssembler ----
 
-    (; parent_assembler, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices, sparsity_radius) = assembler
-    matrix = parent_assembler.matrix
-    parent_row_dof_table = parent_assembler.row_dof_table
-    parent_col_dof_table = parent_assembler.col_dof_table
-    mesh_size = Base.tail(size(row_dof_table))
-    row_ndofs = size(row_dof_table, 1)
-    col_ndofs = size(col_dof_table, 1)
-    parent_row_ndofs = size(parent_row_dof_table, 1)
-    neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
-
-    neighboring_node = row_node - first(neighboring_nodes) + oneunit(row_node)
-    row_offset = (LinearIndices(neighboring_nodes)[neighboring_node] - 1) * parent_row_ndofs
-    values = nonzeros(matrix)
-
-    @inbounds for b in 1:col_ndofs
-        col = parent_col_dof_table[col_parent_indices[b],col_node]
-        slot = first(nzrange(matrix, col)) + row_offset
-        for a in 1:row_ndofs
-            values[slot + row_parent_indices[a] - 1] += value[(b - 1) * row_ndofs + a]
-        end
-    end
-
-    assembler.matrix
-end
-
-# ---- SparseMatrixViewAssembler ----
-
-struct SparseMatrixViewAssembler{V <: SubArray, A <: SparseMatrixCSC, R <: LinearIndices, C <: LinearIndices, RI, CI}
-    matrix::V
-    parent::A
+struct GenericMatrixAssembler{M <: AbstractMatrix, S <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices, RI, CI}
+    matrix::M
+    storage::S
     row_dof_table::R
     col_dof_table::C
     row_parent_indices::RI
     col_parent_indices::CI
 end
 
-function SparseMatrixViewAssembler(matrix::SubArray{T,2,P}, row_mesh, col_mesh) where {T,P <: SparseMatrixCSC}
-    row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
-    row_parent_indices, col_parent_indices = parentindices(matrix)
-    SparseMatrixViewAssembler(matrix, parent(matrix), row_dof_table, col_dof_table, row_parent_indices, col_parent_indices)
-end
-
-function add!(assembler::SparseMatrixViewAssembler, row_nodes, col_nodes, local_matrix)
+function add!(assembler::GenericMatrixAssembler, row_nodes, col_nodes, local_matrix)
     @_propagate_inbounds_meta
-    (; matrix, parent, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
+    (; matrix, storage, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
     row_dofs, col_dofs = support_dofs(row_dof_table, row_nodes, col_dof_table, col_nodes)
     if row_dofs === col_dofs && row_parent_indices === col_parent_indices
-        parent_dofs = row_parent_indices[row_dofs]
-        add!(parent, parent_dofs, parent_dofs, local_matrix)
+        dofs = storage_dofs(row_parent_indices, row_dofs)
+        add!(storage, dofs, dofs, local_matrix)
     else
-        add!(parent, row_parent_indices[row_dofs], col_parent_indices[col_dofs], local_matrix)
+        add!(storage, storage_dofs(row_parent_indices, row_dofs), storage_dofs(col_parent_indices, col_dofs), local_matrix)
     end
     matrix
 end
 
-@inline function add_entry!(assembler::SparseMatrixViewAssembler, row_node, col_node, value)
-    (; matrix, parent, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
+# GenericMatrixAssembler writes entries through the storage indexing interface.
+@inline function add_entry!(assembler::GenericMatrixAssembler, row_node, col_node, value)
+    (; matrix, storage, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices) = assembler
     row_ndofs = size(row_dof_table, 1)
     col_ndofs = size(col_dof_table, 1)
     @boundscheck check_matrix_entry_size(value, row_ndofs, col_ndofs)
+    @inbounds add_matrix_entry!(storage, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices, row_node, col_node, value, row_ndofs, col_ndofs)
+    matrix
+end
+
+@inline function add_matrix_entry!(storage, row_dof_table, col_dof_table, ::Base.OneTo, ::Base.OneTo, row_node, col_node, value, row_ndofs, col_ndofs)
+    @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
+        storage[row_dof_table[a,row_node], col_dof_table[b,col_node]] += value[(b - 1) * row_ndofs + a]
+    end
+    nothing
+end
+
+@inline function add_matrix_entry!(storage, row_dof_table, col_dof_table, row_parent_indices, col_parent_indices, row_node, col_node, value, row_ndofs, col_ndofs)
     @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
         row = row_parent_indices[row_dof_table[a,row_node]]
         col = col_parent_indices[col_dof_table[b,col_node]]
-        parent[row,col] += value[(b - 1) * row_ndofs + a]
+        storage[row,col] += value[(b - 1) * row_ndofs + a]
     end
-    matrix
+    nothing
 end
 
-# ---- GenericMatrixAssembler ----
+storage_dofs(::Base.OneTo, dofs) = dofs
 
-struct GenericMatrixAssembler{A <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices}
-    matrix::A
-    row_dof_table::R
-    col_dof_table::C
-end
-
-function add!(assembler::GenericMatrixAssembler, row_nodes, col_nodes, local_matrix)
+function storage_dofs(parent_indices, dofs)
     @_propagate_inbounds_meta
-    (; matrix, row_dof_table, col_dof_table) = assembler
-    row_dofs, col_dofs = support_dofs(row_dof_table, row_nodes, col_dof_table, col_nodes)
-    add!(matrix, row_dofs, col_dofs, local_matrix)
-end
-
-# GenericMatrixAssembler writes entries through the matrix indexing interface.
-@inline function add_entry!(assembler::GenericMatrixAssembler, row_node, col_node, value)
-    (; matrix, row_dof_table, col_dof_table) = assembler
-    row_ndofs = size(row_dof_table, 1)
-    col_ndofs = size(col_dof_table, 1)
-    @boundscheck check_matrix_entry_size(value, row_ndofs, col_ndofs)
-    @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
-        matrix[row_dof_table[a,row_node], col_dof_table[b,col_node]] += value[(b - 1) * row_ndofs + a]
-    end
-    matrix
+    parent_indices[dofs]
 end
 
 function support_dofs(table_i, nodes_i, table_j, nodes_j)
@@ -619,16 +581,18 @@ end
 
 function matrix_assembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
-    GenericMatrixAssembler(matrix, row_dof_table, col_dof_table)
+    GenericMatrixAssembler(matrix, matrix, row_dof_table, col_dof_table, axes(matrix, 1), axes(matrix, 2))
 end
 function matrix_assembler(matrix::SubArray{T,2,P}, row_mesh, col_mesh, row_basis, col_basis) where {T,P <: SparseMatrixCSC}
-    SparseMatrixViewAssembler(matrix, row_mesh, col_mesh)
+    row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
+    row_parent_indices, col_parent_indices = parentindices(matrix)
+    GenericMatrixAssembler(matrix, parent(matrix), row_dof_table, col_dof_table, row_parent_indices, col_parent_indices)
 end
 function matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 end
 function matrix_assembler(matrix::SubArray{T,2,P}, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis) where {T,P <: SparseMatrixCSC}
-    CartesianSparseMatrixViewAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
+    CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 end
 
 function matrix_dof_tables(gmat, row_grid, col_grid)
@@ -737,7 +701,7 @@ struct BlockMatrixBuffer{T,N}
     key::BlockMatrixBufferKey{T,N}
 end
 
-function BlockMatrixBufferKey(assembler::AbstractCartesianSparseMatrixAssembler, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {N}
+function BlockMatrixBufferKey(assembler::CartesianSparseMatrixAssembler, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {N}
     (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
     BlockMatrixBufferKey{eltype(matrix),N}(
         size(row_nodes),
@@ -785,13 +749,12 @@ end
 
 # Canonical Cartesian CSC matrices and their component views use a block buffer.
 # Other matrices are written directly within the thread-safe block schedule.
-function block_matrix_buffer(assembler::AbstractCartesianSparseMatrixAssembler, assembly::BlockAssembly, orientation)
+function block_matrix_buffer(assembler::CartesianSparseMatrixAssembler, assembly::BlockAssembly, orientation)
     row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
     acquire!(assembly.matrix_buffer_pool, BlockMatrixBufferKey(assembler, row_nodes, col_nodes))
 end
 
 block_matrix_buffer(::GenericMatrixAssembler, ::BlockAssembly, orientation) = nothing
-block_matrix_buffer(::SparseMatrixViewAssembler, ::BlockAssembly, orientation) = nothing
 
 # ---- assembly ----
 
@@ -838,12 +801,13 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
     @_propagate_inbounds_meta
     @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
 
-    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
+    (; matrix, storage, storage_row_dof_table, storage_col_dof_table, row_parent_indices, col_parent_indices, sparsity_radius) = assembler
     (; values, node_colstarts, key) = buffer
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
 
-    mesh_size = Base.tail(size(row_dof_table))
-    matrix_values = nonzeros(matrix)
+    mesh_size = Base.tail(size(storage_row_dof_table))
+    storage_row_ndofs = size(storage_row_dof_table, 1)
+    matrix_values = nonzeros(storage)
     first_row_node = first(row_nodes)
     first_col_node = first(col_nodes)
     for (local_col, local_col_node) in enumerate(CartesianIndices(col_size))
@@ -851,18 +815,14 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
         neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
         matrix_neighboring_rows = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
         for b in 1:col_ndofs
-            col = col_dof_table[b,col_node]
-            matrix_col_start = first(nzrange(matrix, col))
+            col = storage_col_dof_table[col_parent_indices[b],col_node]
+            matrix_col_start = first(nzrange(storage, col))
             for (local_row, local_row_node) in enumerate(neighboring_rows)
                 local_slot = node_colstarts[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
                 row_node = local_row_node + first_row_node - oneunit(first_row_node)
                 matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
-                matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * row_ndofs
-                for _ in 1:row_ndofs
-                    matrix_values[matrix_slot] += values[local_slot]
-                    matrix_slot += 1
-                    local_slot += 1
-                end
+                matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * storage_row_ndofs
+                scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, row_parent_indices, row_ndofs)
             end
         end
     end
@@ -870,46 +830,24 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
     matrix
 end
 
-function scatter!(assembler::CartesianSparseMatrixViewAssembler, buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {T,N}
-    @_propagate_inbounds_meta
-    @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
-
-    (; matrix, parent_assembler, row_parent_indices, col_parent_indices, sparsity_radius) = assembler
-    parent_matrix = parent_assembler.matrix
-    parent_row_dof_table = parent_assembler.row_dof_table
-    parent_col_dof_table = parent_assembler.col_dof_table
-    (; values, node_colstarts, key) = buffer
-    (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
-
-    mesh_size = Base.tail(size(parent_row_dof_table))
-    parent_row_ndofs = size(parent_row_dof_table, 1)
-    matrix_values = nonzeros(parent_matrix)
-    first_row_node = first(row_nodes)
-    first_col_node = first(col_nodes)
-    for (local_col, local_col_node) in enumerate(CartesianIndices(col_size))
-        col_node = local_col_node + first_col_node - oneunit(first_col_node)
-        neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
-        matrix_neighboring_rows = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
-        for b in 1:col_ndofs
-            col = parent_col_dof_table[col_parent_indices[b],col_node]
-            matrix_col_start = first(nzrange(parent_matrix, col))
-            for (local_row, local_row_node) in enumerate(neighboring_rows)
-                local_slot = node_colstarts[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
-                row_node = local_row_node + first_row_node - oneunit(first_row_node)
-                matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
-                matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * parent_row_ndofs
-                for a in 1:row_ndofs
-                    matrix_values[matrix_slot + row_parent_indices[a] - 1] += values[local_slot]
-                    local_slot += 1
-                end
-            end
-        end
+@inline function scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, ::Base.OneTo, row_ndofs)
+    @inbounds for _ in 1:row_ndofs
+        matrix_values[matrix_slot] += values[local_slot]
+        matrix_slot += 1
+        local_slot += 1
     end
-
-    matrix
+    nothing
 end
 
-@noinline function check_block_matrix_scatter(assembler::AbstractCartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, row_nodes::CartesianIndices, col_nodes::CartesianIndices)
+@inline function scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, row_parent_indices, row_ndofs)
+    @inbounds for a in 1:row_ndofs
+        matrix_values[matrix_slot + row_parent_indices[a] - 1] += values[local_slot]
+        local_slot += 1
+    end
+    nothing
+end
+
+@noinline function check_block_matrix_scatter(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, row_nodes::CartesianIndices, col_nodes::CartesianIndices)
     (; row_dof_table, col_dof_table, sparsity_radius) = assembler
     (; key) = buffer
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
@@ -928,7 +866,7 @@ end
 end
 
 # Canonical Cartesian CSC entries are accumulated in the block buffer.
-function assemble_block_entry!(assembler::AbstractCartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation, row_node, col_node, value)
+function assemble_block_entry!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation, row_node, col_node, value)
     @_propagate_inbounds_meta
     row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
     row_node, col_node = orientation((row_node, col_node))
@@ -942,13 +880,7 @@ function assemble_block_entry!(assembler::GenericMatrixAssembler, ::Nothing, ass
     add_entry!(assembler, row_node, col_node, orient_matrix_entry(orientation, value))
 end
 
-function assemble_block_entry!(assembler::SparseMatrixViewAssembler, ::Nothing, assembly::BlockAssembly, orientation, row_node, col_node, value)
-    @_propagate_inbounds_meta
-    row_node, col_node = orientation((row_node, col_node))
-    add_entry!(assembler, row_node, col_node, orient_matrix_entry(orientation, value))
-end
-
-function finish_block_assembly!(assembler::AbstractCartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation)
+function finish_block_assembly!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation)
     @_propagate_inbounds_meta
     row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
     try
@@ -959,10 +891,6 @@ function finish_block_assembly!(assembler::AbstractCartesianSparseMatrixAssemble
 end
 
 function finish_block_assembly!(assembler::GenericMatrixAssembler, ::Nothing, assembly::BlockAssembly, orientation)
-    assembler.matrix
-end
-
-function finish_block_assembly!(assembler::SparseMatrixViewAssembler, ::Nothing, assembly::BlockAssembly, orientation)
     assembler.matrix
 end
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -358,6 +358,27 @@ end
         throw(DimensionMismatch("matrix value is incompatible with matrix entry dimensions"))
 end
 
+storage_index(::Base.OneTo, index) = index
+
+function storage_index(indices, index)
+    @_propagate_inbounds_meta
+    indices[index]
+end
+
+function add_entry_values!(destination, destination_slot, source, source_slot, storage_indices, count)
+    @_propagate_inbounds_meta
+    @inbounds for index in 1:count
+        destination[destination_slot + storage_index(storage_indices, index) - 1] += source[source_slot]
+        source_slot += 1
+    end
+    nothing
+end
+
+function add_entry_values!(destination, destination_slot, source)
+    @_propagate_inbounds_meta
+    add_entry_values!(destination, destination_slot, source, firstindex(source), Base.OneTo(length(source)), length(source))
+end
+
 # ---- CartesianSparseMatrixAssembler ----
 
 # `matrix` is the logical destination. A plain CSC stores values itself, while
@@ -454,9 +475,7 @@ end
     @inbounds for b in 1:col_ndofs
         col = storage_col_dof_table[col_storage_indices[b],col_node]
         slot = first(nzrange(storage, col)) + row_offset
-        for a in 1:row_ndofs
-            values[slot + row_storage_indices[a] - 1] += value[(b - 1) * row_ndofs + a]
-        end
+        add_entry_values!(values, slot, value, (b - 1) * row_ndofs + 1, row_storage_indices, row_ndofs)
     end
 
     matrix
@@ -545,17 +564,10 @@ end
     matrix
 end
 
-@inline function add_matrix_entry!(storage, row_dof_table, col_dof_table, ::Base.OneTo, ::Base.OneTo, row_node, col_node, value, row_ndofs, col_ndofs)
-    @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
-        storage[row_dof_table[a,row_node], col_dof_table[b,col_node]] += value[(b - 1) * row_ndofs + a]
-    end
-    nothing
-end
-
 @inline function add_matrix_entry!(storage, row_dof_table, col_dof_table, row_storage_indices, col_storage_indices, row_node, col_node, value, row_ndofs, col_ndofs)
     @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
-        row = row_storage_indices[row_dof_table[a,row_node]]
-        col = col_storage_indices[col_dof_table[b,col_node]]
+        row = storage_index(row_storage_indices, row_dof_table[a,row_node])
+        col = storage_index(col_storage_indices, col_dof_table[b,col_node])
         storage[row,col] += value[(b - 1) * row_ndofs + a]
     end
     nothing
@@ -769,10 +781,7 @@ function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{
     local_col = LinearIndices(col_size)[local_col_node]
 
     slot = node_colstarts[local_col] + (local_row - 1) * row_ndofs * col_ndofs
-    for index in eachindex(value)
-        values[slot] += value[index]
-        slot += 1
-    end
+    add_entry_values!(values, slot, value)
 
     buffer
 end
@@ -820,29 +829,12 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
                 row_node = local_row_node + first_row_node - oneunit(first_row_node)
                 matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
                 matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * storage_row_ndofs
-                scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, row_storage_indices, row_ndofs)
+                add_entry_values!(matrix_values, matrix_slot, values, local_slot, row_storage_indices, row_ndofs)
             end
         end
     end
 
     matrix
-end
-
-@inline function scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, ::Base.OneTo, row_ndofs)
-    @inbounds for _ in 1:row_ndofs
-        matrix_values[matrix_slot] += values[local_slot]
-        matrix_slot += 1
-        local_slot += 1
-    end
-    nothing
-end
-
-@inline function scatter_matrix_values!(matrix_values, matrix_slot, values, local_slot, row_storage_indices, row_ndofs)
-    @inbounds for a in 1:row_ndofs
-        matrix_values[matrix_slot + row_storage_indices[a] - 1] += values[local_slot]
-        local_slot += 1
-    end
-    nothing
 end
 
 @noinline function check_block_matrix_scatter(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, row_nodes::CartesianIndices, col_nodes::CartesianIndices)

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -299,36 +299,6 @@ function _add!(A::SparseMatrixCSC, I::AbstractVector{Int}, J::AbstractVector{Int
     A
 end
 
-function fillzero!(matrix::SubArray{T,2,P}) where {T,P <: SparseMatrixCSC}
-    selected_rows, selected_cols = parentindices(matrix)
-    sorted_rows = issorted(selected_rows) ? selected_rows : sort(selected_rows)
-    fillzero_sparse_matrix_view!(parent(matrix), sorted_rows, selected_cols)
-    matrix
-end
-
-function fillzero_sparse_matrix_view!(matrix::SparseMatrixCSC, selected_rows, selected_cols)
-    rows = rowvals(matrix)
-    values = nonzeros(matrix)
-    zero_value = zero_recursive(eltype(values))
-    @inbounds for col in selected_cols
-        slots = nzrange(matrix, col)
-        isempty(slots) && continue
-        selected_index = searchsortedfirst(selected_rows, rows[first(slots)])
-        selected_stop = lastindex(selected_rows)
-        for slot in slots
-            row = rows[slot]
-            while selected_index ≤ selected_stop && selected_rows[selected_index] < row
-                selected_index += 1
-            end
-            selected_index > selected_stop && break
-            if selected_rows[selected_index] == row
-                values[slot] = zero_value
-            end
-        end
-    end
-    matrix
-end
-
 function add!(A::AbstractMatrix, I::AbstractVector{Int}, J::AbstractVector{Int}, K::AbstractMatrix)
     @boundscheck checkbounds(A, I, J)
     @assert issorted(I)
@@ -354,26 +324,20 @@ end
         throw(DimensionMismatch("vector value is incompatible with matrix entry dimensions"))
 end
 @noinline function check_matrix_entry_size(value::AbstractMatrix, row_ndofs, col_ndofs)
-    size(value) == (row_ndofs, col_ndofs) ||
-        throw(DimensionMismatch("matrix value is incompatible with matrix entry dimensions"))
+    size(value) == (row_ndofs, col_ndofs) || throw(DimensionMismatch("matrix value is incompatible with matrix entry dimensions"))
 end
 
 storage_index(::Base.OneTo, index) = index
-
-function storage_index(indices, index)
-    @_propagate_inbounds_meta
-    indices[index]
-end
+storage_index(indices, index) = (@_propagate_inbounds_meta; indices[index])
 
 function add_entry_values!(destination, destination_slot, source, source_slot, storage_indices, count)
     @_propagate_inbounds_meta
-    @inbounds for index in 1:count
+    for index in 1:count
         destination[destination_slot + storage_index(storage_indices, index) - 1] += source[source_slot]
         source_slot += 1
     end
     nothing
 end
-
 function add_entry_values!(destination, destination_slot, source)
     @_propagate_inbounds_meta
     add_entry_values!(destination, destination_slot, source, firstindex(source), Base.OneTo(length(source)), length(source))
@@ -393,10 +357,10 @@ struct CartesianSparseMatrixAssembler{M <: AbstractMatrix, R <: LinearIndices, C
 end
 
 matrix_storage(matrix) = matrix
-matrix_storage(matrix::SubArray{T,2,P}) where {T,P <: SparseMatrixCSC} = parent(matrix)
+matrix_storage(matrix::SubArray{<: Any, 2, <: SparseMatrixCSC}) = parent(matrix)
 
 matrix_storage_indices(matrix) = axes(matrix)
-matrix_storage_indices(matrix::SubArray{T,2,P}) where {T,P <: SparseMatrixCSC} = parentindices(matrix)
+matrix_storage_indices(matrix::SubArray{<: Any, 2, <: SparseMatrixCSC}) = parentindices(matrix)
 
 function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, sparsity_radius::Int)
     node_count = prod(mesh_size)
@@ -492,7 +456,7 @@ end
     nothing
 end
 
-function CartesianSparseMatrixAssembler(matrix::SubArray{T,2,P}, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {T,P <: SparseMatrixCSC,N}
+function CartesianSparseMatrixAssembler(matrix::SubArray{<: Any, 2, <: SparseMatrixCSC}, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
     storage_assembler = CartesianSparseMatrixAssembler(parent(matrix), row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
     assembler = CartesianSparseMatrixAssembler(
@@ -564,8 +528,9 @@ end
     matrix
 end
 
-@inline function add_matrix_entry!(storage, row_dof_table, col_dof_table, row_storage_indices, col_storage_indices, row_node, col_node, value, row_ndofs, col_ndofs)
-    @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
+function add_matrix_entry!(storage, row_dof_table, col_dof_table, row_storage_indices, col_storage_indices, row_node, col_node, value, row_ndofs, col_ndofs)
+    @_propagate_inbounds_meta
+    for b in 1:col_ndofs, a in 1:row_ndofs
         row = storage_index(row_storage_indices, row_dof_table[a,row_node])
         col = storage_index(col_storage_indices, col_dof_table[b,col_node])
         storage[row,col] += value[(b - 1) * row_ndofs + a]
@@ -574,11 +539,7 @@ end
 end
 
 storage_dofs(::Base.OneTo, dofs) = dofs
-
-function storage_dofs(storage_indices, dofs)
-    @_propagate_inbounds_meta
-    storage_indices[dofs]
-end
+storage_dofs(storage_indices, dofs) = (@_propagate_inbounds_meta; storage_indices[dofs])
 
 function support_dofs(table_i, nodes_i, table_j, nodes_j)
     @_propagate_inbounds_meta
@@ -599,7 +560,7 @@ end
 function matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 end
-function matrix_assembler(matrix::SubArray{T,2,P}, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis) where {T,P <: SparseMatrixCSC}
+function matrix_assembler(matrix::SubArray{<: Any, 2, <: SparseMatrixCSC}, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 end
 
@@ -640,15 +601,15 @@ end
 
 # ---- DoF indexing ----
 
-function local_dofs(ndofs::Int, index::Integer)
-    @_propagate_inbounds_meta
-    vec(view(LinearIndices((ndofs, index)), :, index))
-end
-
 matrix_row_dofs(buffer::LocalMatrixBuffer, ip) = (@_propagate_inbounds_meta; local_dofs(buffer.row_ndofs, ip))
 matrix_col_dofs(buffer::LocalMatrixBuffer, jp) = (@_propagate_inbounds_meta; local_dofs(buffer.col_ndofs, jp))
 matrix_row_dofs(::Nothing, ip) = nothing
 matrix_col_dofs(::Nothing, jp) = nothing
+
+function local_dofs(ndofs::Int, index::Integer)
+    @_propagate_inbounds_meta
+    vec(view(LinearIndices((ndofs, index)), :, index))
+end
 
 # ---- assembly ----
 

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -327,6 +327,12 @@ end
     size(value) == (row_ndofs, col_ndofs) || throw(DimensionMismatch("matrix value is incompatible with matrix entry dimensions"))
 end
 
+matrix_storage(matrix) = matrix
+matrix_storage(matrix::SparseMatrixCSCView) = parent(matrix)
+
+matrix_storage_indices(matrix) = axes(matrix)
+matrix_storage_indices(matrix::SparseMatrixCSCView) = parentindices(matrix)
+
 storage_index(::Base.OneTo, index) = index
 storage_index(indices, index) = (@_propagate_inbounds_meta; indices[index])
 
@@ -345,8 +351,8 @@ end
 
 # ---- CartesianSparseMatrixAssembler ----
 
-# `matrix` is the logical destination. A plain CSC stores values itself, while
-# a view obtains its storage and parent indices from the SubArray.
+# The unprefixed DoF tables index the logical destination, while the
+# `storage_` tables index the underlying CSC matrix.
 struct CartesianSparseMatrixAssembler{M <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices, SR <: LinearIndices, SC <: LinearIndices}
     matrix::M
     row_dof_table::R
@@ -355,12 +361,6 @@ struct CartesianSparseMatrixAssembler{M <: AbstractMatrix, R <: LinearIndices, C
     storage_col_dof_table::SC
     sparsity_radius::Int
 end
-
-matrix_storage(matrix) = matrix
-matrix_storage(matrix::SubArray{<: Any, 2, <: SparseMatrixCSC}) = parent(matrix)
-
-matrix_storage_indices(matrix) = axes(matrix)
-matrix_storage_indices(matrix::SubArray{<: Any, 2, <: SparseMatrixCSC}) = parentindices(matrix)
 
 function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, sparsity_radius::Int)
     node_count = prod(mesh_size)
@@ -456,7 +456,7 @@ end
     nothing
 end
 
-function CartesianSparseMatrixAssembler(matrix::SubArray{<: Any, 2, <: SparseMatrixCSC}, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
+function CartesianSparseMatrixAssembler(matrix::SparseMatrixCSCView, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
     storage_assembler = CartesianSparseMatrixAssembler(parent(matrix), row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
     assembler = CartesianSparseMatrixAssembler(
@@ -508,10 +508,10 @@ function add!(assembler::GenericMatrixAssembler, row_nodes, col_nodes, local_mat
     row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
     row_dofs, col_dofs = support_dofs(row_dof_table, row_nodes, col_dof_table, col_nodes)
     if row_dofs === col_dofs && row_storage_indices === col_storage_indices
-        dofs = storage_dofs(row_storage_indices, row_dofs)
+        dofs = storage_index(row_storage_indices, row_dofs)
         add!(storage, dofs, dofs, local_matrix)
     else
-        add!(storage, storage_dofs(row_storage_indices, row_dofs), storage_dofs(col_storage_indices, col_dofs), local_matrix)
+        add!(storage, storage_index(row_storage_indices, row_dofs), storage_index(col_storage_indices, col_dofs), local_matrix)
     end
     matrix
 end
@@ -538,9 +538,6 @@ function add_matrix_entry!(storage, row_dof_table, col_dof_table, row_storage_in
     nothing
 end
 
-storage_dofs(::Base.OneTo, dofs) = dofs
-storage_dofs(storage_indices, dofs) = (@_propagate_inbounds_meta; storage_indices[dofs])
-
 function support_dofs(table_i, nodes_i, table_j, nodes_j)
     @_propagate_inbounds_meta
     if size(table_i, 1) == size(table_j, 1) && nodes_i === nodes_j
@@ -560,7 +557,7 @@ end
 function matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 end
-function matrix_assembler(matrix::SubArray{<: Any, 2, <: SparseMatrixCSC}, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
+function matrix_assembler(matrix::SparseMatrixCSCView, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,7 +58,9 @@ function fillzero!(x::StructArray)
     x
 end
 
-function fillzero!(matrix::SubArray{T, 2, P}) where {T, P <: SparseMatrixCSC}
+const SparseMatrixCSCView{T, P <: SparseMatrixCSC} = SubArray{T, 2, P}
+
+function fillzero!(matrix::SparseMatrixCSCView)
     selected_rows, selected_cols = parentindices(matrix)
     sorted_rows = issorted(selected_rows) ? selected_rows : sort(selected_rows)
     _fillzero_sparse_matrix_view!(parent(matrix), sorted_rows, selected_cols)
@@ -69,11 +71,11 @@ function _fillzero_sparse_matrix_view!(matrix::SparseMatrixCSC, selected_rows, s
     rows = rowvals(matrix)
     values = nonzeros(matrix)
     zero_value = zero_recursive(eltype(values))
+    selected_stop = lastindex(selected_rows)
     @inbounds for col in selected_cols
         slots = nzrange(matrix, col)
         isempty(slots) && continue
         selected_index = searchsortedfirst(selected_rows, rows[first(slots)])
-        selected_stop = lastindex(selected_rows)
         for slot in slots
             row = rows[slot]
             while selected_index ≤ selected_stop && selected_rows[selected_index] < row

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -52,9 +52,40 @@ function fillzero!(x::AbstractArray)
     fill!(x, zero_recursive(eltype(x)))
     x
 end
+
 function fillzero!(x::StructArray)
     StructArrays.foreachfield(fillzero!, x)
     x
+end
+
+function fillzero!(matrix::SubArray{T, 2, P}) where {T, P <: SparseMatrixCSC}
+    selected_rows, selected_cols = parentindices(matrix)
+    sorted_rows = issorted(selected_rows) ? selected_rows : sort(selected_rows)
+    _fillzero_sparse_matrix_view!(parent(matrix), sorted_rows, selected_cols)
+    matrix
+end
+
+function _fillzero_sparse_matrix_view!(matrix::SparseMatrixCSC, selected_rows, selected_cols)
+    rows = rowvals(matrix)
+    values = nonzeros(matrix)
+    zero_value = zero_recursive(eltype(values))
+    @inbounds for col in selected_cols
+        slots = nzrange(matrix, col)
+        isempty(slots) && continue
+        selected_index = searchsortedfirst(selected_rows, rows[first(slots)])
+        selected_stop = lastindex(selected_rows)
+        for slot in slots
+            row = rows[slot]
+            while selected_index ≤ selected_stop && selected_rows[selected_index] < row
+                selected_index += 1
+            end
+            selected_index > selected_stop && break
+            if selected_rows[selected_index] == row
+                values[slot] = zero_value
+            end
+        end
+    end
+    matrix
 end
 
 # fastsum

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -425,6 +425,21 @@ const nurbs_cubic = Tesserae.NURBS.cubic
             K_threaded[i,j] = @∑ ∇N[ip] ⋅ ∇N[jp] * V[p]
         end
         @test K_threaded ≈ K_sequential
+
+        parent_sequential = create_sparse_matrix(mesh; ndofs=2)
+        parent_threaded = create_sparse_matrix(mesh; ndofs=2)
+        parent_dofs = LinearIndices((2, length(mesh)))
+        component_dofs = vec(parent_dofs[2:2, :])
+        view_sequential = view(parent_sequential, component_dofs, component_dofs)
+        view_threaded = view(parent_threaded, component_dofs, component_dofs)
+        @P2G_Matrix grid=>(i,j) points=>p weights=>(ip,jp) begin
+            view_sequential[i,j] = @∑ ∇N[ip] ⋅ ∇N[jp] * V[p]
+        end
+        @threaded @P2G_Matrix grid=>(i,j) points=>p weights=>(ip,jp) partition begin
+            view_threaded[i,j] = @∑ ∇N[ip] ⋅ ∇N[jp] * V[p]
+        end
+        @test view_sequential ≈ K_sequential
+        @test view_threaded ≈ K_sequential
     end
 
     @testset "Heat problem" begin

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -109,7 +109,7 @@
         assembler = @inferred Tesserae.matrix_assembler(sequential, mesh, mesh, basis, basis)
         @test assembler isa Tesserae.CartesianSparseMatrixAssembler
         @test assembler.matrix === sequential
-        @test assembler.storage === parent_sequential
+        @test Tesserae.matrix_storage(assembler.matrix) === parent_sequential
 
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             sequential[i,j] = @∑ ∇w[ip] * w[jp]

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -107,9 +107,9 @@
         reference = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
 
         assembler = @inferred Tesserae.matrix_assembler(sequential, mesh, mesh, basis, basis)
-        @test assembler isa Tesserae.CartesianSparseMatrixViewAssembler
+        @test assembler isa Tesserae.CartesianSparseMatrixAssembler
         @test assembler.matrix === sequential
-        @test assembler.parent_assembler.matrix === parent_sequential
+        @test assembler.storage === parent_sequential
 
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             sequential[i,j] = @∑ ∇w[ip] * w[jp]
@@ -492,7 +492,7 @@ end
     col_indices = vec(parent_col_dofs[2:2, :])
     matrix_view = view(parent_matrix, row_indices, col_indices)
     assembler = @inferred Tesserae.matrix_assembler(matrix_view, quad9, quad4, basis(velocity_weights), basis(pressure_weights))
-    @test assembler isa Tesserae.SparseMatrixViewAssembler
+    @test assembler isa Tesserae.GenericMatrixAssembler
 
     @P2G_Matrix (velocity_grid,pressure_grid)=>(i,j) points=>p (velocity_weights,pressure_weights)=>(ip,jp) begin
         matrix_view[i,j] = @∑ ∇N[ip] * N[jp] * V[p]

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -85,6 +85,55 @@
         @test Kpp ≈ Kpp_ref
         @test Kup ≈ Kpu'
     end
+    @testset "sparse matrix views" begin
+        n = length(mesh)
+        parent_dofs = LinearIndices((3, n))
+        velocity_dofs = vec(parent_dofs[1:2, :])
+        pressure_dofs = vec(parent_dofs[3:3, :])
+
+        zeroed_parent = create_sparse_matrix(basis, mesh; ndofs=3)
+        fill!(Tesserae.SparseArrays.nonzeros(zeroed_parent), 7)
+        expected_zeroed_parent = copy(zeroed_parent)
+        fill!(view(expected_zeroed_parent, velocity_dofs, pressure_dofs), 0)
+        Tesserae.fillzero!(view(zeroed_parent, velocity_dofs, pressure_dofs))
+        @test zeroed_parent == expected_zeroed_parent
+
+        parent_sequential = create_sparse_matrix(basis, mesh; ndofs=3)
+        parent_threaded = create_sparse_matrix(basis, mesh; ndofs=3)
+        parent_transposed = create_sparse_matrix(basis, mesh; ndofs=3)
+        sequential = view(parent_sequential, velocity_dofs, pressure_dofs)
+        threaded = view(parent_threaded, velocity_dofs, pressure_dofs)
+        transposed = view(parent_transposed, pressure_dofs, velocity_dofs)
+        reference = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
+
+        assembler = @inferred Tesserae.matrix_assembler(sequential, mesh, mesh, basis, basis)
+        @test assembler isa Tesserae.CartesianSparseMatrixViewAssembler
+        @test assembler.matrix === sequential
+        @test assembler.parent_assembler.matrix === parent_sequential
+
+        @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
+            sequential[i,j] = @∑ ∇w[ip] * w[jp]
+            transposed[j,i] = @∑ ∇w[ip] * w[jp]
+            reference[i,j] = @∑ ∇w[ip] * w[jp]
+        end
+
+        partition = ThreadPartition(mesh)
+        update!(partition, particles.x)
+        @threaded :static @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) partition begin
+            threaded[i,j] = @∑ ∇w[ip] * w[jp]
+        end
+
+        @test sequential ≈ reference
+        @test threaded ≈ reference
+        @test transposed ≈ reference'
+        @test all(iszero, parent_sequential[pressure_dofs, :])
+        @test all(iszero, parent_sequential[:, velocity_dofs])
+
+        inconsistent_dofs = copy(velocity_dofs)
+        inconsistent_dofs[3] = parent_dofs[3,2]
+        inconsistent = view(parent_sequential, inconsistent_dofs, pressure_dofs)
+        @test_throws ArgumentError Tesserae.matrix_assembler(inconsistent, mesh, mesh, basis, basis)
+    end
     @testset "mixed lhs order" begin
         A = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
         B = create_sparse_matrix(basis, mesh; ndofs=(1, 2))
@@ -435,6 +484,20 @@ end
     end
     @test any(!iszero, Tesserae.SparseArrays.nonzeros(A))
     @test B ≈ A'
+
+    parent_matrix = create_sparse_matrix((quad9, quad4); ndofs=(3, 2))
+    parent_row_dofs = LinearIndices((3, length(quad9)))
+    parent_col_dofs = LinearIndices((2, length(quad4)))
+    row_indices = vec(parent_row_dofs[1:2, :])
+    col_indices = vec(parent_col_dofs[2:2, :])
+    matrix_view = view(parent_matrix, row_indices, col_indices)
+    assembler = @inferred Tesserae.matrix_assembler(matrix_view, quad9, quad4, basis(velocity_weights), basis(pressure_weights))
+    @test assembler isa Tesserae.SparseMatrixViewAssembler
+
+    @P2G_Matrix (velocity_grid,pressure_grid)=>(i,j) points=>p (velocity_weights,pressure_weights)=>(ip,jp) begin
+        matrix_view[i,j] = @∑ ∇N[ip] * N[jp] * V[p]
+    end
+    @test matrix_view ≈ A
 
     shifted = FEMesh(Tesserae.Quad4(), CartesianMesh(1, (2,4), (0,1)))
     @test_throws ArgumentError create_sparse_matrix((quad9, shifted); ndofs=(2, 1))

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -86,10 +86,9 @@
         @test Kup ≈ Kpu'
     end
     @testset "sparse matrix views" begin
-        n = length(mesh)
-        parent_dofs = LinearIndices((3, n))
-        velocity_dofs = vec(parent_dofs[1:2, :])
-        pressure_dofs = vec(parent_dofs[3:3, :])
+        parent_dofs = LinearIndices((3, length(mesh)))
+        velocity_dofs = vec(parent_dofs[[3,1], :])
+        pressure_dofs = vec(parent_dofs[2:2, :])
 
         zeroed_parent = create_sparse_matrix(basis, mesh; ndofs=3)
         fill!(Tesserae.SparseArrays.nonzeros(zeroed_parent), 7)
@@ -130,9 +129,12 @@
         @test all(iszero, parent_sequential[:, velocity_dofs])
 
         inconsistent_dofs = copy(velocity_dofs)
-        inconsistent_dofs[3] = parent_dofs[3,2]
+        inconsistent_dofs[3] = parent_dofs[2,2]
         inconsistent = view(parent_sequential, inconsistent_dofs, pressure_dofs)
         @test_throws ArgumentError Tesserae.matrix_assembler(inconsistent, mesh, mesh, basis, basis)
+
+        duplicate = view(parent_sequential, vec(parent_dofs[[3,3], :]), pressure_dofs)
+        @test_throws ArgumentError Tesserae.matrix_assembler(duplicate, mesh, mesh, basis, basis)
     end
     @testset "mixed lhs order" begin
         A = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
@@ -488,7 +490,7 @@ end
     parent_matrix = create_sparse_matrix((quad9, quad4); ndofs=(3, 2))
     parent_row_dofs = LinearIndices((3, length(quad9)))
     parent_col_dofs = LinearIndices((2, length(quad4)))
-    row_indices = vec(parent_row_dofs[1:2, :])
+    row_indices = vec(parent_row_dofs[[3,1], :])
     col_indices = vec(parent_col_dofs[2:2, :])
     matrix_view = view(parent_matrix, row_indices, col_indices)
     assembler = @inferred Tesserae.matrix_assembler(matrix_view, quad9, quad4, basis(velocity_weights), basis(pressure_weights))


### PR DESCRIPTION
Adds `@P2G_Matrix` support for component views of sparse matrices.

- Reuses canonical Cartesian CSC storage for direct entry updates and threaded block scatter.
- Supports sparse matrix views through the generic FEM and IGA assembly paths.
- Preserves entries outside the selected view when assigning assembled values.
- Bumps the package version to v0.7.4.