### PR TITLE
Add block sparse matrix assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to Tesserae.jl will be documented in this file.
 
 - Added support for assembling into sparse matrix component views with
   `@P2G_Matrix`.
-- Added block sparse matrices with a shared monolithic CSC parent and direct
-  `@P2G_Matrix` assembly into individual blocks.
+- Added block sparse matrices created directly from field meshes and DoF
+  counts, with a shared monolithic CSC parent and direct `@P2G_Matrix`
+  assembly into individual blocks.
 
 ## v0.7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ All notable changes to Tesserae.jl will be documented in this file.
 ### Added
 
 - Added `create_block_sparse_matrix` for constructing monolithic field matrices
-  from meshes and per-field DoF counts, and `@block_sparse_matrix` for combining
-  existing CSC blocks. Both provide fixed-sparsity block views of one shared
-  parent CSC matrix.
+  with fixed-sparsity block views of one shared parent CSC matrix.
 - Added direct `@P2G_Matrix` assembly into individual sparse matrix blocks.
+
+### Performance
+
+- Reused the Cartesian sparsity guarantee recorded by
+  `create_block_sparse_matrix` instead of validating every block on each
+  `@P2G_Matrix` call.
 
 ## v0.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,22 @@
 
 All notable changes to Tesserae.jl will be documented in this file.
 
+## v0.7.5
+
+### Added
+
+- Added `create_block_sparse_matrix` for constructing monolithic field matrices
+  from meshes and per-field DoF counts, and `@block_sparse_matrix` for combining
+  existing CSC blocks. Both provide fixed-sparsity block views of one shared
+  parent CSC matrix.
+- Added direct `@P2G_Matrix` assembly into individual sparse matrix blocks.
+
 ## v0.7.4
 
 ### Added
 
 - Added support for assembling into sparse matrix component views with
   `@P2G_Matrix`.
-- Added block sparse matrices created directly from field meshes and DoF
-  counts, with a shared monolithic CSC parent and direct `@P2G_Matrix`
-  assembly into individual blocks.
 
 ## v0.7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Tesserae.jl will be documented in this file.
 
 - Added support for assembling into sparse matrix component views with
   `@P2G_Matrix`.
+- Added block sparse matrices with a shared monolithic CSC parent and direct
+  `@P2G_Matrix` assembly into individual blocks.
 
 ## v0.7.3
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tesserae"
 uuid = "fd374396-9d9c-4d88-9aa5-37a7f6105aca"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
 
 [deps]

--- a/docs/src/implicit_utils.md
+++ b/docs/src/implicit_utils.md
@@ -14,6 +14,7 @@ DofMap
 ```@docs
 create_sparse_matrix
 create_block_sparse_matrix
+@block_sparse_matrix
 extract(::AbstractMatrix, ::DofMap)
 ```
 

--- a/docs/src/implicit_utils.md
+++ b/docs/src/implicit_utils.md
@@ -13,6 +13,7 @@ DofMap
 
 ```@docs
 create_sparse_matrix
+create_block_sparse_matrix
 extract(::AbstractMatrix, ::DofMap)
 ```
 

--- a/docs/src/implicit_utils.md
+++ b/docs/src/implicit_utils.md
@@ -14,7 +14,6 @@ DofMap
 ```@docs
 create_sparse_matrix
 create_block_sparse_matrix
-@block_sparse_matrix
 extract(::AbstractMatrix, ::DofMap)
 ```
 

--- a/src/Tesserae.jl
+++ b/src/Tesserae.jl
@@ -109,6 +109,7 @@ export
     ndofs,
     dofs,
     create_sparse_matrix,
+    create_block_sparse_matrix,
     @P2G_Matrix,
 # VTK
     openvtk,

--- a/src/Tesserae.jl
+++ b/src/Tesserae.jl
@@ -110,6 +110,7 @@ export
     dofs,
     create_sparse_matrix,
     create_block_sparse_matrix,
+    @block_sparse_matrix,
     @P2G_Matrix,
 # VTK
     openvtk,

--- a/src/Tesserae.jl
+++ b/src/Tesserae.jl
@@ -110,7 +110,6 @@ export
     dofs,
     create_sparse_matrix,
     create_block_sparse_matrix,
-    @block_sparse_matrix,
     @P2G_Matrix,
 # VTK
     openvtk,

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -125,9 +125,7 @@ SparseArrays.nnz(block::SparseMatrixBlockView) = sum(length, block.column_slots)
 
 # ---- SparseMatrixBlocks ----
 
-"""
-An array of sparse matrix block views that share the same parent CSC matrix.
-"""
+# Owns the parent CSC and creates block views from shared offsets and slot tables.
 struct SparseMatrixBlocks{T,Ti} <: AbstractMatrix{SparseMatrixBlockView{T,Ti}}
     matrix::SparseMatrixCSC{T,Ti}
     row_offsets::Vector{Int}
@@ -154,6 +152,8 @@ function fillzero!(blocks::SparseMatrixBlocks)
 end
 
 # ---- construction ----
+
+# -- existing matrices --
 
 function _combine_sparse_matrix_blocks(block_rows::Tuple...)
     isempty(block_rows) && throw(ArgumentError("at least one block row is required"))
@@ -227,12 +227,22 @@ end
 
 Combine existing `SparseMatrixCSC` objects into one parent CSC matrix and
 return its block views.
+
+```julia
+blocks = @block_sparse_matrix [Kuu Kup; Kpu Kpp]
+K = parent(blocks)
+```
+
+All blocks must have the same element and index types and consistent row and
+column sizes. The returned views share the fixed sparsity structure of `K`.
 """
 macro block_sparse_matrix(expr)
     block_rows = _block_matrix_rows(expr)
     escaped_rows = map(row -> Expr(:tuple, map(esc, row)...), block_rows)
     :(_combine_sparse_matrix_blocks($(escaped_rows...)))
 end
+
+# -- field matrix API --
 
 """
     create_block_sparse_matrix(mesh; ndofs)
@@ -257,58 +267,19 @@ Structural changes made through `parent(blocks)` invalidate all block views.
 """
 function create_block_sparse_matrix end
 
-function create_block_sparse_matrix(basis::Basis, mesh::AbstractMesh; ndofs::Tuple{Vararg{Int}})
-    _create_block_sparse_matrix(Float64, basis, mesh, ndofs)
-end
+create_block_sparse_matrix(basis::Basis, mesh::CartesianMesh; ndofs::NTuple{N, Int}) where {N} = create_block_sparse_matrix(Float64, basis, mesh; ndofs)
+create_block_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh; ndofs::NTuple{N, Int}) where {T,N} = _create_block_sparse_matrix(T, basis, mesh, ndofs)
 
-function create_block_sparse_matrix(::Type{T}, basis::Basis, mesh::AbstractMesh; ndofs::Tuple{Vararg{Int}}) where {T}
-    _create_block_sparse_matrix(T, basis, mesh, ndofs)
-end
-
-function create_block_sparse_matrix(mesh::Union{FEMesh,IGAMesh}; ndofs::Tuple{Vararg{Int}})
-    create_block_sparse_matrix(Float64, mesh; ndofs)
-end
-
-function create_block_sparse_matrix(::Type{T}, mesh::Union{FEMesh,IGAMesh}; ndofs::Tuple{Vararg{Int}}) where {T}
-    meshes = ntuple(_ -> mesh, length(ndofs))
+create_block_sparse_matrix(mesh::Union{FEMesh, IGAMesh}; ndofs::NTuple{N, Int}) where {N} = create_block_sparse_matrix(Float64, mesh; ndofs)
+function create_block_sparse_matrix(::Type{T}, mesh::Union{FEMesh, IGAMesh}; ndofs::NTuple{N, Int}) where {T,N}
+    meshes = ntuple(_ -> mesh, N)
     _create_block_sparse_matrix(T, meshes, ndofs)
 end
 
-function create_block_sparse_matrix(meshes::Tuple{Vararg{Union{FEMesh,IGAMesh}}}; ndofs::Tuple{Vararg{Int}})
-    create_block_sparse_matrix(Float64, meshes; ndofs)
-end
+create_block_sparse_matrix(meshes::Union{NTuple{N,FEMesh}, NTuple{N,IGAMesh}}; ndofs::NTuple{N, Int}) where {N} = create_block_sparse_matrix(Float64, meshes; ndofs)
+create_block_sparse_matrix(::Type{T}, meshes::Union{NTuple{N,FEMesh}, NTuple{N,IGAMesh}}; ndofs::NTuple{N, Int}) where {T,N} = _create_block_sparse_matrix(T, meshes, ndofs)
 
-function create_block_sparse_matrix(::Type{T}, meshes::Tuple{Vararg{Union{FEMesh,IGAMesh}}}; ndofs::Tuple{Vararg{Int}}) where {T}
-    _create_block_sparse_matrix(T, meshes, ndofs)
-end
-
-function _create_block_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh, ndofs::Tuple{Vararg{Int}}) where {T}
-    check_field_ndofs(ndofs)
-    field_sizes = [ndof * length(mesh) for ndof in ndofs]
-    field_offsets = cumsum([0; field_sizes])
-    I, J = Int[], Int[]
-    for j in eachindex(ndofs), i in eachindex(ndofs)
-        _append_sparse_pattern!(I, J, field_offsets[i], field_offsets[j], basis, mesh, ndofs[i], ndofs[j])
-    end
-    _create_sparse_matrix_blocks(T, I, J, field_offsets)
-end
-
-function _create_block_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Tuple{Vararg{Int}}) where {T}
-    meshes = ntuple(_ -> mesh, length(ndofs))
-    _create_block_sparse_matrix(T, meshes, ndofs)
-end
-
-function _create_block_sparse_matrix(::Type{T}, meshes::Tuple, ndofs::Tuple{Vararg{Int}}) where {T}
-    length(ndofs) == length(meshes) || throw(DimensionMismatch("each field must have one DoF count"))
-    check_field_ndofs(ndofs)
-    field_sizes = [ndofs[i] * length(meshes[i]) for i in eachindex(meshes)]
-    field_offsets = cumsum([0; field_sizes])
-    I, J = Int[], Int[]
-    for j in eachindex(meshes), i in eachindex(meshes)
-        _append_sparse_pattern!(I, J, field_offsets[i], field_offsets[j], meshes[i], meshes[j], ndofs[i], ndofs[j])
-    end
-    _create_sparse_matrix_blocks(T, I, J, field_offsets)
-end
+# -- helpers --
 
 function check_field_ndofs(ndofs)
     isempty(ndofs) && throw(ArgumentError("at least one field is required"))
@@ -338,6 +309,32 @@ function _create_sparse_matrix_blocks(::Type{T}, I, J, field_offsets) where {T}
     end
 
     SparseMatrixBlocks(matrix, field_offsets, field_offsets, column_slots)
+end
+
+# -- MPM --
+
+function _create_block_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh, ndofs::NTuple{N, Int}) where {T, N}
+    check_field_ndofs(ndofs)
+    field_sizes = [ndof * length(mesh) for ndof in ndofs]
+    field_offsets = cumsum([0; field_sizes])
+    I, J = Int[], Int[]
+    for j in eachindex(ndofs), i in eachindex(ndofs)
+        _append_sparse_pattern!(I, J, field_offsets[i], field_offsets[j], basis, mesh, ndofs[i], ndofs[j])
+    end
+    _create_sparse_matrix_blocks(T, I, J, field_offsets)
+end
+
+# -- FEM and IGA --
+
+function _create_block_sparse_matrix(::Type{T}, meshes::Union{NTuple{N, FEMesh}, NTuple{N, IGAMesh}}, ndofs::NTuple{N, Int}) where {T, N}
+    check_field_ndofs(ndofs)
+    field_sizes = [ndofs[i] * length(meshes[i]) for i in eachindex(meshes)]
+    field_offsets = cumsum([0; field_sizes])
+    I, J = Int[], Int[]
+    for j in eachindex(meshes), i in eachindex(meshes)
+        _append_sparse_pattern!(I, J, field_offsets[i], field_offsets[j], meshes[i], meshes[j], ndofs[i], ndofs[j])
+    end
+    _create_sparse_matrix_blocks(T, I, J, field_offsets)
 end
 
 # -----------------------------------------------------------------------------
@@ -403,13 +400,46 @@ julia> extract(A, dofmap)
   ⋅    ⋅    ⋅    ⋅   0.0  0.0   ⋅   0.0  0.0
 ```
 """
-function create_sparse_matrix(basis::Basis, mesh::AbstractMesh; ndofs)
-    _create_sparse_matrix(Float64, basis, mesh, ndofs)
+function create_sparse_matrix end
+
+# -- helpers --
+
+function append_dofs!(I, J, row_dofs, col_dofs, row_offset, col_offset)
+    for col_dof in col_dofs, row_dof in row_dofs
+        push!(I, row_offset + row_dof)
+        push!(J, col_offset + col_dof)
+    end
+    nothing
 end
 
-function create_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh; ndofs) where {T}
-    _create_sparse_matrix(T, basis, mesh, ndofs)
+function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Int) where {T}
+    _create_cell_support_sparse_matrix(T, mesh, (ndofs, ndofs))
 end
+
+function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Tuple{Int,Int}) where {T}
+    I, J = Int[], Int[]
+    _append_sparse_pattern!(I, J, 0, 0, mesh, ndofs[1], ndofs[2])
+    sparse(I, J, zeros(T, length(I)), ndofs[1] * length(mesh), ndofs[2] * length(mesh))
+end
+
+function _append_sparse_pattern!(I, J, row_offset, col_offset, mesh::Union{FEMesh,IGAMesh}, row_ndofs, col_ndofs)
+    row_dofs = LinearIndices((row_ndofs, length(mesh)))
+    col_dofs = LinearIndices((col_ndofs, length(mesh)))
+    for cell in cells(mesh)
+        cell_nodes = supportnodes(mesh, cell)
+        append_dofs!(I, J, row_dofs[:, cell_nodes], col_dofs[:, cell_nodes], row_offset, col_offset)
+    end
+    nothing
+end
+
+function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::Union{FEMesh,IGAMesh}, colmesh::Union{FEMesh,IGAMesh}, row_ndofs, col_ndofs)
+    throw(ArgumentError("all field meshes must use compatible discretizations"))
+end
+
+# -- MPM --
+
+create_sparse_matrix(basis::Basis, mesh::CartesianMesh; ndofs) = _create_sparse_matrix(Float64, basis, mesh, ndofs)
+create_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh; ndofs) where {T} = _create_sparse_matrix(T, basis, mesh, ndofs)
 
 function _create_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh{dim}, ndofs::Int) where {T, dim}
     _create_sparse_matrix(T, basis, mesh, (ndofs, ndofs))
@@ -441,46 +471,7 @@ function node_dofs(node, ndofs)
     (ndofs * (node - 1) + 1):(ndofs * node)
 end
 
-function append_dofs!(I, J, row_dofs, col_dofs, row_offset, col_offset)
-    for col_dof in col_dofs, row_dof in row_dofs
-        push!(I, row_offset + row_dof)
-        push!(J, col_offset + col_dof)
-    end
-    nothing
-end
-
-function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Int) where {T}
-    _create_cell_support_sparse_matrix(T, mesh, (ndofs, ndofs))
-end
-
-function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Tuple{Int,Int}) where {T}
-    I, J = Int[], Int[]
-    _append_sparse_pattern!(I, J, 0, 0, mesh, ndofs[1], ndofs[2])
-    sparse(I, J, zeros(T, length(I)), ndofs[1] * length(mesh), ndofs[2] * length(mesh))
-end
-
-function _append_sparse_pattern!(I, J, row_offset, col_offset, mesh::Union{FEMesh,IGAMesh}, row_ndofs, col_ndofs)
-    row_dofs = LinearIndices((row_ndofs, length(mesh)))
-    col_dofs = LinearIndices((col_ndofs, length(mesh)))
-    for cell in cells(mesh)
-        cell_nodes = supportnodes(mesh, cell)
-        append_dofs!(I, J, row_dofs[:, cell_nodes], col_dofs[:, cell_nodes], row_offset, col_offset)
-    end
-    nothing
-end
-
-function create_sparse_matrix(::IGABasis, mesh::IGAMesh{dim}; ndofs) where {dim}
-    _create_sparse_matrix(Float64, mesh, ndofs)
-end
-function create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh{dim}; ndofs) where {T, dim}
-    _create_sparse_matrix(T, mesh, ndofs)
-end
-_create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Int) where {T} = _create_sparse_matrix(T, mesh, ndofs)
-_create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T} = _create_sparse_matrix(T, mesh, ndofs)
-_create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Int) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
-_create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
-create_sparse_matrix(::Type{T}, mesh::IGAMesh{dim}; ndofs) where {T, dim} = _create_sparse_matrix(T, mesh, ndofs)
-create_sparse_matrix(mesh::IGAMesh{dim}; ndofs) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
+# -- FEM and IGA --
 
 function create_sparse_matrix(::Type{T}, (rowmesh,colmesh)::Tuple{Vararg{Union{FEMesh,IGAMesh},2}}; ndofs::Tuple{Int,Int}) where {T}
     I, J = Int[], Int[]
@@ -492,19 +483,7 @@ function create_sparse_matrix(meshes::Tuple{Vararg{Union{FEMesh,IGAMesh},2}}; nd
     create_sparse_matrix(Float64, meshes; ndofs)
 end
 
-function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::IGAMesh{dim,pdim}, colmesh::IGAMesh{dim,pdim}, row_ndofs, col_ndofs) where {dim,pdim}
-    rowmesh === colmesh && return _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh, row_ndofs, col_ndofs)
-    check_matching_cell_partitions(rowmesh, colmesh)
-
-    row_dofs = LinearIndices((row_ndofs, length(rowmesh)))
-    col_dofs = LinearIndices((col_ndofs, length(colmesh)))
-    for (row_cell, col_cell) in zip(cells(rowmesh), cells(colmesh))
-        row_nodes = supportnodes(rowmesh, row_cell)
-        col_nodes = supportnodes(colmesh, col_cell)
-        append_dofs!(I, J, row_dofs[:, row_nodes], col_dofs[:, col_nodes], row_offset, col_offset)
-    end
-    nothing
-end
+# -- FEM --
 
 create_sparse_matrix(::Type{T}, mesh::FEMesh{<: Any, dim}; ndofs::Int) where {T, dim} = create_sparse_matrix(T, (mesh,mesh); ndofs=(ndofs,ndofs))
 create_sparse_matrix(mesh::FEMesh{<: Any, dim}; ndofs::Int) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
@@ -527,8 +506,30 @@ function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::FEMesh, 
     nothing
 end
 
