### PR TITLE
Add sparse block storage indices

### DIFF
--- a/src/implicit.jl
+++ b/src/implicit.jl
@@ -110,16 +110,36 @@ function Base.getindex(block::SparseMatrixBlockView, i::Int, j::Int)
     @inbounds parent(block)[block.rows[i],block.cols[j]]
 end
 
-function Base.setindex!(block::SparseMatrixBlockView, value, i::Int, j::Int)
+@inline function find_storageindex(block::SparseMatrixBlockView, i::Int, j::Int)
     @boundscheck checkbounds(block, i, j)
 
     matrix = parent(block)
     rows = rowvals(matrix)
     row = @inbounds block.rows[i]
     slots = @inbounds block.column_slots[j]
+    isempty(slots) && return nothing
     slot = searchsortedfirst(rows, row, first(slots), last(slots), Base.Order.Forward)
-    if slot ∈ slots && rows[slot] == row
-        @inbounds nonzeros(matrix)[slot] = value
+    slot ∈ slots && rows[slot] == row ? slot : nothing
+end
+
+"""
+    storageindex(block, i, j)
+
+Return the index in `nonzeros(parent(block))` corresponding to the stored entry
+`block[i,j]`. An `ArgumentError` is thrown when the entry is not part of the
+fixed sparse pattern. Structural changes to the parent matrix invalidate
+previously obtained storage indices.
+"""
+@inline function storageindex(block::SparseMatrixBlockView, i::Int, j::Int)
+    slot = find_storageindex(block, i, j)
+    isnothing(slot) && throw(ArgumentError("entry ($i, $j) is not stored in the sparse matrix block view"))
+    slot
+end
+
+function Base.setindex!(block::SparseMatrixBlockView, value, i::Int, j::Int)
+    slot = find_storageindex(block, i, j)
+    if !isnothing(slot)
+        @inbounds nonzeros(parent(block))[slot] = value
     elseif !iszero(value)
         throw(ArgumentError("cannot change the sparsity pattern of a sparse matrix block view"))
     end

--- a/src/sparray.jl
+++ b/src/sparray.jl
@@ -90,8 +90,7 @@ Base.IndexStyle(::Type{<: SpIndices}) = IndexCartesian()
 @inline blocklength(sp::SpIndices{dim, L}) where {dim, L} = 1 << (L*dim)
 
 # blocknumber + local linear index inside the block -> SpArray.data index.
-@inline storageindex(blocknumber::Integer, localindex::Integer, sp::SpIndices) =
-    (blocknumber - 1) * blocklength(sp) + localindex
+@inline storageindex(sp::SpIndices, blocknumber::Integer, localindex::Integer) = (blocknumber - 1) * blocklength(sp) + localindex
 
 # Logical node index -> block coordinate.
 @inline blockindex(I::Vararg{Integer, dim}; block_size_log2::Val{L}) where {dim, L} =
@@ -120,7 +119,7 @@ end
     @inbounds localcoord = localindices[l]
     I = blocklocal_to_global(block, localcoord; block_size_log2=Val(block_size_log2(spinds)))
     checkbounds(Bool, spinds, Tuple(I)...) || return false, SpIndex(I, 0)
-    true, SpIndex(I, storageindex(blocknumber, l, spinds))
+    true, SpIndex(I, storageindex(spinds, blocknumber, l))
 end
 
 @inline function _active_spindex(spinds::SpIndices, k::Integer)
@@ -140,7 +139,7 @@ end
     block_size = Val(block_size_log2(sp))
     block, localindex = global_to_blocklocal(I...; block_size_log2=block_size)
     @inbounds blocknumber = blocknumbering(sp)[block...]
-    index = storageindex(blocknumber, localindex, sp)
+    index = storageindex(sp, blocknumber, localindex)
     SpIndex(CartesianIndex(I), ifelse(iszero(blocknumber), zero(index), index))
 end
 
@@ -174,7 +173,7 @@ function Base.iterate(iter::ActiveSpIndices{dim}, state=(1, 1)) where {dim}
             while l ≤ nlocal
                 localcoord = localindices[l]
                 I = blocklocal_to_global(block, localcoord; block_size_log2=block_size)
-                i = storageindex(blocknumber, l, sp)
+                i = storageindex(sp, blocknumber, l)
                 l += 1
                 checkbounds(Bool, sp, Tuple(I)...) && return SpIndex(I, i), (b, l)
             end

--- a/test/implicit.jl
+++ b/test/implicit.jl
@@ -124,6 +124,13 @@
 
         blocks[1,1][1,1] = 1
         @test parent(blocks)[1,1] == 1
+        diagonal_slot = @inferred Tesserae.storageindex(blocks[1,1], 1, 1)
+        @test Tesserae.SparseArrays.nonzeros(parent(blocks))[diagonal_slot] == 1
+        cross_slot = @inferred Tesserae.storageindex(blocks[1,2], 1, 1)
+        blocks[1,2][1,1] = 2
+        @test Tesserae.SparseArrays.nonzeros(parent(blocks))[cross_slot] == 2
+        @test_throws BoundsError Tesserae.storageindex(blocks[1,1], 0, 1)
+        @test_throws ArgumentError Tesserae.storageindex(blocks[1,1], 1, lastindex(blocks[1,1], 2))
         rowvals_before = copy(Tesserae.SparseArrays.rowvals(parent(blocks)))
         @test_throws ArgumentError blocks[1,1][1,end] = 1
         @test Tesserae.SparseArrays.rowvals(parent(blocks)) == rowvals_before

--- a/test/sparray.jl
+++ b/test/sparray.jl
@@ -24,6 +24,7 @@ end
     blkspy = rand(Bool, Tesserae.nblocks(spinds))
     n = update_sparsity!(spinds, blkspy)
     @test n == count(blkspy) * Tesserae.blocklength(spinds)
+    @test @inferred(Tesserae.storageindex(spinds, 2, 3)) == Tesserae.blocklength(spinds) + 3
     inds = zeros(Int, size(spinds))
     for I in CartesianIndices(inds)
         block, localindex = Tesserae.global_to_blocklocal(Tuple(I)...; block_size_log2=Val(Tesserae.block_size_log2(spinds)))


### PR DESCRIPTION
Adds internal storage index lookup for sparse matrix block views so parent CSC slots can be cached for repeated access. Also makes the SpIndices storageindex argument order consistent by placing the target object first.