-function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::Union{FEMesh,IGAMesh}, colmesh::Union{FEMesh,IGAMesh}, row_ndofs, col_ndofs)
-    throw(ArgumentError("all field meshes must use compatible discretizations"))
+# -- IGA --
+
+create_sparse_matrix(::IGABasis, mesh::IGAMesh{dim}; ndofs) where {dim} = _create_sparse_matrix(Float64, mesh, ndofs)
+create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh{dim}; ndofs) where {T, dim} = _create_sparse_matrix(T, mesh, ndofs)
+
+_create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Int) where {T} = _create_sparse_matrix(T, mesh, ndofs)
+_create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T} = _create_sparse_matrix(T, mesh, ndofs)
+_create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Int) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
+_create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
+create_sparse_matrix(::Type{T}, mesh::IGAMesh{dim}; ndofs) where {T, dim} = _create_sparse_matrix(T, mesh, ndofs)
+create_sparse_matrix(mesh::IGAMesh{dim}; ndofs) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
+
+function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::IGAMesh{dim,pdim}, colmesh::IGAMesh{dim,pdim}, row_ndofs, col_ndofs) where {dim,pdim}
+    rowmesh === colmesh && return _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh, row_ndofs, col_ndofs)
+    check_matching_cell_partitions(rowmesh, colmesh)
+
+    row_dofs = LinearIndices((row_ndofs, length(rowmesh)))
+    col_dofs = LinearIndices((col_ndofs, length(colmesh)))
+    for (row_cell, col_cell) in zip(cells(rowmesh), cells(colmesh))
+        row_nodes = supportnodes(rowmesh, row_cell)
+        col_nodes = supportnodes(colmesh, col_cell)
+        append_dofs!(I, J, row_dofs[:, row_nodes], col_dofs[:, col_nodes], row_offset, col_offset)
+    end
+    nothing
 end
 
 # ---- extraction ----
@@ -618,12 +619,10 @@ end
 end
 
 matrix_storage(matrix) = matrix
-matrix_storage(matrix::SparseMatrixCSCView) = parent(matrix)
-matrix_storage(matrix::SparseMatrixBlockView) = parent(matrix)
+matrix_storage(matrix::Union{SparseMatrixCSCView,SparseMatrixBlockView}) = parent(matrix)
 
 matrix_storage_indices(matrix) = axes(matrix)
-matrix_storage_indices(matrix::SparseMatrixCSCView) = parentindices(matrix)
-matrix_storage_indices(matrix::SparseMatrixBlockView) = parentindices(matrix)
+matrix_storage_indices(matrix::Union{SparseMatrixCSCView,SparseMatrixBlockView}) = parentindices(matrix)
 
 storage_index(::Base.OneTo, index) = index
 storage_index(indices, index) = (@_propagate_inbounds_meta; indices[index])
@@ -643,23 +642,24 @@ end
 
 # ---- CartesianSparseMatrixAssembler ----
 
-# The unprefixed DoF tables index the logical destination, while the
-# `storage_` tables index the underlying CSC matrix.
-struct CartesianSparseMatrixAssembler{M <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices, SR <: LinearIndices, SC <: LinearIndices}
+# -- storage layout --
+
+# The DoF tables index the logical destination. `storage_row_ndofs` describes
+# the per-node row layout of its segment in the underlying CSC matrix.
+struct CartesianSparseMatrixAssembler{M <: AbstractMatrix, D <: LinearIndices}
     matrix::M
-    row_dof_table::R
-    col_dof_table::C
-    storage_row_dof_table::SR
-    storage_col_dof_table::SC
+    row_dof_table::D
+    col_dof_table::D
+    storage_row_ndofs::Int
     sparsity_radius::Int
 end
 
 function cartesian_matrix_column_slots(assembler::CartesianSparseMatrixAssembler, b, col_node)
     @_propagate_inbounds_meta
-    (; matrix, storage_col_dof_table) = assembler
+    (; matrix, col_dof_table) = assembler
     storage = matrix_storage(matrix)
     col_storage_indices = last(matrix_storage_indices(matrix))
-    col = storage_col_dof_table[col_storage_indices[b],col_node]
+    col = storage_index(col_storage_indices, col_dof_table[b,col_node])
     nzrange(storage, col)
 end
 
@@ -677,13 +677,13 @@ end
     Base.OneTo(size(assembler.row_dof_table, 1))
 end
 
-@inline function cartesian_matrix_storage_row(assembler::CartesianSparseMatrixAssembler, a, row_node)
-    assembler.storage_row_dof_table[a,row_node]
+function cartesian_matrix_storage_row(assembler::CartesianSparseMatrixAssembler, a, row_node)
+    @_propagate_inbounds_meta
+    (; matrix, row_dof_table) = assembler
+    storage_index(first(matrix_storage_indices(matrix)), row_dof_table[a,row_node])
 end
 
-@inline function cartesian_matrix_storage_row(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView}, a, row_node)
-    first(assembler.matrix.rows) - 1 + assembler.row_dof_table[a,row_node]
-end
+# -- construction --
 
 function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, sparsity_radius::Int)
     node_count = prod(mesh_size)
@@ -699,21 +699,26 @@ function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, spa
         A,
         row_dof_table,
         col_dof_table,
-        row_dof_table,
-        col_dof_table,
+        row_dofs_per_node,
         sparsity_radius,
     )
     has_cartesian_sparse_pattern(assembler) || throw(ArgumentError("Cartesian sparse matrix must use the canonical sparsity pattern"))
     assembler
 end
 
-function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
+function cartesian_sparsity_radius(row_mesh, col_mesh, row_basis, col_basis)
     size(row_mesh) == size(col_mesh) || throw(DimensionMismatch("row and column meshes must have the same size"))
-    row_sparsity_radius = support_width(row_basis) - 1
-    col_sparsity_radius = support_width(col_basis) - 1
-    row_sparsity_radius == col_sparsity_radius || throw(ArgumentError("row and column bases must have the same support width"))
-    CartesianSparseMatrixAssembler(A, size(row_mesh), row_sparsity_radius)
+    sparsity_radius = support_width(row_basis) - 1
+    sparsity_radius == support_width(col_basis) - 1 || throw(ArgumentError("row and column bases must have the same support width"))
+    sparsity_radius
 end
+
+function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
+    sparsity_radius = cartesian_sparsity_radius(row_mesh, col_mesh, row_basis, col_basis)
+    CartesianSparseMatrixAssembler(A, size(row_mesh), sparsity_radius)
+end
+
+# -- sparsity pattern --
 
 function cartesian_neighbor_nodes(node::CartesianIndex{N}, mesh_size::Dims{N}, sparsity_radius::Int) where {N}
     shift = sparsity_radius * oneunit(CartesianIndex{N})
@@ -721,9 +726,9 @@ function cartesian_neighbor_nodes(node::CartesianIndex{N}, mesh_size::Dims{N}, s
 end
 
 function cartesian_slot_offset(node, neighboring_nodes, slots_per_node)
-    @_propagate_inbounds_meta
+    # Assembly checks establish that `node` belongs to `neighboring_nodes`.
     local_node = node - first(neighboring_nodes) + oneunit(node)
-    (LinearIndices(neighboring_nodes)[local_node] - 1) * slots_per_node
+    @inbounds (LinearIndices(neighboring_nodes)[local_node] - 1) * slots_per_node
 end
 
 function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
@@ -748,29 +753,33 @@ function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
 end
 
 function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixCSCView})
-    (; matrix, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    (; matrix, row_dof_table, storage_row_ndofs, sparsity_radius) = assembler
+    mesh_size = Base.tail(size(row_dof_table))
+    storage_col_ndofs = size(parent(matrix), 2) ÷ prod(mesh_size)
+    storage_row_dof_table = LinearIndices((storage_row_ndofs, mesh_size...))
+    storage_col_dof_table = LinearIndices((storage_col_ndofs, mesh_size...))
     storage_assembler = CartesianSparseMatrixAssembler(
         parent(matrix),
         storage_row_dof_table,
         storage_col_dof_table,
-        storage_row_dof_table,
-        storage_col_dof_table,
+        storage_row_ndofs,
         sparsity_radius,
     )
     has_cartesian_sparse_pattern(storage_assembler)
 end
 
+# -- assembly --
+
 # The canonical Cartesian CSC pattern allows its destination slots to be computed directly.
 @inline function add_entry!(assembler::CartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
     @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
 
-    (; matrix, row_dof_table, col_dof_table, storage_row_dof_table, sparsity_radius) = assembler
+    (; matrix, row_dof_table, col_dof_table, storage_row_ndofs, sparsity_radius) = assembler
     storage = matrix_storage(matrix)
     row_storage_indices = cartesian_matrix_row_storage_indices(assembler)
     mesh_size = Base.tail(size(row_dof_table))
     row_ndofs = size(row_dof_table, 1)
     col_ndofs = size(col_dof_table, 1)
-    storage_row_ndofs = size(storage_row_dof_table, 1)
     neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
 
     row_offset = cartesian_slot_offset(row_node, neighboring_nodes, storage_row_ndofs)
@@ -795,6 +804,8 @@ end
     nothing
 end
 
+# -- matrix views --
+
 function CartesianSparseMatrixAssembler(matrix::SparseMatrixCSCView, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
     storage_assembler = CartesianSparseMatrixAssembler(parent(matrix), row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
@@ -802,8 +813,7 @@ function CartesianSparseMatrixAssembler(matrix::SparseMatrixCSCView, row_mesh::C
         matrix,
         row_dof_table,
         col_dof_table,
-        storage_assembler.storage_row_dof_table,
-        storage_assembler.storage_col_dof_table,
+        storage_assembler.storage_row_ndofs,
         storage_assembler.sparsity_radius,
     )
     check_cartesian_sparse_matrix_view(assembler)
@@ -811,35 +821,33 @@ function CartesianSparseMatrixAssembler(matrix::SparseMatrixCSCView, row_mesh::C
 end
 
 function CartesianSparseMatrixAssembler(matrix::SparseMatrixBlockView, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
-    size(row_mesh) == size(col_mesh) || throw(DimensionMismatch("row and column meshes must have the same size"))
-    row_sparsity_radius = support_width(row_basis) - 1
-    col_sparsity_radius = support_width(col_basis) - 1
-    row_sparsity_radius == col_sparsity_radius || throw(ArgumentError("row and column bases must have the same support width"))
+    sparsity_radius = cartesian_sparsity_radius(row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
     assembler = CartesianSparseMatrixAssembler(
         matrix,
         row_dof_table,
         col_dof_table,
-        row_dof_table,
-        col_dof_table,
-        row_sparsity_radius,
+        size(row_dof_table, 1),
+        sparsity_radius,
     )
     has_cartesian_sparse_pattern(assembler) || throw(ArgumentError("Cartesian sparse matrix block must use the canonical sparsity pattern"))
     assembler
 end
 
 @noinline function check_cartesian_sparse_matrix_view(assembler::CartesianSparseMatrixAssembler)
-    (; matrix, row_dof_table, col_dof_table, storage_row_dof_table, storage_col_dof_table) = assembler
+    (; matrix, row_dof_table, col_dof_table, storage_row_ndofs) = assembler
+    node_count = prod(Base.tail(size(row_dof_table)))
+    storage_col_ndofs = size(parent(matrix), 2) ÷ node_count
     row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
-    check_cartesian_sparse_matrix_view_indices(row_storage_indices, row_dof_table, storage_row_dof_table)
-    check_cartesian_sparse_matrix_view_indices(col_storage_indices, col_dof_table, storage_col_dof_table)
+    check_cartesian_sparse_matrix_view_indices(row_storage_indices, row_dof_table, storage_row_ndofs)
+    check_cartesian_sparse_matrix_view_indices(col_storage_indices, col_dof_table, storage_col_ndofs)
     nothing
 end
 
-@noinline function check_cartesian_sparse_matrix_view_indices(parent_indices, dof_table, parent_dof_table)
+@noinline function check_cartesian_sparse_matrix_view_indices(parent_indices, dof_table, parent_ndofs)
     ndofs = size(dof_table, 1)
-    parent_ndofs = size(parent_dof_table, 1)
     mesh_nodes = CartesianIndices(Base.tail(size(dof_table)))
+    parent_dof_table = LinearIndices((parent_ndofs, size(mesh_nodes)...))
     first_node = first(mesh_nodes)
     for a in 1:ndofs
         component = parent_indices[dof_table[a,first_node]]
@@ -929,6 +937,8 @@ end
 #  LocalMatrixBuffer
 # -----------------------------------------------------------------------------
 
+# ---- construction ----
+
 struct LocalMatrixBuffer{M <: Matrix}
     matrix::M
     row_ndofs::Int
@@ -1002,6 +1012,8 @@ finish_assembly!(assembler, ::Nothing, orientation, row_nodes, col_nodes) = asse
 # -----------------------------------------------------------------------------
 #  BlockMatrixBuffer
 # -----------------------------------------------------------------------------
+
+# ---- construction ----
 
 struct BlockAssembly{I <: CartesianIndices}
     nodes_i::I
@@ -1081,6 +1093,8 @@ block_matrix_buffer(::GenericMatrixAssembler, ::BlockAssembly, orientation) = no
 
 # ---- assembly ----
 
+# -- accumulation --
+
 function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, row_node::CartesianIndex{N}, col_node::CartesianIndex{N}, value) where {T,N}
     @_propagate_inbounds_meta
     @boundscheck check_block_matrix_entry(buffer, row_nodes, col_nodes, row_node, col_node, value)
@@ -1115,18 +1129,19 @@ end
     nothing
 end
 
+# -- scatter --
+
 function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {T,N}
     @_propagate_inbounds_meta
     @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
 
-    (; matrix, storage_row_dof_table, sparsity_radius) = assembler
+    (; matrix, row_dof_table, storage_row_ndofs, sparsity_radius) = assembler
     storage = matrix_storage(matrix)
     row_storage_indices = cartesian_matrix_row_storage_indices(assembler)
     (; values, node_colstarts, key) = buffer
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
 
-    mesh_size = Base.tail(size(storage_row_dof_table))
-    storage_row_ndofs = size(storage_row_dof_table, 1)
+    mesh_size = Base.tail(size(row_dof_table))
     matrix_values = nonzeros(storage)
     first_row_node = first(row_nodes)
     first_col_node = first(col_nodes)
@@ -1166,6 +1181,8 @@ end
     nothing
 end
 
+# -- route dispatch --
+
 # Canonical Cartesian CSC entries are accumulated in the block buffer.
 function assemble_block_entry!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation, row_node, col_node, value)
     @_propagate_inbounds_meta
@@ -1199,12 +1216,9 @@ end
 #  P2G_Matrix
 # -----------------------------------------------------------------------------
 
-struct ParticleAssembly end
-struct CellAssembly end
-
 # ---- support nodes ----
 
-@inline function matrix_supportnodes(bw, grid)
+function matrix_supportnodes(bw, grid)
     @_propagate_inbounds_meta
     # Matrix assembly indexes global DOF tables, which are built on logical
     # grid indices. For an SpGrid, supportnodes(bw, grid) returns SpIndex
@@ -1215,7 +1229,7 @@ struct CellAssembly end
     nodes, nodes
 end
 
-@inline function matrix_supportnodes(bw_i, grid_i, bw_j, grid_j)
+function matrix_supportnodes(bw_i, grid_i, bw_j, grid_j)
     @_propagate_inbounds_meta
     # See the single-grid method: matrix DOF tables need logical grid indices,
     # not SpGrid storage tokens.
@@ -1244,6 +1258,11 @@ end
 
 # ---- assembly scheduling ----
 
+struct ParticleAssembly end
+struct CellAssembly end
+
+# -- MPM --
+
 function P2G_Matrix(f, device::CPUDevice, schedule::Val, grids, particles, weights, partition)
     P2G((grids, particles, weights, p) -> (@inline f(grids, particles, weights, (p,), ParticleAssembly())), device, schedule, grids, particles, weights, partition)
 end
@@ -1259,6 +1278,8 @@ function P2G_Matrix(f, ::CPUDevice, ::Val{scheduler}, grids, particles, weights,
         end
     end
 end
+
+# -- FEM and IGA --
 
 function P2G_Matrix(f, ::CPUDevice, ::Val{scheduler}, grids, particles::QuadraturePoints,
                     weights::Tuple{<:BasisWeightArray{<:Any, <:Any, <:CellSupportMatrix}, <:BasisWeightArray{<:Any, <:Any, <:CellSupportMatrix}},
@@ -1288,6 +1309,8 @@ end
 
 # ---- macro implementation ----
 
+# -- matrix zeroing --
+
 function sparse_matrix_blocks_cover_parent(blocks, matrix)
     all(block -> parent(block) === matrix, blocks) || return false
     sum(nnz, blocks) == nnz(matrix) || return false
@@ -1299,10 +1322,7 @@ function sparse_matrix_blocks_cover_parent(blocks, matrix)
     true
 end
 
-function fillzero_matrix_targets!(matrices)
-    foreach(fillzero!, matrices)
-    nothing
-end
+fillzero_matrix_targets!(matrices) = foreach(fillzero!, matrices)
 
 # A complete set of disjoint blocks can zero its parent CSC in one contiguous pass.
 function fillzero_matrix_targets!(blocks::Tuple{Vararg{SparseMatrixBlockView}})
@@ -1315,6 +1335,8 @@ function fillzero_matrix_targets!(blocks::Tuple{Vararg{SparseMatrixBlockView}})
     end
     nothing
 end
+
+# -- public macro --
 
 """
     @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) [partition] begin
@@ -1348,6 +1370,8 @@ macro P2G_Matrix(schedule::QuoteNode, grid_ij, particles_p, weights_ipjp, partit
     P2G_Matrix_expr(schedule, grid_ij, particles_p, weights_ipjp, partition, equations)
 end
 
+# -- expansion --
+
 function P2G_Matrix_expr(schedule, grid_ij, particles_p, weights_ipjp, partition, equations)
     P2G_Matrix_expr(schedule, unpair2(grid_ij), unpair(particles_p), unpair2(weights_ipjp), partition, parse_transfer_program(equations))
 end
@@ -1369,29 +1393,25 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
     inner_symbols = p2g_cached_symbols(cached_replacements(scope, i, j, ip, jp))
 
     gmats = Any[]
-    matrices_init = Any[]
-    matrix_targets_to_zero = Any[]
-    hoist_exprs = Any[]
-    buffers_init = Any[]
-    block_buffers_init = Any[]
-    local_jdofs = Any[]
-    local_idofs = Any[]
-    assemble_first = Any[]
-    assemble_add = Any[]
-    assemble_block_entries = Any[]
-    finish_assemblies = Any[]
-    finish_block_assemblies = Any[]
+    matrices_init = Expr[]
+    matrix_targets_to_zero = Symbol[]
+    hoist_exprs = Expr[]
+    buffers_init = Expr[]
+    block_buffers_init = Expr[]
+    local_jdofs = Expr[]
+    local_idofs = Expr[]
+    assemble_first = Expr[]
+    assemble_add = Expr[]
+    assemble_block_entries = Expr[]
+    finish_assemblies = Expr[]
+    finish_block_assemblies = Expr[]
     for equation in equations
         (; lhs, rhs, op) = equation
         @capture(lhs, gmat_[gi_,gj_]) || error("@P2G_Matrix: Invalid global matrix expression, got `$lhs`")
         ((gi == i && gj == j) || (gi == j && gj == i)) || error("@P2G_Matrix: Expected expression of the form `$gmat[$i, $j]` or `$gmat[$j, $i]`, got `$lhs`")
         gmat in gmats && error("@P2G_Matrix: each global matrix may appear only once in a block; combine terms for `$gmat` into one `@∑` expression")
 
-        matrix = gensym(:matrix)
-        buffer = gensym(:buffer)
-        assembler = gensym(:assembler)
-        I = gensym(:I)
-        J = gensym(:J)
+        @gensym matrix buffer assembler matrix_cache I J
 
         op == :(=) && push!(matrix_targets_to_zero, matrix)
         op == :(-=) && (rhs = :(-$rhs))
@@ -1403,7 +1423,6 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         row_grid, col_grid = reorder_pair((grid_i, grid_j))
         row_weights, col_weights = reorder_pair((weights_i, weights_j))
         dof_table_i, dof_table_j = reorder_pair((:($(assembler).row_dof_table), :($(assembler).col_dof_table)))
-        matrix_cache = gensym(:matrix_cache)
         push!(matrices_init, quote
             $matrix = $gmat
             $assembler = Tesserae.matrix_assembler($matrix, Tesserae.get_mesh($row_grid), Tesserae.get_mesh($col_grid), Tesserae.basis($row_weights), Tesserae.basis($col_weights))

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -11,9 +11,9 @@ Create a degree of freedom (DoF) map from a `mask` of size `(ndofs, size(grid)..
 ```jldoctest
 julia> mesh = CartesianMesh(1, (0,2), (0,1));
 
-julia> grid = generate_grid(@NamedTuple{x::Vec{2,Float64}, v::Vec{2,Float64}}, mesh);
+julia> grid = generate_grid(@NamedTuple{x::Vec{2, Float64}, v::Vec{2, Float64}}, mesh);
 
-julia> grid.v .= reshape(reinterpret(Vec{2,Float64}, 1.0:12.0), 3, 2)
+julia> grid.v .= reshape(reinterpret(Vec{2, Float64}, 1.0:12.0), 3, 2)
 3×2 Matrix{Vec{2, Float64}}:
  [1.0, 2.0]  [7.0, 8.0]
  [3.0, 4.0]  [9.0, 10.0]
@@ -25,7 +25,7 @@ julia> dofmask[1,1:2,:] .= true; # activate nodes
 
 julia> dofmask[:,3,2] .= true; # activate nodes
 
-julia> reinterpret(reshape, Vec{2,Bool}, dofmask)
+julia> reinterpret(reshape, Vec{2, Bool}, dofmask)
 3×2 reinterpret(reshape, Vec{2, Bool}, ::BitArray{3}) with eltype Vec{2, Bool}:
  [1, 0]  [1, 0]
  [1, 0]  [1, 0]
@@ -78,13 +78,27 @@ end
 #  Sparse matrix blocks
 # -----------------------------------------------------------------------------
 
+# ---- sparsity patterns ----
+
+abstract type SparseMatrixPattern end
+
+# This metadata proves the canonical Cartesian pattern without rescanning the
+# parent CSC.
+struct CartesianSparseMatrixPattern{N} <: SparseMatrixPattern
+    mesh_size::Dims{N}
+    sparsity_radius::Int
+end
+
+struct CellSparseMatrixPattern <: SparseMatrixPattern end
+
 # ---- SparseMatrixBlockView ----
 
-struct SparseMatrixBlockView{T,Ti} <: AbstractMatrix{T}
-    matrix::SparseMatrixCSC{T,Ti}
+struct SparseMatrixBlockView{T, Ti, P <: SparseMatrixPattern} <: AbstractMatrix{T}
+    matrix::SparseMatrixCSC{T, Ti}
     rows::UnitRange{Int}
     cols::UnitRange{Int}
     column_slots::Vector{UnitRange{Int}}
+    pattern::P
 end
 
 Base.size(block::SparseMatrixBlockView) = (length(block.rows), length(block.cols))
@@ -126,11 +140,11 @@ SparseArrays.nnz(block::SparseMatrixBlockView) = sum(length, block.column_slots)
 # ---- SparseMatrixBlocks ----
 
 # Owns the parent CSC and creates block views from shared offsets and slot tables.
-struct SparseMatrixBlocks{T,Ti} <: AbstractMatrix{SparseMatrixBlockView{T,Ti}}
-    matrix::SparseMatrixCSC{T,Ti}
-    row_offsets::Vector{Int}
-    col_offsets::Vector{Int}
+struct SparseMatrixBlocks{T, Ti, P <: SparseMatrixPattern} <: AbstractMatrix{SparseMatrixBlockView{T, Ti, P}}
+    matrix::SparseMatrixCSC{T, Ti}
+    field_offsets::Vector{Int}
     column_slots::Matrix{Vector{UnitRange{Int}}}
+    pattern::P
 end
 
 Base.size(blocks::SparseMatrixBlocks) = size(blocks.column_slots)
@@ -140,9 +154,10 @@ function Base.getindex(blocks::SparseMatrixBlocks, i::Int, j::Int)
     @boundscheck checkbounds(blocks, i, j)
     @inbounds SparseMatrixBlockView(
         blocks.matrix,
-        (blocks.row_offsets[i] + 1):blocks.row_offsets[i + 1],
-        (blocks.col_offsets[j] + 1):blocks.col_offsets[j + 1],
+        (blocks.field_offsets[i] + 1):blocks.field_offsets[i + 1],
+        (blocks.field_offsets[j] + 1):blocks.field_offsets[j + 1],
         blocks.column_slots[i,j],
+        blocks.pattern,
     )
 end
 
@@ -152,95 +167,6 @@ function fillzero!(blocks::SparseMatrixBlocks)
 end
 
 # ---- construction ----
-
-# -- existing matrices --
-
-function _combine_sparse_matrix_blocks(block_rows::Tuple...)
-    isempty(block_rows) && throw(ArgumentError("at least one block row is required"))
-    nblockcols = length(first(block_rows))
-    nblockcols > 0 || throw(ArgumentError("at least one block column is required"))
-    all(length(row) == nblockcols for row in block_rows) || throw(DimensionMismatch("block rows must have the same number of columns"))
-
-    first_block = first(first(block_rows))
-    first_block isa SparseMatrixCSC || throw(ArgumentError("matrix blocks must be SparseMatrixCSC"))
-    block_type = typeof(first_block)
-    nblockrows = length(block_rows)
-    matrices = Matrix{block_type}(undef, nblockrows, nblockcols)
-    for j in 1:nblockcols, i in 1:nblockrows
-        block = block_rows[i][j]
-        block isa block_type || throw(ArgumentError("matrix blocks must have the same element and index types"))
-        matrices[i,j] = block
-    end
-
-    row_sizes = [size(matrices[i,1], 1) for i in 1:nblockrows]
-    col_sizes = [size(matrices[1,j], 2) for j in 1:nblockcols]
-    for j in 1:nblockcols, i in 1:nblockrows
-        size(matrices[i,j]) == (row_sizes[i], col_sizes[j]) || throw(DimensionMismatch("matrix block sizes are inconsistent"))
-    end
-
-    row_offsets = cumsum([0; row_sizes])
-    col_offsets = cumsum([0; col_sizes])
-    column_slots = [Vector{UnitRange{Int}}(undef, col_sizes[j]) for i in 1:nblockrows, j in 1:nblockcols]
-
-    # Build the parent CSC and record each block's slots in the same column pass.
-    T = eltype(first_block)
-    Ti = SparseArrays.indtype(first_block)
-    matrix_colptr = Vector{Ti}(undef, sum(col_sizes) + 1)
-    matrix_rowvals = Vector{Ti}(undef, sum(nnz, matrices))
-    matrix_values = Vector{T}(undef, length(matrix_rowvals))
-    slot = 1
-    for j in 1:nblockcols, local_col in 1:col_sizes[j]
-        matrix_colptr[col_offsets[j] + local_col] = slot
-        for i in 1:nblockrows
-            block = matrices[i,j]
-            source_rows = rowvals(block)
-            source_values = nonzeros(block)
-            first_slot = slot
-            @inbounds for source_slot in nzrange(block, local_col)
-                matrix_rowvals[slot] = row_offsets[i] + source_rows[source_slot]
-                matrix_values[slot] = source_values[source_slot]
-                slot += 1
-            end
-            column_slots[i,j][local_col] = first_slot:(slot - 1)
-        end
-    end
-    matrix_colptr[end] = slot
-    matrix = SparseMatrixCSC(sum(row_sizes), sum(col_sizes), matrix_colptr, matrix_rowvals, matrix_values)
-
-    SparseMatrixBlocks(matrix, row_offsets, col_offsets, column_slots)
-end
-
-function _block_matrix_rows(expr)
-    if Meta.isexpr(expr, :hcat)
-        return (expr.args,)
-    elseif Meta.isexpr(expr, :vcat)
-        return map(row -> Meta.isexpr(row, :row) ? row.args : Any[row], expr.args)
-    elseif Meta.isexpr(expr, :vect, 1)
-        return (expr.args,)
-    else
-        throw(ArgumentError("@block_sparse_matrix requires a two-dimensional matrix literal"))
-    end
-end
-
-"""
-    @block_sparse_matrix [Kuu Kup; Kpu Kpp]
-
-Combine existing `SparseMatrixCSC` objects into one parent CSC matrix and
-return its block views.
-
-```julia
-blocks = @block_sparse_matrix [Kuu Kup; Kpu Kpp]
-K = parent(blocks)
-```
-
-All blocks must have the same element and index types and consistent row and
-column sizes. The returned views share the fixed sparsity structure of `K`.
-"""
-macro block_sparse_matrix(expr)
-    block_rows = _block_matrix_rows(expr)
-    escaped_rows = map(row -> Expr(:tuple, map(esc, row)...), block_rows)
-    :(_combine_sparse_matrix_blocks($(escaped_rows...)))
-end
 
 # -- field matrix API --
 
@@ -261,23 +187,24 @@ Kuu, Kup = blocks[1,1], blocks[1,2]
 Kpu, Kpp = blocks[2,1], blocks[2,2]
 ```
 
-The parent CSC is constructed directly in block order. Block views share its
-fixed sparsity structure and permit updates only at stored positions.
-Structural changes made through `parent(blocks)` invalidate all block views.
+The parent CSC uses the sparsity pattern generated from the supplied
+discretization. Block views share its fixed structure and permit updates only
+at stored positions. Structural changes made through `parent(blocks)`
+invalidate all block views.
 """
 function create_block_sparse_matrix end
 
 create_block_sparse_matrix(basis::Basis, mesh::CartesianMesh; ndofs::NTuple{N, Int}) where {N} = create_block_sparse_matrix(Float64, basis, mesh; ndofs)
-create_block_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh; ndofs::NTuple{N, Int}) where {T,N} = _create_block_sparse_matrix(T, basis, mesh, ndofs)
+create_block_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh; ndofs::NTuple{N, Int}) where {T, N} = _create_block_sparse_matrix(T, basis, mesh, ndofs)
 
 create_block_sparse_matrix(mesh::Union{FEMesh, IGAMesh}; ndofs::NTuple{N, Int}) where {N} = create_block_sparse_matrix(Float64, mesh; ndofs)
-function create_block_sparse_matrix(::Type{T}, mesh::Union{FEMesh, IGAMesh}; ndofs::NTuple{N, Int}) where {T,N}
+function create_block_sparse_matrix(::Type{T}, mesh::Union{FEMesh, IGAMesh}; ndofs::NTuple{N, Int}) where {T, N}
     meshes = ntuple(_ -> mesh, N)
     _create_block_sparse_matrix(T, meshes, ndofs)
 end
 
-create_block_sparse_matrix(meshes::Union{NTuple{N,FEMesh}, NTuple{N,IGAMesh}}; ndofs::NTuple{N, Int}) where {N} = create_block_sparse_matrix(Float64, meshes; ndofs)
-create_block_sparse_matrix(::Type{T}, meshes::Union{NTuple{N,FEMesh}, NTuple{N,IGAMesh}}; ndofs::NTuple{N, Int}) where {T,N} = _create_block_sparse_matrix(T, meshes, ndofs)
+create_block_sparse_matrix(meshes::Union{NTuple{N, FEMesh}, NTuple{N, IGAMesh}}; ndofs::NTuple{N, Int}) where {N} = create_block_sparse_matrix(Float64, meshes; ndofs)
+create_block_sparse_matrix(::Type{T}, meshes::Union{NTuple{N, FEMesh}, NTuple{N, IGAMesh}}; ndofs::NTuple{N, Int}) where {T, N} = _create_block_sparse_matrix(T, meshes, ndofs)
 
 # -- helpers --
 
@@ -287,7 +214,7 @@ function check_field_ndofs(ndofs)
     nothing
 end
 
-function _create_sparse_matrix_blocks(::Type{T}, I, J, field_offsets) where {T}
+function _create_sparse_matrix_blocks(::Type{T}, I, J, field_offsets, pattern::SparseMatrixPattern) where {T}
     matrix_size = last(field_offsets)
     matrix = sparse(I, J, zeros(T, length(I)), matrix_size, matrix_size)
     nfields = length(field_offsets) - 1
@@ -308,7 +235,7 @@ function _create_sparse_matrix_blocks(::Type{T}, I, J, field_offsets) where {T}
         end
     end
 
-    SparseMatrixBlocks(matrix, field_offsets, field_offsets, column_slots)
+    SparseMatrixBlocks(matrix, field_offsets, column_slots, pattern)
 end
 
 # -- MPM --
@@ -321,7 +248,8 @@ function _create_block_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMes
     for j in eachindex(ndofs), i in eachindex(ndofs)
         _append_sparse_pattern!(I, J, field_offsets[i], field_offsets[j], basis, mesh, ndofs[i], ndofs[j])
     end
-    _create_sparse_matrix_blocks(T, I, J, field_offsets)
+    pattern = CartesianSparseMatrixPattern(size(mesh), support_width(basis) - 1)
+    _create_sparse_matrix_blocks(T, I, J, field_offsets, pattern)
 end
 
 # -- FEM and IGA --
@@ -334,7 +262,7 @@ function _create_block_sparse_matrix(::Type{T}, meshes::Union{NTuple{N, FEMesh},
     for j in eachindex(meshes), i in eachindex(meshes)
         _append_sparse_pattern!(I, J, field_offsets[i], field_offsets[j], meshes[i], meshes[j], ndofs[i], ndofs[j])
     end
-    _create_sparse_matrix_blocks(T, I, J, field_offsets)
+    _create_sparse_matrix_blocks(T, I, J, field_offsets, CellSparseMatrixPattern())
 end
 
 # -----------------------------------------------------------------------------
@@ -416,13 +344,13 @@ function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Int) where {
     _create_cell_support_sparse_matrix(T, mesh, (ndofs, ndofs))
 end
 
-function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Tuple{Int,Int}) where {T}
+function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Tuple{Int, Int}) where {T}
     I, J = Int[], Int[]
     _append_sparse_pattern!(I, J, 0, 0, mesh, ndofs[1], ndofs[2])
     sparse(I, J, zeros(T, length(I)), ndofs[1] * length(mesh), ndofs[2] * length(mesh))
 end
 
-function _append_sparse_pattern!(I, J, row_offset, col_offset, mesh::Union{FEMesh,IGAMesh}, row_ndofs, col_ndofs)
+function _append_sparse_pattern!(I, J, row_offset, col_offset, mesh::Union{FEMesh, IGAMesh}, row_ndofs, col_ndofs)
     row_dofs = LinearIndices((row_ndofs, length(mesh)))
     col_dofs = LinearIndices((col_ndofs, length(mesh)))
     for cell in cells(mesh)
@@ -432,7 +360,7 @@ function _append_sparse_pattern!(I, J, row_offset, col_offset, mesh::Union{FEMes
     nothing
 end
 
-function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::Union{FEMesh,IGAMesh}, colmesh::Union{FEMesh,IGAMesh}, row_ndofs, col_ndofs)
+function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::Union{FEMesh, IGAMesh}, colmesh::Union{FEMesh, IGAMesh}, row_ndofs, col_ndofs)
     throw(ArgumentError("all field meshes must use compatible discretizations"))
 end
 
@@ -445,7 +373,7 @@ function _create_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh{dim}
     _create_sparse_matrix(T, basis, mesh, (ndofs, ndofs))
 end
 
-function _create_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh{dim}, ndofs::Tuple{Int,Int}) where {T, dim}
+function _create_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh{dim}, ndofs::Tuple{Int, Int}) where {T, dim}
     row_ndofs, col_ndofs = ndofs
     I, J = Int[], Int[]
     _append_sparse_pattern!(I, J, 0, 0, basis, mesh, row_ndofs, col_ndofs)
@@ -473,13 +401,13 @@ end
 
 # -- FEM and IGA --
 
-function create_sparse_matrix(::Type{T}, (rowmesh,colmesh)::Tuple{Vararg{Union{FEMesh,IGAMesh},2}}; ndofs::Tuple{Int,Int}) where {T}
+function create_sparse_matrix(::Type{T}, (rowmesh,colmesh)::Tuple{Vararg{Union{FEMesh, IGAMesh}, 2}}; ndofs::Tuple{Int, Int}) where {T}
     I, J = Int[], Int[]
     _append_sparse_pattern!(I, J, 0, 0, rowmesh, colmesh, ndofs[1], ndofs[2])
     sparse(I, J, zeros(T, length(I)), ndofs[1] * length(rowmesh), ndofs[2] * length(colmesh))
 end
 
-function create_sparse_matrix(meshes::Tuple{Vararg{Union{FEMesh,IGAMesh},2}}; ndofs::Tuple{Int,Int})
+function create_sparse_matrix(meshes::Tuple{Vararg{Union{FEMesh, IGAMesh}, 2}}; ndofs::Tuple{Int, Int})
     create_sparse_matrix(Float64, meshes; ndofs)
 end
 
@@ -512,13 +440,13 @@ create_sparse_matrix(::IGABasis, mesh::IGAMesh{dim}; ndofs) where {dim} = _creat
 create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh{dim}; ndofs) where {T, dim} = _create_sparse_matrix(T, mesh, ndofs)
 
 _create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Int) where {T} = _create_sparse_matrix(T, mesh, ndofs)
-_create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T} = _create_sparse_matrix(T, mesh, ndofs)
+_create_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Tuple{Int, Int}) where {T} = _create_sparse_matrix(T, mesh, ndofs)
 _create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Int) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
-_create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
+_create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Tuple{Int, Int}) where {T} = _create_cell_support_sparse_matrix(T, mesh, ndofs)
 create_sparse_matrix(::Type{T}, mesh::IGAMesh{dim}; ndofs) where {T, dim} = _create_sparse_matrix(T, mesh, ndofs)
 create_sparse_matrix(mesh::IGAMesh{dim}; ndofs) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
 
-function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::IGAMesh{dim,pdim}, colmesh::IGAMesh{dim,pdim}, row_ndofs, col_ndofs) where {dim,pdim}
+function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::IGAMesh{dim, pdim}, colmesh::IGAMesh{dim, pdim}, row_ndofs, col_ndofs) where {dim, pdim}
     rowmesh === colmesh && return _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh, row_ndofs, col_ndofs)
     check_matching_cell_partitions(rowmesh, colmesh)
 
@@ -619,10 +547,10 @@ end
 end
 
 matrix_storage(matrix) = matrix
-matrix_storage(matrix::Union{SparseMatrixCSCView,SparseMatrixBlockView}) = parent(matrix)
+matrix_storage(matrix::Union{SparseMatrixCSCView, SparseMatrixBlockView}) = parent(matrix)
 
 matrix_storage_indices(matrix) = axes(matrix)
-matrix_storage_indices(matrix::Union{SparseMatrixCSCView,SparseMatrixBlockView}) = parentindices(matrix)
+matrix_storage_indices(matrix::Union{SparseMatrixCSCView, SparseMatrixBlockView}) = parentindices(matrix)
 
 storage_index(::Base.OneTo, index) = index
 storage_index(indices, index) = (@_propagate_inbounds_meta; indices[index])
@@ -820,18 +748,22 @@ function CartesianSparseMatrixAssembler(matrix::SparseMatrixCSCView, row_mesh::C
     assembler
 end
 
-function CartesianSparseMatrixAssembler(matrix::SparseMatrixBlockView, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
+function CartesianSparseMatrixAssembler(matrix::SparseMatrixBlockView{T, Ti, P}, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {T, Ti, N, P <: CartesianSparseMatrixPattern}
     sparsity_radius = cartesian_sparsity_radius(row_mesh, col_mesh, row_basis, col_basis)
+    matrix.pattern.mesh_size == size(row_mesh) || throw(DimensionMismatch("matrix block and mesh sizes must match"))
+    matrix.pattern.sparsity_radius == sparsity_radius || throw(ArgumentError("matrix block and basis must use the same support width"))
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
-    assembler = CartesianSparseMatrixAssembler(
+    CartesianSparseMatrixAssembler(
         matrix,
         row_dof_table,
         col_dof_table,
         size(row_dof_table, 1),
         sparsity_radius,
     )
-    has_cartesian_sparse_pattern(assembler) || throw(ArgumentError("Cartesian sparse matrix block must use the canonical sparsity pattern"))
-    assembler
+end
+
+function CartesianSparseMatrixAssembler(::SparseMatrixBlockView, ::CartesianMesh, ::CartesianMesh, ::Basis, ::Basis)
+    throw(ArgumentError("Cartesian assembly requires blocks created from a Cartesian mesh"))
 end
 
 @noinline function check_cartesian_sparse_matrix_view(assembler::CartesianSparseMatrixAssembler)
@@ -860,10 +792,10 @@ end
 
 # ---- GenericMatrixAssembler ----
 
-struct GenericMatrixAssembler{M <: AbstractMatrix, R <: LinearIndices, C <: LinearIndices}
+struct GenericMatrixAssembler{M <: AbstractMatrix, D <: LinearIndices}
     matrix::M
-    row_dof_table::R
-    col_dof_table::C
+    row_dof_table::D
+    col_dof_table::D
 end
 
 function add!(assembler::GenericMatrixAssembler, row_nodes, col_nodes, local_matrix)
@@ -889,18 +821,12 @@ end
     row_ndofs = size(row_dof_table, 1)
     col_ndofs = size(col_dof_table, 1)
     @boundscheck check_matrix_entry_size(value, row_ndofs, col_ndofs)
-    @inbounds add_matrix_entry!(storage, row_dof_table, col_dof_table, row_storage_indices, col_storage_indices, row_node, col_node, value, row_ndofs, col_ndofs)
-    matrix
-end
-
-function add_matrix_entry!(storage, row_dof_table, col_dof_table, row_storage_indices, col_storage_indices, row_node, col_node, value, row_ndofs, col_ndofs)
-    @_propagate_inbounds_meta
-    for b in 1:col_ndofs, a in 1:row_ndofs
+    @inbounds for b in 1:col_ndofs, a in 1:row_ndofs
         row = storage_index(row_storage_indices, row_dof_table[a,row_node])
         col = storage_index(col_storage_indices, col_dof_table[b,col_node])
         storage[row,col] += value[(b - 1) * row_ndofs + a]
     end
-    nothing
+    matrix
 end
 
 function support_dofs(table_i, nodes_i, table_j, nodes_j)
@@ -919,7 +845,7 @@ function matrix_assembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
     GenericMatrixAssembler(matrix, row_dof_table, col_dof_table)
 end
-function matrix_assembler(matrix::Union{SparseMatrixCSC,SparseMatrixCSCView,SparseMatrixBlockView}, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
+function matrix_assembler(matrix::Union{SparseMatrixCSC, SparseMatrixCSCView, SparseMatrixBlockView}, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 end
 function matrix_assembler(::SparseMatrixBlocks, row_mesh, col_mesh, row_basis, col_basis)
@@ -1001,10 +927,9 @@ function assemble_first!(assembler, ::Nothing, orientation, row_node, col_node, 
     add_entry!(assembler, row_node, col_node, orient_matrix_entry(orientation, value))
 end
 
-function assemble_add!(assembler, ::Nothing, orientation, row_node, col_node, I, J, value)
+function assemble_add!(assembler, buffer::Nothing, orientation, row_node, col_node, I, J, value)
     @_propagate_inbounds_meta
-    row_node, col_node = orientation((row_node, col_node))
-    add_entry!(assembler, row_node, col_node, orient_matrix_entry(orientation, value))
+    assemble_first!(assembler, buffer, orientation, row_node, col_node, I, J, value)
 end
 
 finish_assembly!(assembler, ::Nothing, orientation, row_nodes, col_nodes) = assembler.matrix
@@ -1021,7 +946,7 @@ struct BlockAssembly{I <: CartesianIndices}
     matrix_buffer_pool::BlockMatrixBufferPool
 end
 
-struct BlockMatrixBufferKey{T,N}
+struct BlockMatrixBufferKey{T, N}
     row_size::Dims{N}
     col_size::Dims{N}
     col_offset::CartesianIndex{N}
@@ -1030,15 +955,15 @@ struct BlockMatrixBufferKey{T,N}
     sparsity_radius::Int
 end
 
-struct BlockMatrixBuffer{T,N}
+struct BlockMatrixBuffer{T, N}
     values::Vector{T}
     node_colstarts::Vector{Int}
-    key::BlockMatrixBufferKey{T,N}
+    key::BlockMatrixBufferKey{T, N}
 end
 
 function BlockMatrixBufferKey(assembler::CartesianSparseMatrixAssembler, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {N}
     (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
-    BlockMatrixBufferKey{eltype(matrix),N}(
+    BlockMatrixBufferKey{eltype(matrix), N}(
         size(row_nodes),
         size(col_nodes),
         first(col_nodes) - first(row_nodes),
@@ -1048,7 +973,7 @@ function BlockMatrixBufferKey(assembler::CartesianSparseMatrixAssembler, row_nod
     )
 end
 
-function BlockMatrixBuffer(key::BlockMatrixBufferKey{T,N}) where {T,N}
+function BlockMatrixBuffer(key::BlockMatrixBufferKey{T, N}) where {T, N}
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs, sparsity_radius) = key
     node_colstarts = Vector{Int}(undef, prod(col_size))
     slot = 1
@@ -1062,13 +987,13 @@ end
 
 # ---- buffer pool ----
 
-function acquire!(pool::BlockMatrixBufferPool, key::BlockMatrixBufferKey{T,N}) where {T,N}
+function acquire!(pool::BlockMatrixBufferPool, key::BlockMatrixBufferKey{T, N}) where {T, N}
     buffer = lock(pool.lock) do
         buffers = get!(Vector{Any}, pool.buffers, key)
         isempty(buffers) ? nothing : pop!(buffers)
     end
     buffer === nothing && return BlockMatrixBuffer(key)
-    buffer = buffer::BlockMatrixBuffer{T,N}
+    buffer = buffer::BlockMatrixBuffer{T, N}
     fillzero!(buffer.values)
     buffer
 end
@@ -1082,8 +1007,9 @@ end
 
 # ---- block buffer selection ----
 
-# Canonical Cartesian CSC matrices and their component views use a block buffer.
-# Other matrices are written directly within the thread-safe block schedule.
+# Canonical Cartesian CSC matrices, component views, and block views use a
+# block buffer. Other matrices are written directly within the thread-safe
+# block schedule.
 function block_matrix_buffer(assembler::CartesianSparseMatrixAssembler, assembly::BlockAssembly, orientation)
     row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))
     acquire!(assembly.matrix_buffer_pool, BlockMatrixBufferKey(assembler, row_nodes, col_nodes))
@@ -1095,7 +1021,7 @@ block_matrix_buffer(::GenericMatrixAssembler, ::BlockAssembly, orientation) = no
 
 # -- accumulation --
 
-function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, row_node::CartesianIndex{N}, col_node::CartesianIndex{N}, value) where {T,N}
+function add_entry!(buffer::BlockMatrixBuffer{T, N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, row_node::CartesianIndex{N}, col_node::CartesianIndex{N}, value) where {T, N}
     @_propagate_inbounds_meta
     @boundscheck check_block_matrix_entry(buffer, row_nodes, col_nodes, row_node, col_node, value)
 
@@ -1113,7 +1039,7 @@ function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{
     buffer
 end
 
-@noinline function check_block_matrix_entry(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, row_node::CartesianIndex{N}, col_node::CartesianIndex{N}, value) where {T,N}
+@noinline function check_block_matrix_entry(buffer::BlockMatrixBuffer{T, N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}, row_node::CartesianIndex{N}, col_node::CartesianIndex{N}, value) where {T, N}
     (; key) = buffer
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs, sparsity_radius) = key
     size(row_nodes) == row_size || throw(DimensionMismatch("row support size does not match block matrix buffer"))
@@ -1131,7 +1057,7 @@ end
 
 # -- scatter --
 
-function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {T,N}
+function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer{T, N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {T, N}
     @_propagate_inbounds_meta
     @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
 
@@ -1183,7 +1109,7 @@ end
 
 # -- route dispatch --
 
-# Canonical Cartesian CSC entries are accumulated in the block buffer.
+# Canonical Cartesian entries are accumulated in the block buffer.
 function assemble_block_entry!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, assembly::BlockAssembly, orientation, row_node, col_node, value)
     @_propagate_inbounds_meta
     row_nodes, col_nodes = orientation((assembly.nodes_i, assembly.nodes_j))

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -70,6 +70,137 @@ function (dofmap::DofMap)(A::AbstractArray{T}) where {T <: Real}
     @inbounds view(A′, dofmap.indices4scalar)
 end
 
+struct SparseMatrixBlockView{T,Ti,P <: SparseMatrixCSC{T,Ti}} <: AbstractMatrix{T}
+    matrix::P
+    rows::UnitRange{Int}
+    cols::UnitRange{Int}
+    column_slots::Vector{UnitRange{Ti}}
+end
+
+Base.size(block::SparseMatrixBlockView) = (length(block.rows), length(block.cols))
+Base.parent(block::SparseMatrixBlockView) = block.matrix
+Base.parentindices(block::SparseMatrixBlockView) = (block.rows, block.cols)
+
+function Base.getindex(block::SparseMatrixBlockView, i::Int, j::Int)
+    @_propagate_inbounds_meta
+    @boundscheck checkbounds(block, i, j)
+    @inbounds parent(block)[block.rows[i],block.cols[j]]
+end
+
+function Base.setindex!(block::SparseMatrixBlockView, value, i::Int, j::Int)
+    @_propagate_inbounds_meta
+    @boundscheck checkbounds(block, i, j)
+    @inbounds parent(block)[block.rows[i],block.cols[j]] = value
+    block
+end
+
+function fillzero!(block::SparseMatrixBlockView)
+    values = nonzeros(parent(block))
+    zero_value = zero_recursive(eltype(values))
+    for slots in block.column_slots, slot in slots
+        @inbounds values[slot] = zero_value
+    end
+    block
+end
+
+SparseArrays.nnz(block::SparseMatrixBlockView) = sum(length, block.column_slots)
+
+"""
+An array of sparse matrix block views that share the same parent CSC matrix.
+"""
+struct SparseMatrixBlocks{V <: SparseMatrixBlockView} <: AbstractMatrix{V}
+    views::Matrix{V}
+
+    function SparseMatrixBlocks(views::Matrix{V}) where {V <: SparseMatrixBlockView}
+        isempty(views) && throw(ArgumentError("sparse matrix blocks must not be empty"))
+        matrix = parent(first(views))
+        all(block -> parent(block) === matrix, views) || throw(ArgumentError("sparse matrix blocks must share the same parent matrix"))
+        new{V}(views)
+    end
+end
+
+
+Base.size(blocks::SparseMatrixBlocks) = size(blocks.views)
+Base.getindex(blocks::SparseMatrixBlocks, i::Int, j::Int) = blocks.views[i,j]
+Base.parent(blocks::SparseMatrixBlocks) = parent(first(blocks.views))
+
+function fillzero!(blocks::SparseMatrixBlocks)
+    fillzero!(parent(blocks))
+    blocks
+end
+
+"""
+    create_block_sparse_matrix(block_rows...)
+
+Combine sparse matrices into one CSC matrix and return its block views. Each
+argument describes one block row and must be a tuple of `SparseMatrixCSC`
+objects.
+"""
+function create_block_sparse_matrix(block_rows::Tuple...)
+    isempty(block_rows) && throw(ArgumentError("at least one block row is required"))
+    nblockcols = length(first(block_rows))
+    nblockcols > 0 || throw(ArgumentError("at least one block column is required"))
+    all(length(row) == nblockcols for row in block_rows) || throw(DimensionMismatch("block rows must have the same number of columns"))
+
+    first_block = first(first(block_rows))
+    first_block isa SparseMatrixCSC || throw(ArgumentError("matrix blocks must be SparseMatrixCSC"))
+    block_type = typeof(first_block)
+    nblockrows = length(block_rows)
+    matrices = Matrix{block_type}(undef, nblockrows, nblockcols)
+    for j in 1:nblockcols, i in 1:nblockrows
+        block = block_rows[i][j]
+        block isa block_type || throw(ArgumentError("matrix blocks must have the same element and index types"))
+        matrices[i,j] = block
+    end
+
+    row_sizes = [size(matrices[i,1], 1) for i in 1:nblockrows]
+    col_sizes = [size(matrices[1,j], 2) for j in 1:nblockcols]
+    for j in 1:nblockcols, i in 1:nblockrows
+        size(matrices[i,j]) == (row_sizes[i], col_sizes[j]) || throw(DimensionMismatch("matrix block sizes are inconsistent"))
+    end
+
+    matrix_rows = [hcat(matrices[i,:]...) for i in 1:nblockrows]
+    matrix = vcat(matrix_rows...)
+    row_offsets = cumsum([0; row_sizes])
+    col_offsets = cumsum([0; col_sizes])
+    Ti = eltype(matrix.colptr)
+    column_slots = Matrix{Vector{UnitRange{Ti}}}(undef, nblockrows, nblockcols)
+    for j in 1:nblockcols, i in 1:nblockrows
+        column_slots[i,j] = Vector{UnitRange{Ti}}(undef, col_sizes[j])
+    end
+    for j in 1:nblockcols, local_col in 1:col_sizes[j]
+        col = col_offsets[j] + local_col
+        slot = first(nzrange(matrix, col))
+        for i in 1:nblockrows
+            count = length(nzrange(matrices[i,j], local_col))
+            column_slots[i,j][local_col] = slot:(slot + count - 1)
+            slot += count
+        end
+        slot == last(nzrange(matrix, col)) + 1 || error("failed to construct sparse matrix block slots")
+    end
+
+    first_view = SparseMatrixBlockView(
+        matrix,
+        (row_offsets[1] + 1):row_offsets[2],
+        (col_offsets[1] + 1):col_offsets[2],
+        column_slots[1,1],
+    )
+    views = Matrix{typeof(first_view)}(undef, nblockrows, nblockcols)
+    for j in 1:nblockcols, i in 1:nblockrows
+        views[i,j] = SparseMatrixBlockView(
+            matrix,
+            (row_offsets[i] + 1):row_offsets[i + 1],
+            (col_offsets[j] + 1):col_offsets[j + 1],
+            column_slots[i,j],
+        )
+    end
+    SparseMatrixBlocks(views)
+end
+
+function create_block_sparse_matrix(block_rows::Tuple{Vararg{Tuple}})
+    create_block_sparse_matrix(block_rows...)
+end
+
 """
     create_sparse_matrix(mesh; ndofs)
     create_sparse_matrix((rowmesh, colmesh); ndofs=(row_ndofs, col_ndofs))
@@ -329,9 +460,11 @@ end
 
 matrix_storage(matrix) = matrix
 matrix_storage(matrix::SparseMatrixCSCView) = parent(matrix)
+matrix_storage(matrix::SparseMatrixBlockView) = parent(matrix)
 
 matrix_storage_indices(matrix) = axes(matrix)
 matrix_storage_indices(matrix::SparseMatrixCSCView) = parentindices(matrix)
+matrix_storage_indices(matrix::SparseMatrixBlockView) = parentindices(matrix)
 
 storage_index(::Base.OneTo, index) = index
 storage_index(indices, index) = (@_propagate_inbounds_meta; indices[index])
@@ -471,6 +604,67 @@ function CartesianSparseMatrixAssembler(matrix::SparseMatrixCSCView, row_mesh::C
     assembler
 end
 
+function CartesianSparseMatrixAssembler(matrix::SparseMatrixBlockView, row_mesh::CartesianMesh{N}, col_mesh::CartesianMesh{N}, row_basis::Basis, col_basis::Basis) where {N}
+    size(row_mesh) == size(col_mesh) || throw(DimensionMismatch("row and column meshes must have the same size"))
+    row_sparsity_radius = support_width(row_basis) - 1
+    col_sparsity_radius = support_width(col_basis) - 1
+    row_sparsity_radius == col_sparsity_radius || throw(ArgumentError("row and column bases must have the same support width"))
+    row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
+    assembler = CartesianSparseMatrixAssembler(
+        matrix,
+        row_dof_table,
+        col_dof_table,
+        row_dof_table,
+        col_dof_table,
+        row_sparsity_radius,
+    )
+    has_cartesian_sparse_pattern(assembler) || throw(ArgumentError("Cartesian sparse matrix block must use the canonical sparsity pattern"))
+    assembler
+end
+
+function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView})
+    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
+    mesh_size = Base.tail(size(row_dof_table))
+    row_ndofs = size(row_dof_table, 1)
+    col_ndofs = size(col_dof_table, 1)
+    row_offset = first(matrix.rows) - 1
+    rows = rowvals(parent(matrix))
+    for col_node in CartesianIndices(mesh_size), b in 1:col_ndofs
+        col = col_dof_table[b,col_node]
+        slots = matrix.column_slots[col]
+        k = first(slots)
+        stop = last(slots) + 1
+        for row_node in cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius), a in 1:row_ndofs
+            k < stop || return false
+            rows[k] == row_offset + row_dof_table[a,row_node] || return false
+            k += 1
+        end
+        k == stop || return false
+    end
+    true
+end
+
+@inline function add_entry!(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView}, row_node::CartesianIndex, col_node::CartesianIndex, value)
+    @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
+
+    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
+    mesh_size = Base.tail(size(row_dof_table))
+    row_ndofs = size(row_dof_table, 1)
+    col_ndofs = size(col_dof_table, 1)
+    neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
+    neighboring_node = row_node - first(neighboring_nodes) + oneunit(row_node)
+    row_offset = (LinearIndices(neighboring_nodes)[neighboring_node] - 1) * row_ndofs
+    values = nonzeros(parent(matrix))
+
+    @inbounds for b in 1:col_ndofs
+        col = col_dof_table[b,col_node]
+        slot = first(matrix.column_slots[col]) + row_offset
+        add_entry_values!(values, slot, value, (b - 1) * row_ndofs + 1, Base.OneTo(row_ndofs), row_ndofs)
+    end
+
+    matrix
+end
+
 @noinline function check_cartesian_sparse_matrix_view(assembler::CartesianSparseMatrixAssembler)
     (; matrix, row_dof_table, col_dof_table, storage_row_dof_table, storage_col_dof_table) = assembler
     row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
@@ -559,6 +753,12 @@ function matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_
 end
 function matrix_assembler(matrix::SparseMatrixCSCView, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
+end
+function matrix_assembler(matrix::SparseMatrixBlockView, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
+    CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
+end
+function matrix_assembler(::SparseMatrixBlocks, row_mesh, col_mesh, row_basis, col_basis)
+    throw(ArgumentError("@P2G_Matrix requires an individual matrix block; pass blocks[row, col] instead of blocks"))
 end
 
 function matrix_dof_tables(gmat, row_grid, col_grid)
@@ -795,6 +995,38 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
     matrix
 end
 
+function scatter!(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView}, buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {T,N}
+    @_propagate_inbounds_meta
+    @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
+
+    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
+    (; values, node_colstarts, key) = buffer
+    (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
+
+    mesh_size = Base.tail(size(row_dof_table))
+    matrix_values = nonzeros(parent(matrix))
+    first_row_node = first(row_nodes)
+    first_col_node = first(col_nodes)
+    for (local_col, local_col_node) in enumerate(CartesianIndices(col_size))
+        col_node = local_col_node + first_col_node - oneunit(first_col_node)
+        neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
+        matrix_neighboring_rows = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
+        for b in 1:col_ndofs
+            col = col_dof_table[b,col_node]
+            matrix_col_start = first(matrix.column_slots[col])
+            for (local_row, local_row_node) in enumerate(neighboring_rows)
+                local_slot = node_colstarts[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
+                row_node = local_row_node + first_row_node - oneunit(first_row_node)
+                matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
+                matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * row_ndofs
+                add_entry_values!(matrix_values, matrix_slot, values, local_slot, Base.OneTo(row_ndofs), row_ndofs)
+            end
+        end
+    end
+
+    matrix
+end
+
 @noinline function check_block_matrix_scatter(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrixBuffer, row_nodes::CartesianIndices, col_nodes::CartesianIndices)
     (; row_dof_table, col_dof_table, sparsity_radius) = assembler
     (; key) = buffer
@@ -1003,12 +1235,13 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         ((gi == i && gj == j) || (gi == j && gj == i)) || error("@P2G_Matrix: Expected expression of the form `$gmat[$i, $j]` or `$gmat[$j, $i]`, got `$lhs`")
         gmat in gmats && error("@P2G_Matrix: each global matrix may appear only once in a block; combine terms for `$gmat` into one `@∑` expression")
 
-        buffer = gensym(Symbol(gmat, :buffer))
-        assembler = gensym(Symbol(gmat, :assembler))
-        I = gensym(Symbol(gmat, :I))
-        J = gensym(Symbol(gmat, :J))
+        matrix = gensym(:matrix)
+        buffer = gensym(:buffer)
+        assembler = gensym(:assembler)
+        I = gensym(:I)
+        J = gensym(:J)
 
-        fillzero = op == :(=) ? :(Tesserae.fillzero!($gmat)) : nothing
+        fillzero = op == :(=) ? :(Tesserae.fillzero!($matrix)) : nothing
         op == :(-=) && (rhs = :(-$rhs))
         rhs = hoist_p2g_rhs!(hoist_exprs, inner_symbols, rhs)
         push!(gmats, gmat)
@@ -1018,11 +1251,12 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         row_grid, col_grid = reorder_pair((grid_i, grid_j))
         row_weights, col_weights = reorder_pair((weights_i, weights_j))
         dof_table_i, dof_table_j = reorder_pair((:($(assembler).row_dof_table), :($(assembler).col_dof_table)))
-        matrix_cache = Symbol(gmat, :cache)
+        matrix_cache = gensym(:matrix_cache)
         push!(matrices_init, quote
+            $matrix = $gmat
+            $assembler = Tesserae.matrix_assembler($matrix, Tesserae.get_mesh($row_grid), Tesserae.get_mesh($col_grid), Tesserae.basis($row_weights), Tesserae.basis($col_weights))
             $fillzero
-            $assembler = Tesserae.matrix_assembler($gmat, Tesserae.get_mesh($row_grid), Tesserae.get_mesh($col_grid), Tesserae.basis($row_weights), Tesserae.basis($col_weights))
-            $matrix_cache = Tesserae.local_matrix_cache($gmat, $dof_table_i, $weights_i, $dof_table_j, $weights_j)
+            $matrix_cache = Tesserae.local_matrix_cache($matrix, $dof_table_i, $weights_i, $dof_table_j, $weights_j)
         end)
         push!(buffers_init, quote
             if $matrix_assembly isa Tesserae.ParticleAssembly

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -70,11 +70,11 @@ function (dofmap::DofMap)(A::AbstractArray{T}) where {T <: Real}
     @inbounds view(A′, dofmap.indices4scalar)
 end
 
-struct SparseMatrixBlockView{T,Ti,P <: SparseMatrixCSC{T,Ti}} <: AbstractMatrix{T}
-    matrix::P
+struct SparseMatrixBlockView{T,Ti} <: AbstractMatrix{T}
+    matrix::SparseMatrixCSC{T,Ti}
     rows::UnitRange{Int}
     cols::UnitRange{Int}
-    column_slots::Vector{UnitRange{Ti}}
+    column_slots::Vector{UnitRange{Int}}
 end
 
 Base.size(block::SparseMatrixBlockView) = (length(block.rows), length(block.cols))
@@ -90,7 +90,17 @@ end
 function Base.setindex!(block::SparseMatrixBlockView, value, i::Int, j::Int)
     @_propagate_inbounds_meta
     @boundscheck checkbounds(block, i, j)
-    @inbounds parent(block)[block.rows[i],block.cols[j]] = value
+
+    matrix = parent(block)
+    rows = rowvals(matrix)
+    row = @inbounds block.rows[i]
+    slots = @inbounds block.column_slots[j]
+    slot = searchsortedfirst(rows, row, first(slots), last(slots), Base.Order.Forward)
+    if slot ∈ slots && rows[slot] == row
+        @inbounds nonzeros(matrix)[slot] = value
+    elseif !iszero(value)
+        throw(ArgumentError("cannot change the sparsity pattern of a sparse matrix block view"))
+    end
     block
 end
 
@@ -108,21 +118,26 @@ SparseArrays.nnz(block::SparseMatrixBlockView) = sum(length, block.column_slots)
 """
 An array of sparse matrix block views that share the same parent CSC matrix.
 """
-struct SparseMatrixBlocks{V <: SparseMatrixBlockView} <: AbstractMatrix{V}
-    views::Matrix{V}
-
-    function SparseMatrixBlocks(views::Matrix{V}) where {V <: SparseMatrixBlockView}
-        isempty(views) && throw(ArgumentError("sparse matrix blocks must not be empty"))
-        matrix = parent(first(views))
-        all(block -> parent(block) === matrix, views) || throw(ArgumentError("sparse matrix blocks must share the same parent matrix"))
-        new{V}(views)
-    end
+struct SparseMatrixBlocks{T,Ti} <: AbstractMatrix{SparseMatrixBlockView{T,Ti}}
+    matrix::SparseMatrixCSC{T,Ti}
+    row_offsets::Vector{Int}
+    col_offsets::Vector{Int}
+    column_slots::Matrix{Vector{UnitRange{Int}}}
 end
 
+Base.size(blocks::SparseMatrixBlocks) = size(blocks.column_slots)
+Base.parent(blocks::SparseMatrixBlocks) = blocks.matrix
 
-Base.size(blocks::SparseMatrixBlocks) = size(blocks.views)
-Base.getindex(blocks::SparseMatrixBlocks, i::Int, j::Int) = blocks.views[i,j]
-Base.parent(blocks::SparseMatrixBlocks) = parent(first(blocks.views))
+function Base.getindex(blocks::SparseMatrixBlocks, i::Int, j::Int)
+    @_propagate_inbounds_meta
+    @boundscheck checkbounds(blocks, i, j)
+    @inbounds SparseMatrixBlockView(
+        blocks.matrix,
+        (blocks.row_offsets[i] + 1):blocks.row_offsets[i + 1],
+        (blocks.col_offsets[j] + 1):blocks.col_offsets[j + 1],
+        blocks.column_slots[i,j],
+    )
+end
 
 function fillzero!(blocks::SparseMatrixBlocks)
     fillzero!(parent(blocks))
@@ -134,7 +149,17 @@ end
 
 Combine sparse matrices into one CSC matrix and return its block views. Each
 argument describes one block row and must be a tuple of `SparseMatrixCSC`
-objects.
+objects. The views are assembly targets; use the combined CSC returned by
+`parent(blocks)` for sparse linear algebra.
+
+```julia
+blocks = create_block_sparse_matrix((Kuu, Kup), (Kpu, Kpp))
+K = parent(blocks)
+```
+
+The block views share a fixed sparsity structure and permit updates only at
+stored positions. Structural changes made through `parent(blocks)` invalidate
+all block views.
 """
 function create_block_sparse_matrix(block_rows::Tuple...)
     isempty(block_rows) && throw(ArgumentError("at least one block row is required"))
@@ -159,46 +184,38 @@ function create_block_sparse_matrix(block_rows::Tuple...)
         size(matrices[i,j]) == (row_sizes[i], col_sizes[j]) || throw(DimensionMismatch("matrix block sizes are inconsistent"))
     end
 
-    matrix_rows = [hcat(matrices[i,:]...) for i in 1:nblockrows]
-    matrix = vcat(matrix_rows...)
     row_offsets = cumsum([0; row_sizes])
     col_offsets = cumsum([0; col_sizes])
-    Ti = eltype(matrix.colptr)
-    column_slots = Matrix{Vector{UnitRange{Ti}}}(undef, nblockrows, nblockcols)
-    for j in 1:nblockcols, i in 1:nblockrows
-        column_slots[i,j] = Vector{UnitRange{Ti}}(undef, col_sizes[j])
-    end
+    column_slots = [Vector{UnitRange{Int}}(undef, col_sizes[j]) for i in 1:nblockrows, j in 1:nblockcols]
+
+    # Build the parent CSC and record each block's slots in the same column pass.
+    T = eltype(first_block)
+    Ti = SparseArrays.indtype(first_block)
+    matrix_colptr = Vector{Ti}(undef, sum(col_sizes) + 1)
+    matrix_rowvals = Vector{Ti}(undef, sum(nnz, matrices))
+    matrix_values = Vector{T}(undef, length(matrix_rowvals))
+    col = 1
+    slot = 1
     for j in 1:nblockcols, local_col in 1:col_sizes[j]
-        col = col_offsets[j] + local_col
-        slot = first(nzrange(matrix, col))
+        matrix_colptr[col] = slot
         for i in 1:nblockrows
-            count = length(nzrange(matrices[i,j], local_col))
-            column_slots[i,j][local_col] = slot:(slot + count - 1)
-            slot += count
+            block = matrices[i,j]
+            source_rows = rowvals(block)
+            source_values = nonzeros(block)
+            first_slot = slot
+            for source_slot in nzrange(block, local_col)
+                matrix_rowvals[slot] = row_offsets[i] + source_rows[source_slot]
+                matrix_values[slot] = source_values[source_slot]
+                slot += 1
+            end
+            column_slots[i,j][local_col] = first_slot:(slot - 1)
         end
-        slot == last(nzrange(matrix, col)) + 1 || error("failed to construct sparse matrix block slots")
+        col += 1
     end
+    matrix_colptr[end] = slot
+    matrix = SparseMatrixCSC(sum(row_sizes), sum(col_sizes), matrix_colptr, matrix_rowvals, matrix_values)
 
-    first_view = SparseMatrixBlockView(
-        matrix,
-        (row_offsets[1] + 1):row_offsets[2],
-        (col_offsets[1] + 1):col_offsets[2],
-        column_slots[1,1],
-    )
-    views = Matrix{typeof(first_view)}(undef, nblockrows, nblockcols)
-    for j in 1:nblockcols, i in 1:nblockrows
-        views[i,j] = SparseMatrixBlockView(
-            matrix,
-            (row_offsets[i] + 1):row_offsets[i + 1],
-            (col_offsets[j] + 1):col_offsets[j + 1],
-            column_slots[i,j],
-        )
-    end
-    SparseMatrixBlocks(views)
-end
-
-function create_block_sparse_matrix(block_rows::Tuple{Vararg{Tuple}})
-    create_block_sparse_matrix(block_rows...)
+    SparseMatrixBlocks(matrix, row_offsets, col_offsets, column_slots)
 end
 
 """
@@ -495,6 +512,37 @@ struct CartesianSparseMatrixAssembler{M <: AbstractMatrix, R <: LinearIndices, C
     sparsity_radius::Int
 end
 
+function cartesian_matrix_column_slots(assembler::CartesianSparseMatrixAssembler, b, col_node)
+    @_propagate_inbounds_meta
+    (; matrix, storage_col_dof_table) = assembler
+    storage = matrix_storage(matrix)
+    col_storage_indices = last(matrix_storage_indices(matrix))
+    col = storage_col_dof_table[col_storage_indices[b],col_node]
+    nzrange(storage, col)
+end
+
+function cartesian_matrix_column_slots(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView}, b, col_node)
+    @_propagate_inbounds_meta
+    (; matrix, col_dof_table) = assembler
+    matrix.column_slots[col_dof_table[b,col_node]]
+end
+
+@inline function cartesian_matrix_row_storage_indices(assembler::CartesianSparseMatrixAssembler)
+    first(matrix_storage_indices(assembler.matrix))
+end
+
+@inline function cartesian_matrix_row_storage_indices(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView})
+    Base.OneTo(size(assembler.row_dof_table, 1))
+end
+
+@inline function cartesian_matrix_storage_row(assembler::CartesianSparseMatrixAssembler, a, row_node)
+    assembler.storage_row_dof_table[a,row_node]
+end
+
+@inline function cartesian_matrix_storage_row(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView}, a, row_node)
+    first(assembler.matrix.rows) - 1 + assembler.row_dof_table[a,row_node]
+end
+
 function CartesianSparseMatrixAssembler(A::SparseMatrixCSC, mesh_size::Dims, sparsity_radius::Int)
     node_count = prod(mesh_size)
     node_count > 0 || throw(ArgumentError("mesh must contain at least one node"))
@@ -530,21 +578,26 @@ function cartesian_neighbor_nodes(node::CartesianIndex{N}, mesh_size::Dims{N}, s
     ((node-shift) : (node+shift)) ∩ CartesianIndices(mesh_size)
 end
 
+function cartesian_slot_offset(node, neighboring_nodes, slots_per_node)
+    @_propagate_inbounds_meta
+    local_node = node - first(neighboring_nodes) + oneunit(node)
+    (LinearIndices(neighboring_nodes)[local_node] - 1) * slots_per_node
+end
+
 function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
-    (; matrix, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
     storage = matrix_storage(matrix)
-    mesh_size = Base.tail(size(storage_row_dof_table))
-    row_dofs_per_node = size(storage_row_dof_table, 1)
-    col_dofs_per_node = size(storage_col_dof_table, 1)
+    mesh_size = Base.tail(size(row_dof_table))
+    row_ndofs = size(row_dof_table, 1)
+    col_ndofs = size(col_dof_table, 1)
     rows = rowvals(storage)
-    for col_node in CartesianIndices(mesh_size), b in 1:col_dofs_per_node
-        col = storage_col_dof_table[b, col_node]
-        indices = nzrange(storage, col)
-        k = first(indices)
-        stop = last(indices) + 1
-        for row_node in cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius), a in 1:row_dofs_per_node
+    for col_node in CartesianIndices(mesh_size), b in 1:col_ndofs
+        slots = cartesian_matrix_column_slots(assembler, b, col_node)
+        k = first(slots)
+        stop = last(slots) + 1
+        for row_node in cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius), a in 1:row_ndofs
             k < stop || return false
-            rows[k] == storage_row_dof_table[a, row_node] || return false
+            rows[k] == cartesian_matrix_storage_row(assembler, a, row_node) || return false
             k += 1
         end
         k == stop || return false
@@ -552,26 +605,37 @@ function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler)
     true
 end
 
+function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixCSCView})
+    (; matrix, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    storage_assembler = CartesianSparseMatrixAssembler(
+        parent(matrix),
+        storage_row_dof_table,
+        storage_col_dof_table,
+        storage_row_dof_table,
+        storage_col_dof_table,
+        sparsity_radius,
+    )
+    has_cartesian_sparse_pattern(storage_assembler)
+end
+
 # The canonical Cartesian CSC pattern allows its destination slots to be computed directly.
 @inline function add_entry!(assembler::CartesianSparseMatrixAssembler, row_node::CartesianIndex, col_node::CartesianIndex, value)
     @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
 
-    (; matrix, row_dof_table, col_dof_table, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    (; matrix, row_dof_table, col_dof_table, storage_row_dof_table, sparsity_radius) = assembler
     storage = matrix_storage(matrix)
-    row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
+    row_storage_indices = cartesian_matrix_row_storage_indices(assembler)
     mesh_size = Base.tail(size(row_dof_table))
     row_ndofs = size(row_dof_table, 1)
     col_ndofs = size(col_dof_table, 1)
     storage_row_ndofs = size(storage_row_dof_table, 1)
     neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
 
-    neighboring_node = row_node - first(neighboring_nodes) + oneunit(row_node)
-    row_offset = (LinearIndices(neighboring_nodes)[neighboring_node] - 1) * storage_row_ndofs
+    row_offset = cartesian_slot_offset(row_node, neighboring_nodes, storage_row_ndofs)
     values = nonzeros(storage)
 
     @inbounds for b in 1:col_ndofs
-        col = storage_col_dof_table[col_storage_indices[b],col_node]
-        slot = first(nzrange(storage, col)) + row_offset
+        slot = first(cartesian_matrix_column_slots(assembler, b, col_node)) + row_offset
         add_entry_values!(values, slot, value, (b - 1) * row_ndofs + 1, row_storage_indices, row_ndofs)
     end
 
@@ -620,49 +684,6 @@ function CartesianSparseMatrixAssembler(matrix::SparseMatrixBlockView, row_mesh:
     )
     has_cartesian_sparse_pattern(assembler) || throw(ArgumentError("Cartesian sparse matrix block must use the canonical sparsity pattern"))
     assembler
-end
-
-function has_cartesian_sparse_pattern(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView})
-    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
-    mesh_size = Base.tail(size(row_dof_table))
-    row_ndofs = size(row_dof_table, 1)
-    col_ndofs = size(col_dof_table, 1)
-    row_offset = first(matrix.rows) - 1
-    rows = rowvals(parent(matrix))
-    for col_node in CartesianIndices(mesh_size), b in 1:col_ndofs
-        col = col_dof_table[b,col_node]
-        slots = matrix.column_slots[col]
-        k = first(slots)
-        stop = last(slots) + 1
-        for row_node in cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius), a in 1:row_ndofs
-            k < stop || return false
-            rows[k] == row_offset + row_dof_table[a,row_node] || return false
-            k += 1
-        end
-        k == stop || return false
-    end
-    true
-end
-
-@inline function add_entry!(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView}, row_node::CartesianIndex, col_node::CartesianIndex, value)
-    @boundscheck check_cartesian_matrix_entry(assembler, row_node, col_node, value)
-
-    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
-    mesh_size = Base.tail(size(row_dof_table))
-    row_ndofs = size(row_dof_table, 1)
-    col_ndofs = size(col_dof_table, 1)
-    neighboring_nodes = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
-    neighboring_node = row_node - first(neighboring_nodes) + oneunit(row_node)
-    row_offset = (LinearIndices(neighboring_nodes)[neighboring_node] - 1) * row_ndofs
-    values = nonzeros(parent(matrix))
-
-    @inbounds for b in 1:col_ndofs
-        col = col_dof_table[b,col_node]
-        slot = first(matrix.column_slots[col]) + row_offset
-        add_entry_values!(values, slot, value, (b - 1) * row_ndofs + 1, Base.OneTo(row_ndofs), row_ndofs)
-    end
-
-    matrix
 end
 
 @noinline function check_cartesian_sparse_matrix_view(assembler::CartesianSparseMatrixAssembler)
@@ -748,13 +769,7 @@ function matrix_assembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
     row_dof_table, col_dof_table = matrix_dof_tables(matrix, row_mesh, col_mesh)
     GenericMatrixAssembler(matrix, row_dof_table, col_dof_table)
 end
-function matrix_assembler(matrix::SparseMatrixCSC, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
-    CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
-end
-function matrix_assembler(matrix::SparseMatrixCSCView, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
-    CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
-end
-function matrix_assembler(matrix::SparseMatrixBlockView, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
+function matrix_assembler(matrix::Union{SparseMatrixCSC,SparseMatrixCSCView,SparseMatrixBlockView}, row_mesh::CartesianMesh, col_mesh::CartesianMesh, row_basis::Basis, col_basis::Basis)
     CartesianSparseMatrixAssembler(matrix, row_mesh, col_mesh, row_basis, col_basis)
 end
 function matrix_assembler(::SparseMatrixBlocks, row_mesh, col_mesh, row_basis, col_basis)
@@ -934,11 +949,9 @@ function add_entry!(buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{
     local_row_node = row_node - first(row_nodes) + oneunit(row_node)
     local_col_node = col_node - first(col_nodes) + oneunit(col_node)
     neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
-    neighboring_row = local_row_node - first(neighboring_rows) + oneunit(local_row_node)
-    local_row = LinearIndices(neighboring_rows)[neighboring_row]
     local_col = LinearIndices(col_size)[local_col_node]
 
-    slot = node_colstarts[local_col] + (local_row - 1) * row_ndofs * col_ndofs
+    slot = node_colstarts[local_col] + cartesian_slot_offset(local_row_node, neighboring_rows, row_ndofs * col_ndofs)
     add_entry_values!(values, slot, value)
 
     buffer
@@ -964,9 +977,9 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
     @_propagate_inbounds_meta
     @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
 
-    (; matrix, storage_row_dof_table, storage_col_dof_table, sparsity_radius) = assembler
+    (; matrix, storage_row_dof_table, sparsity_radius) = assembler
     storage = matrix_storage(matrix)
-    row_storage_indices, col_storage_indices = matrix_storage_indices(matrix)
+    row_storage_indices = cartesian_matrix_row_storage_indices(assembler)
     (; values, node_colstarts, key) = buffer
     (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
 
@@ -980,46 +993,12 @@ function scatter!(assembler::CartesianSparseMatrixAssembler, buffer::BlockMatrix
         neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
         matrix_neighboring_rows = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
         for b in 1:col_ndofs
-            col = storage_col_dof_table[col_storage_indices[b],col_node]
-            matrix_col_start = first(nzrange(storage, col))
+            matrix_col_start = first(cartesian_matrix_column_slots(assembler, b, col_node))
             for (local_row, local_row_node) in enumerate(neighboring_rows)
                 local_slot = node_colstarts[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
                 row_node = local_row_node + first_row_node - oneunit(first_row_node)
-                matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
-                matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * storage_row_ndofs
+                matrix_slot = matrix_col_start + cartesian_slot_offset(row_node, matrix_neighboring_rows, storage_row_ndofs)
                 add_entry_values!(matrix_values, matrix_slot, values, local_slot, row_storage_indices, row_ndofs)
-            end
-        end
-    end
-
-    matrix
-end
-
-function scatter!(assembler::CartesianSparseMatrixAssembler{<:SparseMatrixBlockView}, buffer::BlockMatrixBuffer{T,N}, row_nodes::CartesianIndices{N}, col_nodes::CartesianIndices{N}) where {T,N}
-    @_propagate_inbounds_meta
-    @boundscheck check_block_matrix_scatter(assembler, buffer, row_nodes, col_nodes)
-
-    (; matrix, row_dof_table, col_dof_table, sparsity_radius) = assembler
-    (; values, node_colstarts, key) = buffer
-    (; row_size, col_size, col_offset, row_ndofs, col_ndofs) = key
-
-    mesh_size = Base.tail(size(row_dof_table))
-    matrix_values = nonzeros(parent(matrix))
-    first_row_node = first(row_nodes)
-    first_col_node = first(col_nodes)
-    for (local_col, local_col_node) in enumerate(CartesianIndices(col_size))
-        col_node = local_col_node + first_col_node - oneunit(first_col_node)
-        neighboring_rows = cartesian_neighbor_nodes(local_col_node + col_offset, row_size, sparsity_radius)
-        matrix_neighboring_rows = cartesian_neighbor_nodes(col_node, mesh_size, sparsity_radius)
-        for b in 1:col_ndofs
-            col = col_dof_table[b,col_node]
-            matrix_col_start = first(matrix.column_slots[col])
-            for (local_row, local_row_node) in enumerate(neighboring_rows)
-                local_slot = node_colstarts[local_col] + ((local_row - 1) * col_ndofs + b - 1) * row_ndofs
-                row_node = local_row_node + first_row_node - oneunit(first_row_node)
-                matrix_neighboring_row = row_node - first(matrix_neighboring_rows) + oneunit(row_node)
-                matrix_slot = matrix_col_start + (LinearIndices(matrix_neighboring_rows)[matrix_neighboring_row] - 1) * row_ndofs
-                add_entry_values!(matrix_values, matrix_slot, values, local_slot, Base.OneTo(row_ndofs), row_ndofs)
             end
         end
     end
@@ -1167,6 +1146,34 @@ end
 
 # ---- macro implementation ----
 
+function sparse_matrix_blocks_cover_parent(blocks, matrix)
+    all(block -> parent(block) === matrix, blocks) || return false
+    sum(nnz, blocks) == nnz(matrix) || return false
+    for j in 2:length(blocks), i in 1:j-1
+        block_i = blocks[i]
+        block_j = blocks[j]
+        isdisjoint(block_i.rows, block_j.rows) || isdisjoint(block_i.cols, block_j.cols) || return false
+    end
+    true
+end
+
+function fillzero_matrix_targets!(matrices)
+    foreach(fillzero!, matrices)
+    nothing
+end
+
+# A complete set of disjoint blocks can zero its parent CSC in one contiguous pass.
+function fillzero_matrix_targets!(blocks::Tuple{Vararg{SparseMatrixBlockView}})
+    isempty(blocks) && return nothing
+    matrix = parent(first(blocks))
+    if sparse_matrix_blocks_cover_parent(blocks, matrix)
+        fillzero!(matrix)
+    else
+        foreach(fillzero!, blocks)
+    end
+    nothing
+end
+
 """
     @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) [partition] begin
         equations...
@@ -1183,6 +1190,8 @@ end
 
 where `c` and `V` denote the stiffness (symmetric fourth-order) tensor and the volume, respectively.
 It is recommended to create global stiffness `K` using [`create_sparse_matrix`](@ref).
+Individual views returned by [`create_block_sparse_matrix`](@ref) may also be
+used as targets, for example `blocks[1,2][i,j]`.
 """
 macro P2G_Matrix(grid_ij, particles_p, weights_ipjp, equations)
     P2G_Matrix_expr(QuoteNode(:nothing), grid_ij, particles_p, weights_ipjp, nothing, equations)
@@ -1219,6 +1228,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
 
     gmats = Any[]
     matrices_init = Any[]
+    matrix_targets_to_zero = Any[]
     hoist_exprs = Any[]
     buffers_init = Any[]
     block_buffers_init = Any[]
@@ -1241,7 +1251,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         I = gensym(:I)
         J = gensym(:J)
 
-        fillzero = op == :(=) ? :(Tesserae.fillzero!($matrix)) : nothing
+        op == :(=) && push!(matrix_targets_to_zero, matrix)
         op == :(-=) && (rhs = :(-$rhs))
         rhs = hoist_p2g_rhs!(hoist_exprs, inner_symbols, rhs)
         push!(gmats, gmat)
@@ -1255,7 +1265,6 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         push!(matrices_init, quote
             $matrix = $gmat
             $assembler = Tesserae.matrix_assembler($matrix, Tesserae.get_mesh($row_grid), Tesserae.get_mesh($col_grid), Tesserae.basis($row_weights), Tesserae.basis($col_weights))
-            $fillzero
             $matrix_cache = Tesserae.local_matrix_cache($matrix, $dof_table_i, $weights_i, $dof_table_j, $weights_j)
         end)
         push!(buffers_init, quote
@@ -1275,6 +1284,12 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
         push!(assemble_block_entries, :(Tesserae.assemble_block_entry!($assembler, $buffer, $matrix_assembly, $orientation, $i, $j, $rhs)))
         push!(finish_assemblies, :(Tesserae.finish_assembly!($assembler, $buffer, $orientation, $gridindices_i, $gridindices_j)))
         push!(finish_block_assemblies, :(Tesserae.finish_block_assembly!($assembler, $buffer, $matrix_assembly, $orientation)))
+    end
+
+    fillzero_matrix_targets = if isempty(matrix_targets_to_zero)
+        nothing
+    else
+        :(Tesserae.fillzero_matrix_targets!(($(matrix_targets_to_zero...),)))
     end
 
     supportnodes_expr = if grid_i == grid_j && weights_i == weights_j
@@ -1353,6 +1368,7 @@ function P2G_Matrix_expr(schedule::QuoteNode, ((grid_i,grid_j),(i,j)), (particle
             $check_arguments_for_P2G_Matrix($grid_i, $particles, $weights_i, $partition)
             $check_arguments_for_P2G_Matrix($grid_j, $particles, $weights_j, $partition)
             $(matrices_init...)
+            $fillzero_matrix_targets
             Tesserae.P2G_Matrix((($grid_i′,$grid_j′), $particles, ($weights_i′,$weights_j′), $particle_indices, $matrix_assembly) -> $body,
                                 $get_device($grid_i), Val($schedule), ($grid_i,$grid_j), $particles, ($weights_i,$weights_j), $partition)
         end

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -1,3 +1,7 @@
+# -----------------------------------------------------------------------------
+#  DofMap
+# -----------------------------------------------------------------------------
+
 """
     DofMap(mask::AbstractArray{Bool})
 
@@ -70,6 +74,12 @@ function (dofmap::DofMap)(A::AbstractArray{T}) where {T <: Real}
     @inbounds view(A′, dofmap.indices4scalar)
 end
 
+# -----------------------------------------------------------------------------
+#  Sparse matrix blocks
+# -----------------------------------------------------------------------------
+
+# ---- SparseMatrixBlockView ----
+
 struct SparseMatrixBlockView{T,Ti} <: AbstractMatrix{T}
     matrix::SparseMatrixCSC{T,Ti}
     rows::UnitRange{Int}
@@ -82,13 +92,11 @@ Base.parent(block::SparseMatrixBlockView) = block.matrix
 Base.parentindices(block::SparseMatrixBlockView) = (block.rows, block.cols)
 
 function Base.getindex(block::SparseMatrixBlockView, i::Int, j::Int)
-    @_propagate_inbounds_meta
     @boundscheck checkbounds(block, i, j)
     @inbounds parent(block)[block.rows[i],block.cols[j]]
 end
 
 function Base.setindex!(block::SparseMatrixBlockView, value, i::Int, j::Int)
-    @_propagate_inbounds_meta
     @boundscheck checkbounds(block, i, j)
 
     matrix = parent(block)
@@ -115,6 +123,8 @@ end
 
 SparseArrays.nnz(block::SparseMatrixBlockView) = sum(length, block.column_slots)
 
+# ---- SparseMatrixBlocks ----
+
 """
 An array of sparse matrix block views that share the same parent CSC matrix.
 """
@@ -129,7 +139,6 @@ Base.size(blocks::SparseMatrixBlocks) = size(blocks.column_slots)
 Base.parent(blocks::SparseMatrixBlocks) = blocks.matrix
 
 function Base.getindex(blocks::SparseMatrixBlocks, i::Int, j::Int)
-    @_propagate_inbounds_meta
     @boundscheck checkbounds(blocks, i, j)
     @inbounds SparseMatrixBlockView(
         blocks.matrix,
@@ -144,24 +153,9 @@ function fillzero!(blocks::SparseMatrixBlocks)
     blocks
 end
 
-"""
-    create_block_sparse_matrix(block_rows...)
+# ---- construction ----
 
-Combine sparse matrices into one CSC matrix and return its block views. Each
-argument describes one block row and must be a tuple of `SparseMatrixCSC`
-objects. The views are assembly targets; use the combined CSC returned by
-`parent(blocks)` for sparse linear algebra.
-
-```julia
-blocks = create_block_sparse_matrix((Kuu, Kup), (Kpu, Kpp))
-K = parent(blocks)
-```
-
-The block views share a fixed sparsity structure and permit updates only at
-stored positions. Structural changes made through `parent(blocks)` invalidate
-all block views.
-"""
-function create_block_sparse_matrix(block_rows::Tuple...)
+function _combine_sparse_matrix_blocks(block_rows::Tuple...)
     isempty(block_rows) && throw(ArgumentError("at least one block row is required"))
     nblockcols = length(first(block_rows))
     nblockcols > 0 || throw(ArgumentError("at least one block column is required"))
@@ -194,10 +188,9 @@ function create_block_sparse_matrix(block_rows::Tuple...)
     matrix_colptr = Vector{Ti}(undef, sum(col_sizes) + 1)
     matrix_rowvals = Vector{Ti}(undef, sum(nnz, matrices))
     matrix_values = Vector{T}(undef, length(matrix_rowvals))
-    col = 1
     slot = 1
     for j in 1:nblockcols, local_col in 1:col_sizes[j]
-        matrix_colptr[col] = slot
+        matrix_colptr[col_offsets[j] + local_col] = slot
         for i in 1:nblockrows
             block = matrices[i,j]
             source_rows = rowvals(block)
@@ -210,13 +203,148 @@ function create_block_sparse_matrix(block_rows::Tuple...)
             end
             column_slots[i,j][local_col] = first_slot:(slot - 1)
         end
-        col += 1
     end
     matrix_colptr[end] = slot
     matrix = SparseMatrixCSC(sum(row_sizes), sum(col_sizes), matrix_colptr, matrix_rowvals, matrix_values)
 
     SparseMatrixBlocks(matrix, row_offsets, col_offsets, column_slots)
 end
+
+function _block_matrix_rows(expr)
+    if Meta.isexpr(expr, :hcat)
+        return (expr.args,)
+    elseif Meta.isexpr(expr, :vcat)
+        return map(row -> Meta.isexpr(row, :row) ? row.args : Any[row], expr.args)
+    elseif Meta.isexpr(expr, :vect, 1)
+        return (expr.args,)
+    else
+        throw(ArgumentError("@block_sparse_matrix requires a two-dimensional matrix literal"))
+    end
+end
+
+"""
+    @block_sparse_matrix [Kuu Kup; Kpu Kpp]
+
+Combine existing `SparseMatrixCSC` objects into one parent CSC matrix and
+return its block views.
+"""
+macro block_sparse_matrix(expr)
+    block_rows = _block_matrix_rows(expr)
+    escaped_rows = map(row -> Expr(:tuple, map(esc, row)...), block_rows)
+    :(_combine_sparse_matrix_blocks($(escaped_rows...)))
+end
+
+"""
+    create_block_sparse_matrix(mesh; ndofs)
+    create_block_sparse_matrix(meshes; ndofs)
+    create_block_sparse_matrix(basis, mesh; ndofs)
+
+Create a monolithic sparse matrix for multiple fields and return its block
+views. `ndofs` is a tuple containing the number of DoFs per node for each
+field. A tuple of meshes assigns one mesh to each field. For Cartesian meshes,
+pass the basis explicitly.
+
+```julia
+blocks = create_block_sparse_matrix((velocity_mesh, pressure_mesh); ndofs=(2, 1))
+K = parent(blocks)
+Kuu, Kup = blocks[1,1], blocks[1,2]
+Kpu, Kpp = blocks[2,1], blocks[2,2]
+```
+
+The parent CSC is constructed directly in block order. Block views share its
+fixed sparsity structure and permit updates only at stored positions.
+Structural changes made through `parent(blocks)` invalidate all block views.
+"""
+function create_block_sparse_matrix end
+
+function create_block_sparse_matrix(basis::Basis, mesh::AbstractMesh; ndofs::Tuple{Vararg{Int}})
+    _create_block_sparse_matrix(Float64, basis, mesh, ndofs)
+end
+
+function create_block_sparse_matrix(::Type{T}, basis::Basis, mesh::AbstractMesh; ndofs::Tuple{Vararg{Int}}) where {T}
+    _create_block_sparse_matrix(T, basis, mesh, ndofs)
+end
+
+function create_block_sparse_matrix(mesh::Union{FEMesh,IGAMesh}; ndofs::Tuple{Vararg{Int}})
+    create_block_sparse_matrix(Float64, mesh; ndofs)
+end
+
+function create_block_sparse_matrix(::Type{T}, mesh::Union{FEMesh,IGAMesh}; ndofs::Tuple{Vararg{Int}}) where {T}
+    meshes = ntuple(_ -> mesh, length(ndofs))
+    _create_block_sparse_matrix(T, meshes, ndofs)
+end
+
+function create_block_sparse_matrix(meshes::Tuple{Vararg{Union{FEMesh,IGAMesh}}}; ndofs::Tuple{Vararg{Int}})
+    create_block_sparse_matrix(Float64, meshes; ndofs)
+end
+
+function create_block_sparse_matrix(::Type{T}, meshes::Tuple{Vararg{Union{FEMesh,IGAMesh}}}; ndofs::Tuple{Vararg{Int}}) where {T}
+    _create_block_sparse_matrix(T, meshes, ndofs)
+end
+
+function _create_block_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh, ndofs::Tuple{Vararg{Int}}) where {T}
+    check_field_ndofs(ndofs)
+    field_sizes = [ndof * length(mesh) for ndof in ndofs]
+    field_offsets = cumsum([0; field_sizes])
+    I, J = Int[], Int[]
+    for j in eachindex(ndofs), i in eachindex(ndofs)
+        _append_sparse_pattern!(I, J, field_offsets[i], field_offsets[j], basis, mesh, ndofs[i], ndofs[j])
+    end
+    _create_sparse_matrix_blocks(T, I, J, field_offsets)
+end
+
+function _create_block_sparse_matrix(::Type{T}, ::IGABasis, mesh::IGAMesh, ndofs::Tuple{Vararg{Int}}) where {T}
+    meshes = ntuple(_ -> mesh, length(ndofs))
+    _create_block_sparse_matrix(T, meshes, ndofs)
+end
+
+function _create_block_sparse_matrix(::Type{T}, meshes::Tuple, ndofs::Tuple{Vararg{Int}}) where {T}
+    length(ndofs) == length(meshes) || throw(DimensionMismatch("each field must have one DoF count"))
+    check_field_ndofs(ndofs)
+    field_sizes = [ndofs[i] * length(meshes[i]) for i in eachindex(meshes)]
+    field_offsets = cumsum([0; field_sizes])
+    I, J = Int[], Int[]
+    for j in eachindex(meshes), i in eachindex(meshes)
+        _append_sparse_pattern!(I, J, field_offsets[i], field_offsets[j], meshes[i], meshes[j], ndofs[i], ndofs[j])
+    end
+    _create_sparse_matrix_blocks(T, I, J, field_offsets)
+end
+
+function check_field_ndofs(ndofs)
+    isempty(ndofs) && throw(ArgumentError("at least one field is required"))
+    all(>(0), ndofs) || throw(ArgumentError("field DoF counts must be positive"))
+    nothing
+end
+
+function _create_sparse_matrix_blocks(::Type{T}, I, J, field_offsets) where {T}
+    matrix_size = last(field_offsets)
+    matrix = sparse(I, J, zeros(T, length(I)), matrix_size, matrix_size)
+    nfields = length(field_offsets) - 1
+    column_slots = [Vector{UnitRange{Int}}(undef, field_offsets[j + 1] - field_offsets[j]) for i in 1:nfields, j in 1:nfields]
+    rows = rowvals(matrix)
+
+    # Rows are sorted within each CSC column, so each field occupies one contiguous slot range.
+    for j in 1:nfields, local_col in 1:(field_offsets[j + 1] - field_offsets[j])
+        slots = nzrange(matrix, field_offsets[j] + local_col)
+        slot = first(slots)
+        stop = last(slots) + 1
+        for i in 1:nfields
+            first_slot = slot
+            @inbounds while slot < stop && rows[slot] ≤ field_offsets[i + 1]
+                slot += 1
+            end
+            column_slots[i,j][local_col] = first_slot:(slot - 1)
+        end
+    end
+
+    SparseMatrixBlocks(matrix, field_offsets, field_offsets, column_slots)
+end
+
+# -----------------------------------------------------------------------------
+#  Sparse matrices
+# -----------------------------------------------------------------------------
+
+# ---- construction ----
 
 """
     create_sparse_matrix(mesh; ndofs)
@@ -289,40 +417,36 @@ end
 
 function _create_sparse_matrix(::Type{T}, basis::Basis, mesh::CartesianMesh{dim}, ndofs::Tuple{Int,Int}) where {T, dim}
     row_ndofs, col_ndofs = ndofs
-
-    dims = size(mesh)
-    nrows = row_ndofs * prod(dims)
-    ncols = col_ndofs * prod(dims)
-
     I, J = Int[], Int[]
-    LI, CI = LinearIndices(dims), CartesianIndices(dims)
-
-    function gendofs(node_id, ndofs)
-        first = ndofs * (node_id - 1) + 1
-        last  = ndofs * node_id
-        first:last
-    end
-
-    for i in CI
-        unit = (support_width(basis) - 1) * oneunit(i)
-        indices = intersect((i-unit):(i+unit), CI)
-        idofs = gendofs(LI[i], row_ndofs)
-        for j in indices
-            jdofs = gendofs(LI[j], col_ndofs)
-            append_dofs!(I, J, idofs, jdofs)
-        end
-    end
-
-    sparse(I, J, zeros(T, length(I)), nrows, ncols)
+    _append_sparse_pattern!(I, J, 0, 0, basis, mesh, row_ndofs, col_ndofs)
+    sparse(I, J, zeros(T, length(I)), row_ndofs * length(mesh), col_ndofs * length(mesh))
 end
 
-function append_dofs!(I, J, idofs, jdofs)
-    for jdof in jdofs
-        append!(I, idofs)
-        for _ in idofs
-            push!(J, jdof)
+function _append_sparse_pattern!(I, J, row_offset, col_offset, basis::Basis, mesh::CartesianMesh{N}, row_ndofs, col_ndofs) where {N}
+    mesh_size = size(mesh)
+    node_ids = LinearIndices(mesh_size)
+    mesh_nodes = CartesianIndices(mesh_size)
+    radius = (support_width(basis) - 1) * oneunit(CartesianIndex{N})
+    for row_node in mesh_nodes
+        row_dofs = node_dofs(node_ids[row_node], row_ndofs)
+        for col_node in intersect((row_node - radius):(row_node + radius), mesh_nodes)
+            col_dofs = node_dofs(node_ids[col_node], col_ndofs)
+            append_dofs!(I, J, row_dofs, col_dofs, row_offset, col_offset)
         end
     end
+    nothing
+end
+
+function node_dofs(node, ndofs)
+    (ndofs * (node - 1) + 1):(ndofs * node)
+end
+
+function append_dofs!(I, J, row_dofs, col_dofs, row_offset, col_offset)
+    for col_dof in col_dofs, row_dof in row_dofs
+        push!(I, row_offset + row_dof)
+        push!(J, col_offset + col_dof)
+    end
+    nothing
 end
 
 function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Int) where {T}
@@ -330,16 +454,19 @@ function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Int) where {
 end
 
 function _create_cell_support_sparse_matrix(::Type{T}, mesh, ndofs::Tuple{Int,Int}) where {T}
-    gdofs1 = LinearIndices((ndofs[1], length(mesh)))
-    gdofs2 = LinearIndices((ndofs[2], length(mesh)))
-
     I, J = Int[], Int[]
-    for cell in cells(mesh)
-        cellnodes = supportnodes(mesh, cell)
-        append_dofs!(I, J, gdofs1[:, cellnodes], gdofs2[:, cellnodes])
-    end
+    _append_sparse_pattern!(I, J, 0, 0, mesh, ndofs[1], ndofs[2])
+    sparse(I, J, zeros(T, length(I)), ndofs[1] * length(mesh), ndofs[2] * length(mesh))
+end
 
-    sparse(I, J, zeros(T, length(I)), length(gdofs1), length(gdofs2))
+function _append_sparse_pattern!(I, J, row_offset, col_offset, mesh::Union{FEMesh,IGAMesh}, row_ndofs, col_ndofs)
+    row_dofs = LinearIndices((row_ndofs, length(mesh)))
+    col_dofs = LinearIndices((col_ndofs, length(mesh)))
+    for cell in cells(mesh)
+        cell_nodes = supportnodes(mesh, cell)
+        append_dofs!(I, J, row_dofs[:, cell_nodes], col_dofs[:, cell_nodes], row_offset, col_offset)
+    end
+    nothing
 end
 
 function create_sparse_matrix(::IGABasis, mesh::IGAMesh{dim}; ndofs) where {dim}
@@ -355,43 +482,56 @@ _create_sparse_matrix(::Type{T}, mesh::IGAMesh, ndofs::Tuple{Int,Int}) where {T}
 create_sparse_matrix(::Type{T}, mesh::IGAMesh{dim}; ndofs) where {T, dim} = _create_sparse_matrix(T, mesh, ndofs)
 create_sparse_matrix(mesh::IGAMesh{dim}; ndofs) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
 
-function create_sparse_matrix(::Type{T}, (rowmesh,colmesh)::Tuple{IGAMesh{dim,pdim}, IGAMesh{dim,pdim}}; ndofs::Tuple{Int, Int}) where {T, dim, pdim}
-    rowmesh === colmesh && return _create_cell_support_sparse_matrix(T, rowmesh, ndofs)
+function create_sparse_matrix(::Type{T}, (rowmesh,colmesh)::Tuple{Vararg{Union{FEMesh,IGAMesh},2}}; ndofs::Tuple{Int,Int}) where {T}
+    I, J = Int[], Int[]
+    _append_sparse_pattern!(I, J, 0, 0, rowmesh, colmesh, ndofs[1], ndofs[2])
+    sparse(I, J, zeros(T, length(I)), ndofs[1] * length(rowmesh), ndofs[2] * length(colmesh))
+end
+
+function create_sparse_matrix(meshes::Tuple{Vararg{Union{FEMesh,IGAMesh},2}}; ndofs::Tuple{Int,Int})
+    create_sparse_matrix(Float64, meshes; ndofs)
+end
+
+function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::IGAMesh{dim,pdim}, colmesh::IGAMesh{dim,pdim}, row_ndofs, col_ndofs) where {dim,pdim}
+    rowmesh === colmesh && return _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh, row_ndofs, col_ndofs)
     check_matching_cell_partitions(rowmesh, colmesh)
 
-    row_dofs = LinearIndices((ndofs[1], length(rowmesh)))
-    col_dofs = LinearIndices((ndofs[2], length(colmesh)))
-    I, J = Int[], Int[]
-    for (rowcell, colcell) in zip(cells(rowmesh), cells(colmesh))
-        append_dofs!(I, J, row_dofs[:, supportnodes(rowmesh, rowcell)], col_dofs[:, supportnodes(colmesh, colcell)])
+    row_dofs = LinearIndices((row_ndofs, length(rowmesh)))
+    col_dofs = LinearIndices((col_ndofs, length(colmesh)))
+    for (row_cell, col_cell) in zip(cells(rowmesh), cells(colmesh))
+        row_nodes = supportnodes(rowmesh, row_cell)
+        col_nodes = supportnodes(colmesh, col_cell)
+        append_dofs!(I, J, row_dofs[:, row_nodes], col_dofs[:, col_nodes], row_offset, col_offset)
     end
-    sparse(I, J, zeros(T, length(I)), length(row_dofs), length(col_dofs))
+    nothing
 end
-create_sparse_matrix(meshes::Tuple{IGAMesh{dim,pdim}, IGAMesh{dim,pdim}}; ndofs::Tuple{Int, Int}) where {dim, pdim} = create_sparse_matrix(Float64, meshes; ndofs)
 
-function create_sparse_matrix(::Type{T}, (mesh1,mesh2)::Tuple{FEMesh, FEMesh}; ndofs::Tuple{Int, Int}) where {T}
-    mesh1 === mesh2 && return _create_cell_support_sparse_matrix(T, mesh1, ndofs)
-    _reference_cell_family(cellshape(mesh1)) === _reference_cell_family(cellshape(mesh2)) || throw(ArgumentError("FEM meshes must use the same reference-cell family"))
-    ncells(mesh1) == ncells(mesh2) || throw(DimensionMismatch("FEM meshes must have the same number of cells"))
-
-    gdofs1 = LinearIndices((ndofs[1], length(mesh1)))
-    gdofs2 = LinearIndices((ndofs[2], length(mesh2)))
-    primarynodes1 = primarynodes_indices(cellshape(mesh1))
-    primarynodes2 = primarynodes_indices(cellshape(mesh2))
-
-    I, J = Int[], Int[]
-    for (cell1, cell2) in zip(cells(mesh1), cells(mesh2))
-        cellnodes1 = supportnodes(mesh1, cell1)
-        cellnodes2 = supportnodes(mesh2, cell2)
-        mesh1[cellnodes1[primarynodes1]] ≈ mesh2[cellnodes2[primarynodes2]] || throw(ArgumentError("FEM meshes must describe the same cells in the same order and orientation; cell $cell1 does not match"))
-        append_dofs!(I, J, gdofs1[:, cellnodes1], gdofs2[:, cellnodes2])
-    end
-
-    sparse(I, J, zeros(T, length(I)), length(gdofs1), length(gdofs2))
-end
-create_sparse_matrix(meshes::Tuple{FEMesh, FEMesh}; ndofs::Tuple{Int, Int}) = create_sparse_matrix(Float64, meshes; ndofs)
 create_sparse_matrix(::Type{T}, mesh::FEMesh{<: Any, dim}; ndofs::Int) where {T, dim} = create_sparse_matrix(T, (mesh,mesh); ndofs=(ndofs,ndofs))
 create_sparse_matrix(mesh::FEMesh{<: Any, dim}; ndofs::Int) where {dim} = create_sparse_matrix(Float64, mesh; ndofs)
+
+function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::FEMesh, colmesh::FEMesh, row_ndofs, col_ndofs)
+    rowmesh === colmesh && return _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh, row_ndofs, col_ndofs)
+    _reference_cell_family(cellshape(rowmesh)) === _reference_cell_family(cellshape(colmesh)) || throw(ArgumentError("FEM meshes must use the same reference-cell family"))
+    ncells(rowmesh) == ncells(colmesh) || throw(DimensionMismatch("FEM meshes must have the same number of cells"))
+
+    row_dofs = LinearIndices((row_ndofs, length(rowmesh)))
+    col_dofs = LinearIndices((col_ndofs, length(colmesh)))
+    row_primary_nodes = primarynodes_indices(cellshape(rowmesh))
+    col_primary_nodes = primarynodes_indices(cellshape(colmesh))
+    for (row_cell, col_cell) in zip(cells(rowmesh), cells(colmesh))
+        row_nodes = supportnodes(rowmesh, row_cell)
+        col_nodes = supportnodes(colmesh, col_cell)
+        rowmesh[row_nodes[row_primary_nodes]] ≈ colmesh[col_nodes[col_primary_nodes]] || throw(ArgumentError("FEM meshes must describe the same cells in the same order and orientation; cell $row_cell does not match"))
+        append_dofs!(I, J, row_dofs[:, row_nodes], col_dofs[:, col_nodes], row_offset, col_offset)
+    end
+    nothing
+end
+
+function _append_sparse_pattern!(I, J, row_offset, col_offset, rowmesh::Union{FEMesh,IGAMesh}, colmesh::Union{FEMesh,IGAMesh}, row_ndofs, col_ndofs)
+    throw(ArgumentError("all field meshes must use compatible discretizations"))
+end
+
+# ---- extraction ----
 
 """
     extract(matrix::AbstractMatrix, dofmap_row::DofMap, dofmap_col::DofMap = dofmap_row)
@@ -415,6 +555,8 @@ function _indices_for_extract(S::AbstractMatrix, dofmap_i::Union{DofMap, Colon},
 end
 dofs(dofmap::DofMap) = LinearIndices(dofmap.masksize)[dofmap.indices]
 dofs(colon::Colon) = colon
+
+# ---- sparse addition ----
 
 function add!(A::SparseMatrixCSC, I::AbstractVector{Int}, J::AbstractVector{Int}, K::AbstractMatrix)
     if issorted(I)

--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -203,7 +203,7 @@ function create_block_sparse_matrix(block_rows::Tuple...)
             source_rows = rowvals(block)
             source_values = nonzeros(block)
             first_slot = slot
-            for source_slot in nzrange(block, local_col)
+            @inbounds for source_slot in nzrange(block, local_col)
                 matrix_rowvals[slot] = row_offsets[i] + source_rows[source_slot]
                 matrix_values[slot] = source_values[source_slot]
                 slot += 1

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -400,7 +400,7 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         @test stored_pattern(D32) == rectangular_pattern
 
         blocks = @inferred create_block_sparse_matrix((mesh, column_mesh); ndofs=(2, 1))
-        blocks32 = @inferred create_block_sparse_matrix(Float32, mesh_basis, mesh; ndofs=(2, 1))
+        blocks32 = @inferred create_block_sparse_matrix(Float32, mesh; ndofs=(2, 1))
         @test blocks[1,1] == create_sparse_matrix(mesh; ndofs=2)
         @test blocks[1,2] == D
         @test blocks[2,1] == create_sparse_matrix((column_mesh, mesh); ndofs=(1, 2))

--- a/test/iga.jl
+++ b/test/iga.jl
@@ -399,6 +399,15 @@ const nurbs_cubic = Tesserae.NURBS.cubic
         @test stored_pattern(D) == rectangular_pattern
         @test stored_pattern(D32) == rectangular_pattern
 
+        blocks = @inferred create_block_sparse_matrix((mesh, column_mesh); ndofs=(2, 1))
+        blocks32 = @inferred create_block_sparse_matrix(Float32, mesh_basis, mesh; ndofs=(2, 1))
+        @test blocks[1,1] == create_sparse_matrix(mesh; ndofs=2)
+        @test blocks[1,2] == D
+        @test blocks[2,1] == create_sparse_matrix((column_mesh, mesh); ndofs=(1, 2))
+        @test blocks[2,2] == create_sparse_matrix(column_mesh; ndofs=1)
+        @test eltype(parent(blocks32)) === Float32
+        @test blocks32[1,2] == C
+
         # Equal cell counts are insufficient when the span endpoints differ.
         mismatched_knots = map(copy, iga_test_knot_vectors(patch))
         mismatched_knots[1][4] = 0.2

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -85,6 +85,67 @@
         @test Kpp ≈ Kpp_ref
         @test Kup ≈ Kpu'
     end
+    @testset "block sparse matrix" begin
+        Kuu_ref = create_sparse_matrix(basis, mesh; ndofs=(2, 2))
+        Kup_ref = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
+        Kpu_ref = create_sparse_matrix(basis, mesh; ndofs=(1, 2))
+        Kpp_ref = create_sparse_matrix(basis, mesh; ndofs=(1, 1))
+        blocks = create_block_sparse_matrix(
+            (copy(Kuu_ref), copy(Kup_ref)),
+            (copy(Kpu_ref), copy(Kpp_ref)),
+        )
+
+        @test size(blocks) == (2, 2)
+        @test isconcretetype(eltype(blocks))
+        @test size(parent(blocks)) == (3length(mesh), 3length(mesh))
+        @test all(parent(block) === parent(blocks) for block in blocks)
+        @test size(blocks[1,1]) == size(Kuu_ref)
+        @test size(blocks[1,2]) == size(Kup_ref)
+        @test size(blocks[2,1]) == size(Kpu_ref)
+        @test size(blocks[2,2]) == size(Kpp_ref)
+
+        @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
+            blocks[1,1][i,j] = @∑ ∇w[ip] ⊗ ∇w[jp]
+            blocks[1,2][i,j] = @∑ ∇w[ip] * w[jp]
+            blocks[2,1][i,j] = @∑ w[ip] * ∇w[jp]'
+            blocks[2,2][i,j] = @∑ w[ip] * w[jp]
+        end
+        @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
+            Kuu_ref[i,j] = @∑ ∇w[ip] ⊗ ∇w[jp]
+            Kup_ref[i,j] = @∑ ∇w[ip] * w[jp]
+            Kpu_ref[i,j] = @∑ w[ip] * ∇w[jp]'
+            Kpp_ref[i,j] = @∑ w[ip] * w[jp]
+        end
+
+        @test blocks[1,1] ≈ Kuu_ref
+        @test blocks[1,2] ≈ Kup_ref
+        @test blocks[2,1] ≈ Kpu_ref
+        @test blocks[2,2] ≈ Kpp_ref
+
+        threaded = create_block_sparse_matrix(
+            (copy(Kuu_ref), copy(Kup_ref)),
+            (copy(Kpu_ref), copy(Kpp_ref)),
+        )
+        fillzero!(threaded)
+        partition = ThreadPartition(mesh)
+        update!(partition, particles.x)
+        @threaded :static @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) partition begin
+            threaded[1,1][i,j] = @∑ ∇w[ip] ⊗ ∇w[jp]
+            threaded[1,2][i,j] = @∑ ∇w[ip] * w[jp]
+            threaded[2,1][i,j] = @∑ w[ip] * ∇w[jp]'
+            threaded[2,2][i,j] = @∑ w[ip] * w[jp]
+        end
+        @test parent(threaded) ≈ parent(blocks)
+
+        fill!(Tesserae.SparseArrays.nonzeros(parent(blocks)), 7)
+        before = copy(parent(blocks))
+        @test_throws ArgumentError begin
+            @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
+                blocks[i,j] = @∑ w[ip] * w[jp]
+            end
+        end
+        @test parent(blocks) == before
+    end
     @testset "sparse matrix views" begin
         parent_dofs = LinearIndices((3, length(mesh)))
         velocity_dofs = vec(parent_dofs[[3,1], :])
@@ -500,6 +561,23 @@ end
         matrix_view[i,j] = @∑ ∇N[ip] * N[jp] * V[p]
     end
     @test matrix_view ≈ A
+
+    block_matrix = create_block_sparse_matrix(
+        (
+            create_sparse_matrix(quad9; ndofs=2),
+            create_sparse_matrix((quad9, quad4); ndofs=(2, 1)),
+        ),
+        (
+            create_sparse_matrix((quad4, quad9); ndofs=(1, 2)),
+            create_sparse_matrix(quad4; ndofs=1),
+        ),
+    )
+    @P2G_Matrix (velocity_grid,pressure_grid)=>(i,j) points=>p (velocity_weights,pressure_weights)=>(ip,jp) begin
+        block_matrix[1,2][i,j] = @∑ ∇N[ip] * N[jp] * V[p]
+        block_matrix[2,1][j,i] = @∑ ∇N[ip] * N[jp] * V[p]
+    end
+    @test block_matrix[1,2] ≈ A
+    @test block_matrix[2,1] ≈ B
 
     shifted = FEMesh(Tesserae.Quad4(), CartesianMesh(1, (2,4), (0,1)))
     @test_throws ArgumentError create_sparse_matrix((quad9, shifted); ndofs=(2, 1))

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -91,7 +91,8 @@
         A12 = sparse(Int32[], Int32[], Float64[], 3, 1)
         A21 = sparse(Int32[2], Int32[1], [3.0], 2, 2)
         A22 = sparse(Int32[], Int32[], Float64[], 2, 1)
-        irregular = @block_sparse_matrix [A11 A12; A21 A22]
+        combine_blocks = (A11, A12, A21, A22) -> (@block_sparse_matrix [A11 A12; A21 A22])
+        irregular = @inferred combine_blocks(A11, A12, A21, A22)
 
         @test parent(irregular) == hvcat((2, 2), A11, A12, A21, A22)
         @test Tesserae.SparseArrays.indtype(parent(irregular)) == Int32
@@ -610,7 +611,7 @@ end
     @test block_matrix[1,2] == create_sparse_matrix((quad9, quad4); ndofs=(2, 1))
     @test block_matrix[2,1] == create_sparse_matrix((quad4, quad9); ndofs=(1, 2))
     @test block_matrix[2,2] == create_sparse_matrix(quad4; ndofs=1)
-    @test_throws DimensionMismatch create_block_sparse_matrix((quad9, quad4); ndofs=(2, 1, 1))
+    @test_throws TypeError create_block_sparse_matrix((quad9, quad4); ndofs=(2, 1, 1))
     @P2G_Matrix (velocity_grid,pressure_grid)=>(i,j) points=>p (velocity_weights,pressure_weights)=>(ip,jp) begin
         block_matrix[1,2][i,j] = @∑ ∇N[ip] * N[jp] * V[p]
         block_matrix[2,1][j,i] = @∑ ∇N[ip] * N[jp] * V[p]

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -86,37 +86,6 @@
         @test Kup ≈ Kpu'
     end
     @testset "block sparse matrix" begin
-        sparse = Tesserae.SparseArrays.sparse
-        A11 = sparse(Int32[1,3], Int32[1,2], [1.0,0.0], 3, 2)
-        A12 = sparse(Int32[], Int32[], Float64[], 3, 1)
-        A21 = sparse(Int32[2], Int32[1], [3.0], 2, 2)
-        A22 = sparse(Int32[], Int32[], Float64[], 2, 1)
-        combine_blocks = (A11, A12, A21, A22) -> (@block_sparse_matrix [A11 A12; A21 A22])
-        irregular = @inferred combine_blocks(A11, A12, A21, A22)
-
-        @test parent(irregular) == hvcat((2, 2), A11, A12, A21, A22)
-        @test Tesserae.SparseArrays.indtype(parent(irregular)) == Int32
-        @test @inferred(irregular[1,1]) isa AbstractMatrix{Float64}
-        @test Tesserae.SparseArrays.nnz(irregular[1,1]) == Tesserae.SparseArrays.nnz(A11)
-        @test Tesserae.SparseArrays.nnz(irregular[1,2]) == 0
-        @test_throws BoundsError irregular[0,1]
-        @test_throws BoundsError irregular[1,1][0,1]
-        @test_throws BoundsError irregular[1,1][0,1] = 0
-        irregular[1,1][3,2] = 2
-        @test irregular[1,1][3,2] == 2
-        irregular[1,2][1,1] = 0
-        @test_throws ArgumentError irregular[1,2][1,1] = 1
-        fillzero!(irregular[1,1])
-        @test all(iszero, irregular[1,1])
-        @test irregular[2,1] == A21
-
-        @test size(@block_sparse_matrix [A11]) == (1, 1)
-        @test size(@block_sparse_matrix [A11 A12]) == (1, 2)
-        @test size(@block_sparse_matrix [A11; A21]) == (2, 1)
-        @test_throws DimensionMismatch @block_sparse_matrix [A11 A12; A21]
-        @test_throws ArgumentError @block_sparse_matrix [A11 Float32.(A12)]
-        @test_throws DimensionMismatch @block_sparse_matrix [A11 sparse(Int32[], Int32[], Float64[], 4, 1)]
-
         Kuu_ref = create_sparse_matrix(basis, mesh; ndofs=(2, 2))
         Kup_ref = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
         Kpu_ref = create_sparse_matrix(basis, mesh; ndofs=(1, 2))
@@ -132,6 +101,9 @@
         @test size(three_fields) == (3, 3)
         @test size(parent(three_fields)) == (4length(mesh), 4length(mesh))
         @test all(parent(block) === parent(blocks) for block in blocks)
+        @test_throws BoundsError blocks[0,1]
+        @test_throws BoundsError blocks[1,1][0,1]
+        @test_throws BoundsError blocks[1,1][0,1] = 0
         @test size(blocks[1,1]) == size(Kuu_ref)
         @test size(blocks[1,2]) == size(Kup_ref)
         @test size(blocks[2,1]) == size(Kpu_ref)
@@ -143,11 +115,23 @@
         @test_throws ArgumentError create_block_sparse_matrix(basis, mesh; ndofs=())
         @test_throws ArgumentError create_block_sparse_matrix(basis, mesh; ndofs=(2, 0))
 
+        assembler = @inferred Tesserae.matrix_assembler(blocks[1,1], mesh, mesh, basis, basis)
+        @test Tesserae.has_cartesian_sparse_pattern(assembler)
+        linear_basis = BSpline(Linear())
+        @test_throws ArgumentError Tesserae.matrix_assembler(blocks[1,1], mesh, mesh, linear_basis, linear_basis)
+        different_mesh = CartesianMesh(1, (0,3), (0,5))
+        @test_throws DimensionMismatch Tesserae.matrix_assembler(blocks[1,1], different_mesh, different_mesh, basis, basis)
+
         blocks[1,1][1,1] = 1
         @test parent(blocks)[1,1] == 1
         rowvals_before = copy(Tesserae.SparseArrays.rowvals(parent(blocks)))
         @test_throws ArgumentError blocks[1,1][1,end] = 1
         @test Tesserae.SparseArrays.rowvals(parent(blocks)) == rowvals_before
+        fill!(Tesserae.SparseArrays.nonzeros(parent(blocks)), 7)
+        unchanged_block = copy(blocks[2,1])
+        fillzero!(blocks[1,1])
+        @test all(iszero, blocks[1,1])
+        @test blocks[2,1] == unchanged_block
         fill!(Tesserae.SparseArrays.nonzeros(parent(blocks)), 7)
 
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -91,13 +91,16 @@
         A12 = sparse(Int32[], Int32[], Float64[], 3, 1)
         A21 = sparse(Int32[2], Int32[1], [3.0], 2, 2)
         A22 = sparse(Int32[], Int32[], Float64[], 2, 1)
-        irregular = @inferred create_block_sparse_matrix((A11, A12), (A21, A22))
+        irregular = @block_sparse_matrix [A11 A12; A21 A22]
 
         @test parent(irregular) == hvcat((2, 2), A11, A12, A21, A22)
         @test Tesserae.SparseArrays.indtype(parent(irregular)) == Int32
         @test @inferred(irregular[1,1]) isa AbstractMatrix{Float64}
         @test Tesserae.SparseArrays.nnz(irregular[1,1]) == Tesserae.SparseArrays.nnz(A11)
         @test Tesserae.SparseArrays.nnz(irregular[1,2]) == 0
+        @test_throws BoundsError irregular[0,1]
+        @test_throws BoundsError irregular[1,1][0,1]
+        @test_throws BoundsError irregular[1,1][0,1] = 0
         irregular[1,1][3,2] = 2
         @test irregular[1,1][3,2] == 2
         irregular[1,2][1,1] = 0
@@ -106,32 +109,38 @@
         @test all(iszero, irregular[1,1])
         @test irregular[2,1] == A21
 
-        @test size(create_block_sparse_matrix((A11,))) == (1, 1)
-        @test size(create_block_sparse_matrix((A11, A12))) == (1, 2)
-        @test size(create_block_sparse_matrix((A11,), (A21,))) == (2, 1)
-        @test_throws ArgumentError create_block_sparse_matrix()
-        @test_throws ArgumentError create_block_sparse_matrix(())
-        @test_throws DimensionMismatch create_block_sparse_matrix((A11, A12), (A21,))
-        @test_throws ArgumentError create_block_sparse_matrix((A11, Float32.(A12)))
-        @test_throws DimensionMismatch create_block_sparse_matrix((A11, sparse(Int32[], Int32[], Float64[], 4, 1)))
+        @test size(@block_sparse_matrix [A11]) == (1, 1)
+        @test size(@block_sparse_matrix [A11 A12]) == (1, 2)
+        @test size(@block_sparse_matrix [A11; A21]) == (2, 1)
+        @test_throws DimensionMismatch @block_sparse_matrix [A11 A12; A21]
+        @test_throws ArgumentError @block_sparse_matrix [A11 Float32.(A12)]
+        @test_throws DimensionMismatch @block_sparse_matrix [A11 sparse(Int32[], Int32[], Float64[], 4, 1)]
 
         Kuu_ref = create_sparse_matrix(basis, mesh; ndofs=(2, 2))
         Kup_ref = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
         Kpu_ref = create_sparse_matrix(basis, mesh; ndofs=(1, 2))
         Kpp_ref = create_sparse_matrix(basis, mesh; ndofs=(1, 1))
-        blocks = @inferred create_block_sparse_matrix(
-            (copy(Kuu_ref), copy(Kup_ref)),
-            (copy(Kpu_ref), copy(Kpp_ref)),
-        )
+        blocks = @inferred create_block_sparse_matrix(basis, mesh; ndofs=(2, 1))
+        blocks32 = @inferred create_block_sparse_matrix(Float32, basis, mesh; ndofs=(2, 1))
+        three_fields = @inferred create_block_sparse_matrix(basis, mesh; ndofs=(2, 1, 1))
 
         @test size(blocks) == (2, 2)
         @test isconcretetype(eltype(blocks))
         @test size(parent(blocks)) == (3length(mesh), 3length(mesh))
+        @test eltype(parent(blocks32)) == Float32
+        @test size(three_fields) == (3, 3)
+        @test size(parent(three_fields)) == (4length(mesh), 4length(mesh))
         @test all(parent(block) === parent(blocks) for block in blocks)
         @test size(blocks[1,1]) == size(Kuu_ref)
         @test size(blocks[1,2]) == size(Kup_ref)
         @test size(blocks[2,1]) == size(Kpu_ref)
         @test size(blocks[2,2]) == size(Kpp_ref)
+        @test blocks[1,1] == Kuu_ref
+        @test blocks[1,2] == Kup_ref
+        @test blocks[2,1] == Kpu_ref
+        @test blocks[2,2] == Kpp_ref
+        @test_throws ArgumentError create_block_sparse_matrix(basis, mesh; ndofs=())
+        @test_throws ArgumentError create_block_sparse_matrix(basis, mesh; ndofs=(2, 0))
 
         blocks[1,1][1,1] = 1
         @test parent(blocks)[1,1] == 1
@@ -158,10 +167,7 @@
         @test blocks[2,1] ≈ Kpu_ref
         @test blocks[2,2] ≈ Kpp_ref
 
-        threaded = create_block_sparse_matrix(
-            (copy(Kuu_ref), copy(Kup_ref)),
-            (copy(Kpu_ref), copy(Kpp_ref)),
-        )
+        threaded = create_block_sparse_matrix(basis, mesh; ndofs=(2, 1))
         fillzero!(threaded)
         partition = ThreadPartition(mesh)
         update!(partition, particles.x)
@@ -599,16 +605,12 @@ end
     end
     @test matrix_view ≈ A
 
-    block_matrix = create_block_sparse_matrix(
-        (
-            create_sparse_matrix(quad9; ndofs=2),
-            create_sparse_matrix((quad9, quad4); ndofs=(2, 1)),
-        ),
-        (
-            create_sparse_matrix((quad4, quad9); ndofs=(1, 2)),
-            create_sparse_matrix(quad4; ndofs=1),
-        ),
-    )
+    block_matrix = @inferred create_block_sparse_matrix((quad9, quad4); ndofs=(2, 1))
+    @test block_matrix[1,1] == create_sparse_matrix(quad9; ndofs=2)
+    @test block_matrix[1,2] == create_sparse_matrix((quad9, quad4); ndofs=(2, 1))
+    @test block_matrix[2,1] == create_sparse_matrix((quad4, quad9); ndofs=(1, 2))
+    @test block_matrix[2,2] == create_sparse_matrix(quad4; ndofs=1)
+    @test_throws DimensionMismatch create_block_sparse_matrix((quad9, quad4); ndofs=(2, 1, 1))
     @P2G_Matrix (velocity_grid,pressure_grid)=>(i,j) points=>p (velocity_weights,pressure_weights)=>(ip,jp) begin
         block_matrix[1,2][i,j] = @∑ ∇N[ip] * N[jp] * V[p]
         block_matrix[2,1][j,i] = @∑ ∇N[ip] * N[jp] * V[p]

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -86,11 +86,40 @@
         @test Kup ≈ Kpu'
     end
     @testset "block sparse matrix" begin
+        sparse = Tesserae.SparseArrays.sparse
+        A11 = sparse(Int32[1,3], Int32[1,2], [1.0,0.0], 3, 2)
+        A12 = sparse(Int32[], Int32[], Float64[], 3, 1)
+        A21 = sparse(Int32[2], Int32[1], [3.0], 2, 2)
+        A22 = sparse(Int32[], Int32[], Float64[], 2, 1)
+        irregular = @inferred create_block_sparse_matrix((A11, A12), (A21, A22))
+
+        @test parent(irregular) == hvcat((2, 2), A11, A12, A21, A22)
+        @test Tesserae.SparseArrays.indtype(parent(irregular)) == Int32
+        @test @inferred(irregular[1,1]) isa AbstractMatrix{Float64}
+        @test Tesserae.SparseArrays.nnz(irregular[1,1]) == Tesserae.SparseArrays.nnz(A11)
+        @test Tesserae.SparseArrays.nnz(irregular[1,2]) == 0
+        irregular[1,1][3,2] = 2
+        @test irregular[1,1][3,2] == 2
+        irregular[1,2][1,1] = 0
+        @test_throws ArgumentError irregular[1,2][1,1] = 1
+        fillzero!(irregular[1,1])
+        @test all(iszero, irregular[1,1])
+        @test irregular[2,1] == A21
+
+        @test size(create_block_sparse_matrix((A11,))) == (1, 1)
+        @test size(create_block_sparse_matrix((A11, A12))) == (1, 2)
+        @test size(create_block_sparse_matrix((A11,), (A21,))) == (2, 1)
+        @test_throws ArgumentError create_block_sparse_matrix()
+        @test_throws ArgumentError create_block_sparse_matrix(())
+        @test_throws DimensionMismatch create_block_sparse_matrix((A11, A12), (A21,))
+        @test_throws ArgumentError create_block_sparse_matrix((A11, Float32.(A12)))
+        @test_throws DimensionMismatch create_block_sparse_matrix((A11, sparse(Int32[], Int32[], Float64[], 4, 1)))
+
         Kuu_ref = create_sparse_matrix(basis, mesh; ndofs=(2, 2))
         Kup_ref = create_sparse_matrix(basis, mesh; ndofs=(2, 1))
         Kpu_ref = create_sparse_matrix(basis, mesh; ndofs=(1, 2))
         Kpp_ref = create_sparse_matrix(basis, mesh; ndofs=(1, 1))
-        blocks = create_block_sparse_matrix(
+        blocks = @inferred create_block_sparse_matrix(
             (copy(Kuu_ref), copy(Kup_ref)),
             (copy(Kpu_ref), copy(Kpp_ref)),
         )
@@ -103,6 +132,13 @@
         @test size(blocks[1,2]) == size(Kup_ref)
         @test size(blocks[2,1]) == size(Kpu_ref)
         @test size(blocks[2,2]) == size(Kpp_ref)
+
+        blocks[1,1][1,1] = 1
+        @test parent(blocks)[1,1] == 1
+        rowvals_before = copy(Tesserae.SparseArrays.rowvals(parent(blocks)))
+        @test_throws ArgumentError blocks[1,1][1,end] = 1
+        @test Tesserae.SparseArrays.rowvals(parent(blocks)) == rowvals_before
+        fill!(Tesserae.SparseArrays.nonzeros(parent(blocks)), 7)
 
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             blocks[1,1][i,j] = @∑ ∇w[ip] ⊗ ∇w[jp]
@@ -170,6 +206,7 @@
         @test assembler isa Tesserae.CartesianSparseMatrixAssembler
         @test assembler.matrix === sequential
         @test Tesserae.matrix_storage(assembler.matrix) === parent_sequential
+        @test Tesserae.has_cartesian_sparse_pattern(assembler)
 
         @P2G_Matrix grid=>(i,j) particles=>p weights=>(ip,jp) begin
             sequential[i,j] = @∑ ∇w[ip] * w[jp]


### PR DESCRIPTION
## Summary

- add fixed-sparsity block views backed by a shared parent CSC matrix
- add field-matrix construction from meshes and per-field DoF counts
- support direct `@P2G_Matrix` assembly into individual blocks across Cartesian, FEM, and IGA paths
- reuse recorded Cartesian pattern metadata instead of rescanning every block on each assembly call
- update the changelog and version for v0.7.5
